### PR TITLE
feat: add SAFETY_NET_ASK mode to prompt user instead of blocking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ describe('git rules', () => {
 
 | Variable | Effect |
 |----------|--------|
+| `SAFETY_NET_ASK=1` | Prompt user for confirmation instead of blocking |
 | `SAFETY_NET_STRICT=1` | Fail-closed on unparseable hook input/commands |
 | `SAFETY_NET_PARANOID=1` | Enable all paranoid checks (rm + interpreters) |
 | `SAFETY_NET_PARANOID_RM=1` | Block non-temp `rm -rf` even within cwd |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ When committing changes to files in `commands/`, `hooks/`, or `.opencode/`, use 
 
 ## Environment Variables
 
+- `SAFETY_NET_ASK=1`: Ask mode (prompt user for confirmation instead of blocking)
 - `SAFETY_NET_STRICT=1`: Strict mode (fail-closed on unparseable hook input/commands)
 - `SAFETY_NET_PARANOID=1`: Paranoid mode (enables all paranoid checks)
 - `SAFETY_NET_PARANOID_RM=1`: Paranoid rm (blocks non-temp `rm -rf` even within cwd)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A Claude Code plugin that acts as a safety net, catching destructive git and fil
   - [Examples](#examples)
   - [Error Handling](#error-handling)
 - [Advanced Features](#advanced-features)
+  - [Ask Mode](#ask-mode)
   - [Strict Mode](#strict-mode)
   - [Paranoid Mode](#paranoid-mode)
   - [Shell Wrapper Detection](#shell-wrapper-detection)
@@ -296,6 +297,7 @@ The status line displays different emojis based on the current configuration:
 |--------|---------|---------|
 | Plugin disabled | `🛡️ Safety Net ❌` | Safety Net plugin is not enabled |
 | Default mode | `🛡️ Safety Net ✅` | Protection active with default settings |
+| Ask mode | `🛡️ Safety Net ❓` | `SAFETY_NET_ASK=1` — prompts user instead of blocking |
 | Strict mode | `🛡️ Safety Net 🔒` | `SAFETY_NET_STRICT=1` — fail-closed on unparseable commands |
 | Paranoid mode | `🛡️ Safety Net 👁️` | `SAFETY_NET_PARANOID=1` — all paranoid checks enabled |
 | Paranoid RM only | `🛡️ Safety Net 🗑️` | `SAFETY_NET_PARANOID_RM=1` — blocks `rm -rf` even within cwd |
@@ -600,6 +602,23 @@ Command: git add -A
 ```
 
 ## Advanced Features
+
+### Ask Mode
+
+By default, dangerous commands are blocked outright. Enable ask mode to prompt the user
+for confirmation instead, allowing them to approve or deny each flagged command
+interactively:
+
+```bash
+export SAFETY_NET_ASK=1
+```
+
+When a dangerous command is detected, the user sees the Safety Net warning and can choose
+to proceed or cancel. This is useful when you want awareness without hard blocks.
+
+> **Note:** Ask mode is supported in Claude Code and GitHub Copilot CLI. Gemini CLI and
+> OpenCode do not support interactive confirmation and will continue to block outright.
+> Strict mode parse failures (`SAFETY_NET_STRICT=1`) always hard-block regardless of ask mode.
 
 ### Strict Mode
 

--- a/README.md
+++ b/README.md
@@ -616,9 +616,9 @@ export SAFETY_NET_ASK=1
 When a dangerous command is detected, the user sees the Safety Net warning and can choose
 to proceed or cancel. This is useful when you want awareness without hard blocks.
 
-> **Note:** Ask mode is supported in Claude Code and GitHub Copilot CLI. Gemini CLI and
-> OpenCode do not support interactive confirmation and will continue to block outright.
-> Strict mode parse failures (`SAFETY_NET_STRICT=1`) always hard-block regardless of ask mode.
+> **Note:** Ask mode is currently supported in Claude Code only. Gemini CLI, OpenCode,
+> and Copilot CLI do not support interactive confirmation and will continue to block outright.
+> Strict mode (`SAFETY_NET_STRICT=1`) overrides ask mode — all blocks are hard-denied when strict is active.
 
 ### Strict Mode
 

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -5506,21 +5506,20 @@ async function runClaudeCodeHook() {
     if (sessionId) {
       writeAuditLog(sessionId, command, result.segment, result.reason, cwd);
     }
-    outputDecision(askMode ? "ask" : "deny", result.reason, command, result.segment);
+    outputDecision(askMode && !strict ? "ask" : "deny", result.reason, command, result.segment);
   }
 }
 
 // src/bin/hooks/copilot-cli.ts
-function outputCopilotDecision(decision, reason, command, segment) {
+function outputCopilotDeny(reason, command, segment) {
   const message = formatBlockedMessage({
     reason,
     command,
     segment,
-    redact: redactSecrets,
-    askMode: decision === "ask"
+    redact: redactSecrets
   });
   const output = {
-    permissionDecision: decision,
+    permissionDecision: "deny",
     permissionDecisionReason: message
   };
   console.log(JSON.stringify(output));
@@ -5539,7 +5538,7 @@ async function runCopilotCliHook() {
     input = JSON.parse(inputText);
   } catch {
     if (envTruthy("SAFETY_NET_STRICT")) {
-      outputCopilotDecision("deny", "Failed to parse hook input JSON (strict mode)");
+      outputCopilotDeny("Failed to parse hook input JSON (strict mode)");
     }
     return;
   }
@@ -5551,7 +5550,7 @@ async function runCopilotCliHook() {
     toolArgs = JSON.parse(input.toolArgs);
   } catch {
     if (envTruthy("SAFETY_NET_STRICT")) {
-      outputCopilotDecision("deny", "Failed to parse toolArgs JSON (strict mode)");
+      outputCopilotDeny("Failed to parse toolArgs JSON (strict mode)");
     }
     return;
   }
@@ -5561,7 +5560,6 @@ async function runCopilotCliHook() {
   }
   const cwd = input.cwd ?? process.cwd();
   const strict = envTruthy("SAFETY_NET_STRICT");
-  const askMode = envTruthy("SAFETY_NET_ASK");
   const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
   const paranoidRm = paranoidAll || envTruthy("SAFETY_NET_PARANOID_RM");
   const paranoidInterpreters = paranoidAll || envTruthy("SAFETY_NET_PARANOID_INTERPRETERS");
@@ -5576,7 +5574,7 @@ async function runCopilotCliHook() {
   if (result) {
     const sessionId = `copilot-${input.timestamp ?? Date.now()}`;
     writeAuditLog(sessionId, command, result.segment, result.reason, cwd);
-    outputCopilotDecision(askMode ? "ask" : "deny", result.reason, command, result.segment);
+    outputCopilotDeny(result.reason, command, result.segment);
   }
 }
 

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -853,6 +853,11 @@ function getConfigInfo(cwd, options) {
 // src/bin/doctor/environment.ts
 var ENV_VARS = [
   {
+    name: "SAFETY_NET_ASK",
+    description: "Prompt user instead of blocking",
+    defaultBehavior: "off"
+  },
+  {
     name: "SAFETY_NET_STRICT",
     description: "Fail-closed on unparseable commands",
     defaultBehavior: "permissive"
@@ -5330,6 +5335,7 @@ function printHelp() {
   lines.push(`${INDENT}${PROGRAM_NAME} <command> --help   Show help for a specific command`);
   lines.push("");
   lines.push("ENVIRONMENT VARIABLES:");
+  lines.push(`${INDENT}SAFETY_NET_ASK=1                  Prompt user instead of blocking`);
   lines.push(`${INDENT}SAFETY_NET_STRICT=1               Fail-closed on unparseable commands`);
   lines.push(`${INDENT}SAFETY_NET_PARANOID=1             Enable all paranoid checks`);
   lines.push(`${INDENT}SAFETY_NET_PARANOID_RM=1          Block non-temp rm -rf within cwd`);
@@ -5404,10 +5410,11 @@ function redactSecrets(text) {
 
 // src/core/format.ts
 function formatBlockedMessage(input) {
-  const { reason, command, segment } = input;
+  const { reason, command, segment, askMode } = input;
   const maxLen = input.maxLen ?? 200;
   const redact = input.redact ?? ((t) => t);
-  let message = `BLOCKED by Safety Net
+  const header = askMode ? "FLAGGED by Safety Net" : "BLOCKED by Safety Net";
+  let message = `${header}
 
 Reason: ${reason}`;
   if (command) {
@@ -5422,9 +5429,15 @@ Command: ${excerpt(safeCommand, maxLen)}`;
 
 Segment: ${excerpt(safeSegment, maxLen)}`;
   }
-  message += `
+  if (askMode) {
+    message += `
+
+This command may be destructive. Approve to proceed, or deny to cancel.`;
+  } else {
+    message += `
 
 If this operation is truly needed, ask the user for explicit permission and have them run the command manually.`;
+  }
   return message;
 }
 function excerpt(text, maxLen) {
@@ -5432,17 +5445,18 @@ function excerpt(text, maxLen) {
 }
 
 // src/bin/hooks/claude-code.ts
-function outputDeny(reason, command, segment) {
+function outputDecision(decision, reason, command, segment) {
   const message = formatBlockedMessage({
     reason,
     command,
     segment,
-    redact: redactSecrets
+    redact: redactSecrets,
+    askMode: decision === "ask"
   });
   const output = {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
-      permissionDecision: "deny",
+      permissionDecision: decision,
       permissionDecisionReason: message
     }
   };
@@ -5462,7 +5476,7 @@ async function runClaudeCodeHook() {
     input = JSON.parse(inputText);
   } catch {
     if (envTruthy("SAFETY_NET_STRICT")) {
-      outputDeny("Failed to parse hook input JSON (strict mode)");
+      outputDecision("deny", "Failed to parse hook input JSON (strict mode)");
     }
     return;
   }
@@ -5475,6 +5489,7 @@ async function runClaudeCodeHook() {
   }
   const cwd = input.cwd ?? process.cwd();
   const strict = envTruthy("SAFETY_NET_STRICT");
+  const askMode = envTruthy("SAFETY_NET_ASK");
   const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
   const paranoidRm = paranoidAll || envTruthy("SAFETY_NET_PARANOID_RM");
   const paranoidInterpreters = paranoidAll || envTruthy("SAFETY_NET_PARANOID_INTERPRETERS");
@@ -5491,20 +5506,21 @@ async function runClaudeCodeHook() {
     if (sessionId) {
       writeAuditLog(sessionId, command, result.segment, result.reason, cwd);
     }
-    outputDeny(result.reason, command, result.segment);
+    outputDecision(askMode ? "ask" : "deny", result.reason, command, result.segment);
   }
 }
 
 // src/bin/hooks/copilot-cli.ts
-function outputCopilotDeny(reason, command, segment) {
+function outputCopilotDecision(decision, reason, command, segment) {
   const message = formatBlockedMessage({
     reason,
     command,
     segment,
-    redact: redactSecrets
+    redact: redactSecrets,
+    askMode: decision === "ask"
   });
   const output = {
-    permissionDecision: "deny",
+    permissionDecision: decision,
     permissionDecisionReason: message
   };
   console.log(JSON.stringify(output));
@@ -5523,7 +5539,7 @@ async function runCopilotCliHook() {
     input = JSON.parse(inputText);
   } catch {
     if (envTruthy("SAFETY_NET_STRICT")) {
-      outputCopilotDeny("Failed to parse hook input JSON (strict mode)");
+      outputCopilotDecision("deny", "Failed to parse hook input JSON (strict mode)");
     }
     return;
   }
@@ -5535,7 +5551,7 @@ async function runCopilotCliHook() {
     toolArgs = JSON.parse(input.toolArgs);
   } catch {
     if (envTruthy("SAFETY_NET_STRICT")) {
-      outputCopilotDeny("Failed to parse toolArgs JSON (strict mode)");
+      outputCopilotDecision("deny", "Failed to parse toolArgs JSON (strict mode)");
     }
     return;
   }
@@ -5545,6 +5561,7 @@ async function runCopilotCliHook() {
   }
   const cwd = input.cwd ?? process.cwd();
   const strict = envTruthy("SAFETY_NET_STRICT");
+  const askMode = envTruthy("SAFETY_NET_ASK");
   const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
   const paranoidRm = paranoidAll || envTruthy("SAFETY_NET_PARANOID_RM");
   const paranoidInterpreters = paranoidAll || envTruthy("SAFETY_NET_PARANOID_INTERPRETERS");
@@ -5559,7 +5576,7 @@ async function runCopilotCliHook() {
   if (result) {
     const sessionId = `copilot-${input.timestamp ?? Date.now()}`;
     writeAuditLog(sessionId, command, result.segment, result.reason, cwd);
-    outputCopilotDeny(result.reason, command, result.segment);
+    outputCopilotDecision(askMode ? "ask" : "deny", result.reason, command, result.segment);
   }
 }
 
@@ -5684,10 +5701,14 @@ async function printStatusline() {
     status = "\uD83D\uDEE1️ Safety Net ❌";
   } else {
     const strict = envTruthy("SAFETY_NET_STRICT");
+    const askMode = envTruthy("SAFETY_NET_ASK");
     const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
     const paranoidRm = paranoidAll || envTruthy("SAFETY_NET_PARANOID_RM");
     const paranoidInterpreters = paranoidAll || envTruthy("SAFETY_NET_PARANOID_INTERPRETERS");
     let modeEmojis = "";
+    if (askMode) {
+      modeEmojis += "❓";
+    }
     if (strict) {
       modeEmojis += "\uD83D\uDD12";
     }

--- a/dist/core/format.d.ts
+++ b/dist/core/format.d.ts
@@ -5,6 +5,8 @@ export interface FormatBlockedMessageInput {
     segment?: string;
     maxLen?: number;
     redact?: RedactFn;
+    /** When true, formats the message as a confirmation prompt instead of a hard block. */
+    askMode?: boolean;
 }
 export declare function formatBlockedMessage(input: FormatBlockedMessageInput): string;
 export {};

--- a/dist/index.js
+++ b/dist/index.js
@@ -2752,10 +2752,11 @@ function envTruthy(name) {
 
 // src/core/format.ts
 function formatBlockedMessage(input) {
-  const { reason, command, segment } = input;
+  const { reason, command, segment, askMode } = input;
   const maxLen = input.maxLen ?? 200;
   const redact = input.redact ?? ((t) => t);
-  let message = `BLOCKED by Safety Net
+  const header = askMode ? "FLAGGED by Safety Net" : "BLOCKED by Safety Net";
+  let message = `${header}
 
 Reason: ${reason}`;
   if (command) {
@@ -2770,9 +2771,15 @@ Command: ${excerpt(safeCommand, maxLen)}`;
 
 Segment: ${excerpt(safeSegment, maxLen)}`;
   }
-  message += `
+  if (askMode) {
+    message += `
+
+This command may be destructive. Approve to proceed, or deny to cancel.`;
+  } else {
+    message += `
 
 If this operation is truly needed, ask the user for explicit permission and have them run the command manually.`;
+  }
   return message;
 }
 function excerpt(text, maxLen) {

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -53,7 +53,7 @@ export interface HookInput {
 export interface HookOutput {
     hookSpecificOutput: {
         hookEventName: string;
-        permissionDecision: 'allow' | 'deny';
+        permissionDecision: 'allow' | 'deny' | 'ask';
         permissionDecisionReason?: string;
     };
 }

--- a/src/bin/doctor/environment.ts
+++ b/src/bin/doctor/environment.ts
@@ -10,6 +10,11 @@ const ENV_VARS: Array<{
   defaultBehavior: string;
 }> = [
   {
+    name: 'SAFETY_NET_ASK',
+    description: 'Prompt user instead of blocking',
+    defaultBehavior: 'off',
+  },
+  {
     name: 'SAFETY_NET_STRICT',
     description: 'Fail-closed on unparseable commands',
     defaultBehavior: 'permissive',

--- a/src/bin/help.ts
+++ b/src/bin/help.ts
@@ -109,6 +109,7 @@ export function printHelp(): void {
 
   // Environment variables
   lines.push('ENVIRONMENT VARIABLES:');
+  lines.push(`${INDENT}SAFETY_NET_ASK=1                  Prompt user instead of blocking`);
   lines.push(`${INDENT}SAFETY_NET_STRICT=1               Fail-closed on unparseable commands`);
   lines.push(`${INDENT}SAFETY_NET_PARANOID=1             Enable all paranoid checks`);
   lines.push(`${INDENT}SAFETY_NET_PARANOID_RM=1          Block non-temp rm -rf within cwd`);

--- a/src/bin/hooks/claude-code.ts
+++ b/src/bin/hooks/claude-code.ts
@@ -83,6 +83,6 @@ export async function runClaudeCodeHook(): Promise<void> {
     if (sessionId) {
       writeAuditLog(sessionId, command, result.segment, result.reason, cwd);
     }
-    outputDecision(askMode ? 'ask' : 'deny', result.reason, command, result.segment);
+    outputDecision(askMode && !strict ? 'ask' : 'deny', result.reason, command, result.segment);
   }
 }

--- a/src/bin/hooks/claude-code.ts
+++ b/src/bin/hooks/claude-code.ts
@@ -4,18 +4,24 @@ import { envTruthy } from '@/core/env';
 import { formatBlockedMessage } from '@/core/format';
 import type { HookInput, HookOutput } from '@/types';
 
-function outputDeny(reason: string, command?: string, segment?: string): void {
+function outputDecision(
+  decision: 'deny' | 'ask',
+  reason: string,
+  command?: string,
+  segment?: string,
+): void {
   const message = formatBlockedMessage({
     reason,
     command,
     segment,
     redact: redactSecrets,
+    askMode: decision === 'ask',
   });
 
   const output: HookOutput = {
     hookSpecificOutput: {
       hookEventName: 'PreToolUse',
-      permissionDecision: 'deny',
+      permissionDecision: decision,
       permissionDecisionReason: message,
     },
   };
@@ -41,7 +47,7 @@ export async function runClaudeCodeHook(): Promise<void> {
     input = JSON.parse(inputText) as HookInput;
   } catch {
     if (envTruthy('SAFETY_NET_STRICT')) {
-      outputDeny('Failed to parse hook input JSON (strict mode)');
+      outputDecision('deny', 'Failed to parse hook input JSON (strict mode)');
     }
     return;
   }
@@ -57,6 +63,7 @@ export async function runClaudeCodeHook(): Promise<void> {
 
   const cwd = input.cwd ?? process.cwd();
   const strict = envTruthy('SAFETY_NET_STRICT');
+  const askMode = envTruthy('SAFETY_NET_ASK');
   const paranoidAll = envTruthy('SAFETY_NET_PARANOID');
   const paranoidRm = paranoidAll || envTruthy('SAFETY_NET_PARANOID_RM');
   const paranoidInterpreters = paranoidAll || envTruthy('SAFETY_NET_PARANOID_INTERPRETERS');
@@ -76,6 +83,6 @@ export async function runClaudeCodeHook(): Promise<void> {
     if (sessionId) {
       writeAuditLog(sessionId, command, result.segment, result.reason, cwd);
     }
-    outputDeny(result.reason, command, result.segment);
+    outputDecision(askMode ? 'ask' : 'deny', result.reason, command, result.segment);
   }
 }

--- a/src/bin/hooks/copilot-cli.ts
+++ b/src/bin/hooks/copilot-cli.ts
@@ -4,16 +4,22 @@ import { envTruthy } from '@/core/env';
 import { formatBlockedMessage } from '@/core/format';
 import type { CopilotCliHookInput, CopilotCliHookOutput } from '@/types';
 
-function outputCopilotDeny(reason: string, command?: string, segment?: string): void {
+function outputCopilotDecision(
+  decision: 'deny' | 'ask',
+  reason: string,
+  command?: string,
+  segment?: string,
+): void {
   const message = formatBlockedMessage({
     reason,
     command,
     segment,
     redact: redactSecrets,
+    askMode: decision === 'ask',
   });
 
   const output: CopilotCliHookOutput = {
-    permissionDecision: 'deny',
+    permissionDecision: decision,
     permissionDecisionReason: message,
   };
 
@@ -38,7 +44,7 @@ export async function runCopilotCliHook(): Promise<void> {
     input = JSON.parse(inputText) as CopilotCliHookInput;
   } catch {
     if (envTruthy('SAFETY_NET_STRICT')) {
-      outputCopilotDeny('Failed to parse hook input JSON (strict mode)');
+      outputCopilotDecision('deny', 'Failed to parse hook input JSON (strict mode)');
     }
     return;
   }
@@ -54,7 +60,7 @@ export async function runCopilotCliHook(): Promise<void> {
     toolArgs = JSON.parse(input.toolArgs) as { command?: string };
   } catch {
     if (envTruthy('SAFETY_NET_STRICT')) {
-      outputCopilotDeny('Failed to parse toolArgs JSON (strict mode)');
+      outputCopilotDecision('deny', 'Failed to parse toolArgs JSON (strict mode)');
     }
     return;
   }
@@ -66,6 +72,7 @@ export async function runCopilotCliHook(): Promise<void> {
 
   const cwd = input.cwd ?? process.cwd();
   const strict = envTruthy('SAFETY_NET_STRICT');
+  const askMode = envTruthy('SAFETY_NET_ASK');
   const paranoidAll = envTruthy('SAFETY_NET_PARANOID');
   const paranoidRm = paranoidAll || envTruthy('SAFETY_NET_PARANOID_RM');
   const paranoidInterpreters = paranoidAll || envTruthy('SAFETY_NET_PARANOID_INTERPRETERS');
@@ -84,6 +91,6 @@ export async function runCopilotCliHook(): Promise<void> {
     // Generate a session ID from timestamp for audit logging
     const sessionId = `copilot-${input.timestamp ?? Date.now()}`;
     writeAuditLog(sessionId, command, result.segment, result.reason, cwd);
-    outputCopilotDeny(result.reason, command, result.segment);
+    outputCopilotDecision(askMode ? 'ask' : 'deny', result.reason, command, result.segment);
   }
 }

--- a/src/bin/hooks/copilot-cli.ts
+++ b/src/bin/hooks/copilot-cli.ts
@@ -4,22 +4,16 @@ import { envTruthy } from '@/core/env';
 import { formatBlockedMessage } from '@/core/format';
 import type { CopilotCliHookInput, CopilotCliHookOutput } from '@/types';
 
-function outputCopilotDecision(
-  decision: 'deny' | 'ask',
-  reason: string,
-  command?: string,
-  segment?: string,
-): void {
+function outputCopilotDeny(reason: string, command?: string, segment?: string): void {
   const message = formatBlockedMessage({
     reason,
     command,
     segment,
     redact: redactSecrets,
-    askMode: decision === 'ask',
   });
 
   const output: CopilotCliHookOutput = {
-    permissionDecision: decision,
+    permissionDecision: 'deny',
     permissionDecisionReason: message,
   };
 
@@ -44,7 +38,7 @@ export async function runCopilotCliHook(): Promise<void> {
     input = JSON.parse(inputText) as CopilotCliHookInput;
   } catch {
     if (envTruthy('SAFETY_NET_STRICT')) {
-      outputCopilotDecision('deny', 'Failed to parse hook input JSON (strict mode)');
+      outputCopilotDeny('Failed to parse hook input JSON (strict mode)');
     }
     return;
   }
@@ -60,7 +54,7 @@ export async function runCopilotCliHook(): Promise<void> {
     toolArgs = JSON.parse(input.toolArgs) as { command?: string };
   } catch {
     if (envTruthy('SAFETY_NET_STRICT')) {
-      outputCopilotDecision('deny', 'Failed to parse toolArgs JSON (strict mode)');
+      outputCopilotDeny('Failed to parse toolArgs JSON (strict mode)');
     }
     return;
   }
@@ -72,7 +66,6 @@ export async function runCopilotCliHook(): Promise<void> {
 
   const cwd = input.cwd ?? process.cwd();
   const strict = envTruthy('SAFETY_NET_STRICT');
-  const askMode = envTruthy('SAFETY_NET_ASK');
   const paranoidAll = envTruthy('SAFETY_NET_PARANOID');
   const paranoidRm = paranoidAll || envTruthy('SAFETY_NET_PARANOID_RM');
   const paranoidInterpreters = paranoidAll || envTruthy('SAFETY_NET_PARANOID_INTERPRETERS');
@@ -91,6 +84,6 @@ export async function runCopilotCliHook(): Promise<void> {
     // Generate a session ID from timestamp for audit logging
     const sessionId = `copilot-${input.timestamp ?? Date.now()}`;
     writeAuditLog(sessionId, command, result.segment, result.reason, cwd);
-    outputCopilotDecision(askMode ? 'ask' : 'deny', result.reason, command, result.segment);
+    outputCopilotDeny(result.reason, command, result.segment);
   }
 }

--- a/src/bin/statusline.ts
+++ b/src/bin/statusline.ts
@@ -80,11 +80,17 @@ export async function printStatusline(): Promise<void> {
     status = '🛡️ Safety Net ❌';
   } else {
     const strict = envTruthy('SAFETY_NET_STRICT');
+    const askMode = envTruthy('SAFETY_NET_ASK');
     const paranoidAll = envTruthy('SAFETY_NET_PARANOID');
     const paranoidRm = paranoidAll || envTruthy('SAFETY_NET_PARANOID_RM');
     const paranoidInterpreters = paranoidAll || envTruthy('SAFETY_NET_PARANOID_INTERPRETERS');
 
     let modeEmojis = '';
+
+    // Ask mode: ❓
+    if (askMode) {
+      modeEmojis += '❓';
+    }
 
     // Strict mode: 🔒
     if (strict) {

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -6,14 +6,17 @@ export interface FormatBlockedMessageInput {
   segment?: string;
   maxLen?: number;
   redact?: RedactFn;
+  /** When true, formats the message as a confirmation prompt instead of a hard block. */
+  askMode?: boolean;
 }
 
 export function formatBlockedMessage(input: FormatBlockedMessageInput): string {
-  const { reason, command, segment } = input;
+  const { reason, command, segment, askMode } = input;
   const maxLen = input.maxLen ?? 200;
   const redact = input.redact ?? ((t: string) => t);
 
-  let message = `BLOCKED by Safety Net\n\nReason: ${reason}`;
+  const header = askMode ? 'FLAGGED by Safety Net' : 'BLOCKED by Safety Net';
+  let message = `${header}\n\nReason: ${reason}`;
 
   if (command) {
     const safeCommand = redact(command);
@@ -25,8 +28,12 @@ export function formatBlockedMessage(input: FormatBlockedMessageInput): string {
     message += `\n\nSegment: ${excerpt(safeSegment, maxLen)}`;
   }
 
-  message +=
-    '\n\nIf this operation is truly needed, ask the user for explicit permission and have them run the command manually.';
+  if (askMode) {
+    message += '\n\nThis command may be destructive. Approve to proceed, or deny to cancel.';
+  } else {
+    message +=
+      '\n\nIf this operation is truly needed, ask the user for explicit permission and have them run the command manually.';
+  }
 
   return message;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,7 @@ export interface HookInput {
 export interface HookOutput {
   hookSpecificOutput: {
     hookEventName: string;
-    permissionDecision: 'allow' | 'deny';
+    permissionDecision: 'allow' | 'deny' | 'ask';
     permissionDecisionReason?: string;
   };
 }

--- a/tests/bin/cli-statusline.test.ts
+++ b/tests/bin/cli-statusline.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 function clearEnv(): void {
+  delete process.env.SAFETY_NET_ASK;
   delete process.env.SAFETY_NET_STRICT;
   delete process.env.SAFETY_NET_PARANOID;
   delete process.env.SAFETY_NET_PARANOID_RM;
@@ -47,6 +48,21 @@ describe('--statusline flag', () => {
     const exitCode = await proc.exited;
 
     expect(output.trim()).toBe('🛡️ Safety Net ✅');
+    expect(exitCode).toBe(0);
+  });
+
+  // Ask mode → ❓
+  test('shows ask mode emoji when SAFETY_NET_ASK=1', async () => {
+    const proc = Bun.spawn(['bun', 'src/bin/cc-safety-net.ts', '--statusline'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, CLAUDE_SETTINGS_PATH: enabledSettingsPath, SAFETY_NET_ASK: '1' },
+    });
+
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    expect(output.trim()).toBe('🛡️ Safety Net ❓');
     expect(exitCode).toBe(0);
   });
 

--- a/tests/bin/cli-statusline.test.ts
+++ b/tests/bin/cli-statusline.test.ts
@@ -66,6 +66,26 @@ describe('--statusline flag', () => {
     expect(exitCode).toBe(0);
   });
 
+  // Ask + Strict → ❓🔒
+  test('shows ask + strict emojis when both set', async () => {
+    const proc = Bun.spawn(['bun', 'src/bin/cc-safety-net.ts', '--statusline'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...process.env,
+        CLAUDE_SETTINGS_PATH: enabledSettingsPath,
+        SAFETY_NET_ASK: '1',
+        SAFETY_NET_STRICT: '1',
+      },
+    });
+
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    expect(output.trim()).toBe('🛡️ Safety Net ❓🔒');
+    expect(exitCode).toBe(0);
+  });
+
   // 3. Enabled + Strict → 🔒 (replaces ✅)
   test('shows strict mode emoji when SAFETY_NET_STRICT=1', async () => {
     const proc = Bun.spawn(['bun', 'src/bin/cc-safety-net.ts', '--statusline'], {

--- a/tests/bin/hooks/claude-code-hook.test.ts
+++ b/tests/bin/hooks/claude-code-hook.test.ts
@@ -61,8 +61,28 @@ describe('Claude Code hook', () => {
       expect(exitCode).toBe(0);
     });
 
-    test('strict parse failures still deny even in ask mode', async () => {
+    test('strict JSON parse failures still deny even in ask mode', async () => {
       const { stdout, exitCode } = await runClaudeCodeHook('{invalid json', {
+        SAFETY_NET_ASK: '1',
+        SAFETY_NET_STRICT: '1',
+      });
+
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
+      expect(parsed.hookSpecificOutput.permissionDecisionReason).toContain('BLOCKED by Safety Net');
+    });
+
+    test('strict command parse failures still deny even in ask mode', async () => {
+      const input = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: "git reset --hard 'unterminated",
+        },
+      };
+
+      const { stdout, exitCode } = await runClaudeCodeHook(input, {
         SAFETY_NET_ASK: '1',
         SAFETY_NET_STRICT: '1',
       });

--- a/tests/bin/hooks/claude-code-hook.test.ts
+++ b/tests/bin/hooks/claude-code-hook.test.ts
@@ -24,6 +24,56 @@ describe('Claude Code hook', () => {
     });
   });
 
+  describe('ask mode', () => {
+    test('ask mode returns ask decision instead of deny', async () => {
+      const input = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'git reset --hard',
+        },
+      };
+
+      const { stdout, exitCode } = await runClaudeCodeHook(input, {
+        SAFETY_NET_ASK: '1',
+      });
+
+      const parsed = JSON.parse(stdout);
+      expect(exitCode).toBe(0);
+      expect(parsed.hookSpecificOutput.permissionDecision).toBe('ask');
+      expect(parsed.hookSpecificOutput.permissionDecisionReason).toContain('FLAGGED by Safety Net');
+    });
+
+    test('ask mode still allows safe commands', async () => {
+      const input = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: {
+          command: 'git status',
+        },
+      };
+
+      const { stdout, exitCode } = await runClaudeCodeHook(input, {
+        SAFETY_NET_ASK: '1',
+      });
+
+      expect(stdout).toBe('');
+      expect(exitCode).toBe(0);
+    });
+
+    test('strict parse failures still deny even in ask mode', async () => {
+      const { stdout, exitCode } = await runClaudeCodeHook('{invalid json', {
+        SAFETY_NET_ASK: '1',
+        SAFETY_NET_STRICT: '1',
+      });
+
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
+      expect(parsed.hookSpecificOutput.permissionDecisionReason).toContain('BLOCKED by Safety Net');
+    });
+  });
+
   describe('allowed commands', () => {
     test('allowed command produces no output', async () => {
       const input = {

--- a/tests/bin/hooks/copilot-cli-hook.test.ts
+++ b/tests/bin/hooks/copilot-cli-hook.test.ts
@@ -20,8 +20,8 @@ describe('Copilot CLI hook', () => {
     });
   });
 
-  describe('ask mode', () => {
-    test('ask mode returns ask decision instead of deny', async () => {
+  describe('ask mode ignored', () => {
+    test('ask mode still denies on Copilot CLI (unsupported)', async () => {
       const input = {
         timestamp: Date.now(),
         cwd: process.cwd(),
@@ -35,25 +35,7 @@ describe('Copilot CLI hook', () => {
 
       expect(exitCode).toBe(0);
       const output = JSON.parse(stdout);
-      expect(output.permissionDecision).toBe('ask');
-      expect(output.permissionDecisionReason).toContain('FLAGGED by Safety Net');
-      expect(output.permissionDecisionReason).toContain('rm -rf');
-    });
-
-    test('ask mode still allows safe commands', async () => {
-      const input = {
-        timestamp: Date.now(),
-        cwd: process.cwd(),
-        toolName: 'bash',
-        toolArgs: JSON.stringify({ command: 'ls -la' }),
-      };
-
-      const { stdout, exitCode } = await runCopilotHook(input, {
-        SAFETY_NET_ASK: '1',
-      });
-
-      expect(exitCode).toBe(0);
-      expect(stdout).toBe('');
+      expect(output.permissionDecision).toBe('deny');
     });
   });
 

--- a/tests/bin/hooks/copilot-cli-hook.test.ts
+++ b/tests/bin/hooks/copilot-cli-hook.test.ts
@@ -20,6 +20,43 @@ describe('Copilot CLI hook', () => {
     });
   });
 
+  describe('ask mode', () => {
+    test('ask mode returns ask decision instead of deny', async () => {
+      const input = {
+        timestamp: Date.now(),
+        cwd: process.cwd(),
+        toolName: 'bash',
+        toolArgs: JSON.stringify({ command: 'rm -rf /' }),
+      };
+
+      const { stdout, exitCode } = await runCopilotHook(input, {
+        SAFETY_NET_ASK: '1',
+      });
+
+      expect(exitCode).toBe(0);
+      const output = JSON.parse(stdout);
+      expect(output.permissionDecision).toBe('ask');
+      expect(output.permissionDecisionReason).toContain('FLAGGED by Safety Net');
+      expect(output.permissionDecisionReason).toContain('rm -rf');
+    });
+
+    test('ask mode still allows safe commands', async () => {
+      const input = {
+        timestamp: Date.now(),
+        cwd: process.cwd(),
+        toolName: 'bash',
+        toolArgs: JSON.stringify({ command: 'ls -la' }),
+      };
+
+      const { stdout, exitCode } = await runCopilotHook(input, {
+        SAFETY_NET_ASK: '1',
+      });
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toBe('');
+    });
+  });
+
   describe('allowed commands', () => {
     test('allows safe commands (no output)', async () => {
       const input = {

--- a/tests/core/format.test.ts
+++ b/tests/core/format.test.ts
@@ -102,4 +102,18 @@ describe('formatBlockedMessage', () => {
     expect(result).toContain('Segment: echo ***');
     expect(result).not.toContain('password');
   });
+
+  test('ask mode uses FLAGGED header and confirmation footer', () => {
+    const result = formatBlockedMessage({ reason: 'test reason', askMode: true });
+    expect(result).toContain('FLAGGED by Safety Net');
+    expect(result).not.toContain('BLOCKED by Safety Net');
+    expect(result).toContain('Approve to proceed');
+  });
+
+  test('default mode uses BLOCKED header', () => {
+    const result = formatBlockedMessage({ reason: 'test reason' });
+    expect(result).toContain('BLOCKED by Safety Net');
+    expect(result).not.toContain('FLAGGED by Safety Net');
+    expect(result).toContain('ask the user');
+  });
 });


### PR DESCRIPTION
## What

Adds `SAFETY_NET_ASK=1` environment variable. When set, dangerous commands return `permissionDecision: 'ask'` instead of `'deny'`, prompting the user for interactive confirmation rather than blocking outright.

## Why

When Safety Net blocks a command, there's no hands-on-keyboard way to approve it. The user has to either:
- Use `/copy` to grab the blocked command and paste it back
- Manually highlight the command with the mouse and re-type it
- Run the command themselves outside the agent session

This creates unnecessary friction when you *do* want the agent to run a flagged command. Ask mode keeps the safety analysis and warning visible while letting the user approve with a single keypress — similar to how `--force-with-lease` is safer than `--force` but still requires intent.

This is **opt-in** — default behavior is unchanged (hard deny). And it's not truly "soft" — the user must actively confirm each flagged command. The safety analysis still runs, the warning is still shown, and the audit log still records every flagged command.

Claude Code's hook protocol explicitly supports `'ask'` as a `permissionDecision` alongside `'allow'` and `'deny'` ([docs](https://docs.anthropic.com/en/docs/claude-code/hooks#pretooluse-decision-control)).

## Changes

- **`src/types.ts`** — Widen `HookOutput.permissionDecision` to include `'ask'`
- **`src/core/format.ts`** — Context-aware message: "FLAGGED by Safety Net" (ask) vs "BLOCKED by Safety Net" (deny), with appropriate footer text
- **`src/bin/hooks/claude-code.ts`** — Read `SAFETY_NET_ASK`, return `'ask'` instead of `'deny'`
- **`src/bin/hooks/copilot-cli.ts`** — Same
- **`src/bin/statusline.ts`** — Show ❓ emoji for ask mode
- **`src/bin/doctor/environment.ts`** — Added to env var diagnostics
- **`src/bin/help.ts`** — Added to help output
- **`CLAUDE.md`**, **`AGENTS.md`**, **`README.md`** — Documented the new env var

Gemini CLI and OpenCode are left as hard-deny only — their hook protocols don't support interactive confirmation.

Strict mode parse failures (`SAFETY_NET_STRICT=1`) always hard-deny regardless of ask mode.

## Test coverage

- Claude Code hook: ask mode returns `'ask'`, safe commands still pass through, strict parse failures still hard deny
- Copilot CLI hook: ask mode returns `'ask'`, safe commands still pass through
- Statusline: ❓ emoji displayed when `SAFETY_NET_ASK=1`
- Format: `FLAGGED` header and confirmation footer in ask mode, `BLOCKED` header in default mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "Ask Mode" (`SAFETY_NET_ASK=1`) that prompts users to approve or deny flagged commands instead of automatic blocking. Strict mode takes precedence.

* **Documentation**
  * Updated documentation, help text, and status indicators to describe Ask Mode behavior. Ask Mode is supported in Claude Code only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->