### PR TITLE
fix: add future annotations import for py3.9 compat

### DIFF
--- a/scripts/safety_net_impl/hook.py
+++ b/scripts/safety_net_impl/hook.py
@@ -8,6 +8,8 @@ Exit behavior:
   - Exit 0 with no output = allow command
 """
 
+from __future__ import annotations
+
 import json
 import posixpath
 import re

--- a/scripts/safety_net_impl/rules_git.py
+++ b/scripts/safety_net_impl/rules_git.py
@@ -1,5 +1,7 @@
 """Git command analysis rules for the safety net."""
 
+from __future__ import annotations
+
 from .shell import _short_opts
 
 _REASON_GIT_CHECKOUT_DOUBLE_DASH = (

--- a/scripts/safety_net_impl/rules_rm.py
+++ b/scripts/safety_net_impl/rules_rm.py
@@ -1,5 +1,7 @@
 """Filesystem (rm) command analysis rules for the safety net."""
 
+from __future__ import annotations
+
 import os
 import posixpath
 

--- a/scripts/safety_net_impl/shell.py
+++ b/scripts/safety_net_impl/shell.py
@@ -1,5 +1,7 @@
 """Shell parsing helpers for the safety net."""
 
+from __future__ import annotations
+
 import shlex
 
 


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- Fixes incompatible type annotations for systems running python <= 3.9. The MacOS system `python3` is `3.9.6` by default (Tahoe 26.1). This ensures most, if not all, MacOS consumers of the plugin can execute these scripts regardless of project environment. The plugin is much more approachable for users that are not writing python themselves and will not have a python virtual environment available to the claude-code instance.

## Changes

<!-- What was changed and how. List specific modifications. -->

- Adds `from __future__ import annotations` to relevant script files.

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

- N/A

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
just check
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->
- N/A