### PR TITLE
feat: add safety net allow override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ When committing changes to files in `commands/`, `hooks/`, or `.opencode/`, use 
 - `SAFETY_NET_PARANOID=1`: Paranoid mode (enables all paranoid checks)
 - `SAFETY_NET_PARANOID_RM=1`: Paranoid rm (blocks non-temp `rm -rf` even within cwd)
 - `SAFETY_NET_PARANOID_INTERPRETERS=1`: Paranoid interpreters (blocks interpreter one-liners)
+- `SAFETY_NET_ALLOW=1`: Allow override for intentionally running blocked commands
 
 ## Custom Rules
 

--- a/README.md
+++ b/README.md
@@ -472,6 +472,17 @@ Paranoid behavior:
 - **interpreters**: blocks interpreter one-liners like `python -c`, `node -e`, `ruby -e`,
   and `perl -e` (these can hide destructive commands).
 
+### Allow Override
+
+If you intentionally need to run a blocked command, you can explicitly override the safety net
+for a single invocation by setting `SAFETY_NET_ALLOW=1` in the environment:
+
+```bash
+SAFETY_NET_ALLOW=1 git reset --hard
+```
+
+This bypass should be used sparingly and only when you understand the impact of the command.
+
 ### Shell Wrapper Detection
 
 The guard recursively analyzes commands wrapped in shells:

--- a/src/bin/cc-safety-net.ts
+++ b/src/bin/cc-safety-net.ts
@@ -27,6 +27,7 @@ ENVIRONMENT VARIABLES:
   SAFETY_NET_PARANOID=1           Enable all paranoid checks
   SAFETY_NET_PARANOID_RM=1        Block non-temp rm -rf within cwd
   SAFETY_NET_PARANOID_INTERPRETERS=1  Block interpreter one-liners
+  SAFETY_NET_ALLOW=1              Allow all commands (explicit override)
 
 CONFIG FILES:
   ~/.cc-safety-net/config.json    User-scope config

--- a/src/core/analyze/segment.ts
+++ b/src/core/analyze/segment.ts
@@ -5,7 +5,7 @@ import {
   PARANOID_INTERPRETERS_SUFFIX,
   SHELL_WRAPPERS,
 } from '../../types.ts';
-
+import { envAssignmentTruthy, envTruthy } from '../env.ts';
 import { checkCustomRules } from '../rules-custom.ts';
 import { analyzeGit } from '../rules-git.ts';
 import { analyzeRm, isHomeDirectory } from '../rules-rm.ts';
@@ -73,6 +73,10 @@ export function analyzeSegment(
 
   const head = stripped[0];
   if (!head) {
+    return null;
+  }
+
+  if (envTruthy('SAFETY_NET_ALLOW') || envAssignmentTruthy(envAssignments, 'SAFETY_NET_ALLOW')) {
     return null;
   }
 

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -2,3 +2,8 @@ export function envTruthy(name: string): boolean {
   const value = process.env[name];
   return value === '1' || value?.toLowerCase() === 'true';
 }
+
+export function envAssignmentTruthy(assignments: Map<string, string>, name: string): boolean {
+  const value = assignments.get(name);
+  return value === '1' || value?.toLowerCase() === 'true';
+}

--- a/tests/edge-cases.test.ts
+++ b/tests/edge-cases.test.ts
@@ -106,6 +106,18 @@ describe('edge cases', () => {
     });
   });
 
+  describe('allow override', () => {
+    test('SAFETY_NET_ALLOW bypasses blocks', () => {
+      withEnv({ SAFETY_NET_ALLOW: '1' }, () => {
+        assertAllowed('git reset --hard');
+      });
+    });
+
+    test('SAFETY_NET_ALLOW env assignment bypasses blocks', () => {
+      assertAllowed('SAFETY_NET_ALLOW=1 git reset --hard');
+    });
+  });
+
   describe('shell wrappers', () => {
     test('sh -lc wrapper blocked', () => {
       assertBlocked("sh -lc 'git reset --hard'", 'git reset --hard');

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { envTruthy } from '../src/core/env.ts';
+import { envAssignmentTruthy, envTruthy } from '../src/core/env.ts';
 
 describe('envTruthy', () => {
   test("returns true for '1'", () => {
@@ -59,5 +59,32 @@ describe('envTruthy', () => {
     process.env.TEST_ENV_TRUTHY = 'yes';
     expect(envTruthy('TEST_ENV_TRUTHY')).toBe(false);
     delete process.env.TEST_ENV_TRUTHY;
+  });
+});
+
+describe('envAssignmentTruthy', () => {
+  test("returns true for '1'", () => {
+    const assignments = new Map<string, string>([['TEST_ENV_TRUTHY', '1']]);
+    expect(envAssignmentTruthy(assignments, 'TEST_ENV_TRUTHY')).toBe(true);
+  });
+
+  test("returns true for 'true'", () => {
+    const assignments = new Map<string, string>([['TEST_ENV_TRUTHY', 'true']]);
+    expect(envAssignmentTruthy(assignments, 'TEST_ENV_TRUTHY')).toBe(true);
+  });
+
+  test("returns true for 'TRUE'", () => {
+    const assignments = new Map<string, string>([['TEST_ENV_TRUTHY', 'TRUE']]);
+    expect(envAssignmentTruthy(assignments, 'TEST_ENV_TRUTHY')).toBe(true);
+  });
+
+  test("returns false for 'false'", () => {
+    const assignments = new Map<string, string>([['TEST_ENV_TRUTHY', 'false']]);
+    expect(envAssignmentTruthy(assignments, 'TEST_ENV_TRUTHY')).toBe(false);
+  });
+
+  test('returns false for missing key', () => {
+    const assignments = new Map<string, string>();
+    expect(envAssignmentTruthy(assignments, 'TEST_ENV_TRUTHY')).toBe(false);
   });
 });


### PR DESCRIPTION
## Motivation

- Provide an explicit escape hatch to allow intentionally running commands that the safety net would normally block.
- Support both process-level environment flags and inline command env assignments (e.g. `SAFETY_NET_ALLOW=1 cmd`) as valid overrides.

## Description

- Added `envAssignmentTruthy(assignments, name)` helper in `src/core/env.ts` to evaluate truthy values in parsed env assignments.
- Short-circuit analysis in `analyzeSegment` when `SAFETY_NET_ALLOW` is set either in the process environment or in command-level env assignments by checking `envTruthy('SAFETY_NET_ALLOW')` and `envAssignmentTruthy(...)`.
- Documented the override in the CLI help (`src/bin/cc-safety-net.ts`), `README.md`, and `CLAUDE.md`.
- Added/updated tests:
  - New `envAssignmentTruthy` unit tests in `tests/env.test.ts`
  - `SAFETY_NET_ALLOW` override checks in `tests/edge-cases.test.ts`

## Testing

- Ran workspace checks with `knip --production` which completed successfully.
- Ran formatting/lint tasks via `biome check --write --no-errors-on-unmatched` which passed.
- Ran `ast-grep` scan from pre-commit tasks which completed successfully.
