### PR TITLE
docs: add database wipe protection examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,46 @@ Create `.safety-net.json` in your project root:
 
 Now `git add -A`, `git add --all`, and `git add .` will be blocked with your custom message.
 
+### More Examples: Database Wipe Protection
+
+Prevent Claude from running destructive database commands that wipe data ([#37405](https://github.com/anthropics/claude-code/issues/37405), [#34729](https://github.com/anthropics/claude-code/issues/34729), [#37574](https://github.com/anthropics/claude-code/issues/37574)):
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "name": "block-laravel-migrate-fresh",
+      "command": "php",
+      "subcommand": "artisan",
+      "block_args": ["migrate:fresh", "migrate:reset", "db:wipe"],
+      "reason": "Destructive migration blocked. Use 'migrate' for safe migrations."
+    },
+    {
+      "name": "block-prisma-reset",
+      "command": "npx",
+      "subcommand": "prisma",
+      "block_args": ["migrate reset"],
+      "reason": "prisma migrate reset wipes all data. Use 'migrate deploy' instead."
+    },
+    {
+      "name": "block-django-flush",
+      "command": "python",
+      "subcommand": "manage.py",
+      "block_args": ["flush", "sqlflush"],
+      "reason": "Django flush deletes all data. This is blocked for safety."
+    },
+    {
+      "name": "block-rails-db-drop",
+      "command": "rails",
+      "subcommand": "db:drop",
+      "block_args": [],
+      "reason": "rails db:drop is blocked. Use db:migrate for safe changes."
+    }
+  ]
+}
+```
+
 ### Config File Location
 
 Config files are loaded from two scopes and merged:


### PR DESCRIPTION
Adds database wipe protection examples to the Custom Rules section of README.
Three real incidents from GitHub Issues where Claude Code wiped databases:
- [#37405](https://github.com/anthropics/claude-code/issues/37405): Laravel `migrate:fresh` wiped SQLite database
- [#34729](https://github.com/anthropics/claude-code/issues/34729): Prisma `migrate reset` deleted all user data  
- [#37574](https://github.com/anthropics/claude-code/issues/37574): Doctrine `fixtures:load` purged PostgreSQL
These are common enough that having examples in the README would help users protect themselves.
Custom rule examples for:
- Laravel (`migrate:fresh`, `migrate:reset`, `db:wipe`)
- Prisma (`migrate reset`)
- Django (`flush`, `sqlflush`)
- Rails (`db:drop`)
- [ ] README renders correctly on GitHub
- [ ] JSON examples are valid (tested with `jq`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added examples for configuring custom database wipe protection rules to block destructive database commands across multiple frameworks (Laravel, Prisma, Django, Rails).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->