### PR TITLE
docs: clarify Copilot CLI hooks require project-level installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ gemini extensions install https://github.com/kenryu42/gemini-safety-net
 
 Safety Net supports GitHub Copilot CLI via its [hooks system](https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-hooks).
 
+> [!NOTE]
+> Copilot CLI hooks must be installed at the **project level** (in each repository). User-level hooks (`~/.github/hooks/` or `~/.copilot/hooks/`) are not currently supported by Copilot CLI. See [copilot-cli#1067](https://github.com/github/copilot-cli/issues/1067) to track progress on user-level hook support.
+
 1. **Create the hooks directory** in your repository:
 
    ```bash
@@ -241,6 +244,8 @@ Safety Net supports GitHub Copilot CLI via its [hooks system](https://docs.githu
      }
    }
    ```
+
+3. **Restart Copilot CLI** — hooks are loaded at session start.
 
 The hook will intercept bash commands and block destructive operations before they execute.
 


### PR DESCRIPTION
## Summary

Clarifies that GitHub Copilot CLI hooks must be installed at the **project level** (in each repository's `.github/hooks/` directory). User-level hooks are not currently supported.

## Changes

- Added a `[!NOTE]` callout explaining project-level requirement
- Added link to [github/copilot-cli#1067](https://github.com/github/copilot-cli/issues/1067) for tracking user-level hook support
- Added step reminding users to restart Copilot CLI after configuration

## Context

This addresses feedback from issue [#24](https://github.com/kenryu42/claude-code-safety-net/issues/24#issuecomment-3803332081) where the installation instructions could be misinterpreted as supporting user-level hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Copilot CLI installation instructions with clarification that hooks must be configured at the project level
  * Added restart step to ensure CLI hooks are properly loaded after setup

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->