### PR TITLE
Worktree mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ log*
 plan-*.md
 *-plan-*.md
 .safety-net.json
-.sisyphus/
 .opencode
 .gemini
 .codex

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ plan-*.md
 .safety-net.json
 .opencode
 .gemini
+coverage
 .codex
 
 # --- Node.js ---

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A Claude Code plugin that acts as a safety net, catching destructive git and fil
 - [Advanced Features](#advanced-features)
   - [Strict Mode](#strict-mode)
   - [Paranoid Mode](#paranoid-mode)
+  - [Worktree Mode](#worktree-mode)
   - [Shell Wrapper Detection](#shell-wrapper-detection)
   - [Interpreter One-Liner Detection](#interpreter-one-liner-detection)
   - [Secret Redaction](#secret-redaction)
@@ -300,6 +301,7 @@ The status line displays different emojis based on the current configuration:
 | Paranoid mode | `🛡️ Safety Net 👁️` | `SAFETY_NET_PARANOID=1` — all paranoid checks enabled |
 | Paranoid RM only | `🛡️ Safety Net 🗑️` | `SAFETY_NET_PARANOID_RM=1` — blocks `rm -rf` even within cwd |
 | Paranoid interpreters only | `🛡️ Safety Net 🐚` | `SAFETY_NET_PARANOID_INTERPRETERS=1` — blocks interpreter one-liners |
+| Worktree mode | `🛡️ Safety Net 🌳` | `SAFETY_NET_WORKTREE=1` — relax local git discards inside linked worktrees |
 | Strict + Paranoid | `🛡️ Safety Net 🔒👁️` | Both strict and paranoid modes enabled |
 
 Multiple mode emojis are combined when multiple environment variables are set.
@@ -398,6 +400,7 @@ npx cc-safety-net explain --cwd /tmp "git status"
 | rm -rf /var/tmp/... | System temp directory |
 | rm -rf $TMPDIR/... | User's temp directory |
 | rm -rf ./... (within cwd) | Limited to current working directory |
+| git restore / checkout -- / reset --hard / clean -f (in linked worktree) | Relaxed only when `SAFETY_NET_WORKTREE=1` and cwd is a linked worktree |
 
 ## What Happens When Blocked
 
@@ -630,6 +633,46 @@ Paranoid behavior:
 - **rm**: blocks non-temp `rm -rf` even within the current working directory.
 - **interpreters**: blocks interpreter one-liners like `python -c`, `node -e`, `ruby -e`,
   and `perl -e` (these can hide destructive commands).
+
+### Worktree Mode
+
+Linked git worktrees are designed as disposable, isolated workspaces — discarding
+changes inside one doesn't risk the main working tree. Worktree mode relaxes
+local-discard rules when (and only when) the command is proven to run inside a
+linked worktree:
+
+```bash
+export SAFETY_NET_WORKTREE=1
+```
+
+When enabled, these commands are allowed inside a linked worktree:
+
+- `git restore <file>` and `git restore --worktree <file>`
+- `git checkout -- <file>`, `git checkout <ref> -- <file>`, `git checkout --force`,
+  and ambiguous multi-positional checkout forms
+- `git switch --discard-changes` and `git switch -f / --force`
+- `git reset --hard` and `git reset --merge`
+- `git clean -f` (and combined short flags like `-fd`)
+
+These remain blocked even in linked worktrees because they reach beyond the
+local working tree:
+
+- `git push --force` (affects remote)
+- `git branch -D` (affects shared refs)
+- `git stash drop` / `git stash clear` (stash is shared across worktrees)
+- `git worktree remove --force` (could delete another worktree)
+
+Detection is fail-closed and pure-filesystem — no shelling out to git:
+
+- A linked worktree is identified by a `.git` *file* containing `gitdir:` whose
+  resolved git directory contains a `commondir` file. Main worktrees and
+  submodules don't satisfy this and are not relaxed.
+- The cwd walk uses `realpath` so symlinked paths resolve correctly.
+- `git -C <path>` (including chained `-C` and attached `-Cpath`) is honored;
+  unresolved targets keep the command blocked.
+- Relaxation is disabled if cwd becomes unknown (e.g., after `cd`/`pushd`),
+  if `--git-dir` / `--work-tree` is passed, or if `GIT_DIR` / `GIT_WORK_TREE`
+  / `GIT_COMMON_DIR` is set in the environment.
 
 ### Shell Wrapper Detection
 

--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ local working tree:
 - `git stash drop` / `git stash clear` (stash is shared across worktrees)
 - `git worktree remove --force` (could delete another worktree)
 
-Detection is fail-closed and pure-filesystem — no shelling out to git:
+Detection is fail-closed and mostly filesystem-based:
 
 - A linked worktree is identified by a `.git` *file* containing `gitdir:` whose
   resolved git directory contains a `commondir` file. Main worktrees and
@@ -673,6 +673,8 @@ Detection is fail-closed and pure-filesystem — no shelling out to git:
 - Relaxation is disabled if cwd becomes unknown (e.g., after `cd`/`pushd`),
   if `--git-dir` / `--work-tree` is passed, or if `GIT_DIR` / `GIT_WORK_TREE`
   / `GIT_COMMON_DIR` is set in the environment.
+- Git may be invoked from a trusted system path to inspect effective config that
+  could make submodule operations recursive.
 
 ### Shell Wrapper Detection
 

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -1711,7 +1711,7 @@ function worktreeGitdirBacklinkMatches(gitDir, dotGitPath) {
   }
   const linkedDotGitPath = isAbsolute(rawBacklink) ? rawBacklink : resolve2(gitDir, rawBacklink);
   try {
-    return realpathSync(linkedDotGitPath) === realpathSync(dotGitPath);
+    return sameFilesystemPath(linkedDotGitPath, dotGitPath);
   } catch {
     return false;
   }
@@ -1727,10 +1727,27 @@ function worktreeConfigMatchesRoot(gitDir, worktreeRoot) {
   }
   const resolvedConfiguredWorktree = isAbsolute(configuredWorktree) ? configuredWorktree : resolve2(gitDir, configuredWorktree);
   try {
-    return realpathSync(resolvedConfiguredWorktree) === realpathSync(worktreeRoot);
+    return sameFilesystemPath(resolvedConfiguredWorktree, worktreeRoot);
   } catch {
     return false;
   }
+}
+function sameFilesystemPath(left, right) {
+  try {
+    const leftStat = statSync(left);
+    const rightStat = statSync(right);
+    if (leftStat.ino !== 0 && rightStat.ino !== 0 && leftStat.dev === rightStat.dev && leftStat.ino === rightStat.ino) {
+      return true;
+    }
+  } catch {}
+  return normalizePathForComparison(realpathSync(left)) === normalizePathForComparison(realpathSync(right));
+}
+function normalizePathForComparison(path) {
+  let normalized = path.replace(/\\/g, "/");
+  if (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 function readCoreWorktree(configPath) {
   const content = readFileSync4(configPath, "utf-8");
@@ -3572,7 +3589,7 @@ import { realpathSync as realpathSync3 } from "node:fs";
 import { homedir as homedir3, tmpdir } from "node:os";
 import { normalize, resolve as resolve3, sep as sep3 } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
-function normalizePathForComparison(p) {
+function normalizePathForComparison2(p) {
   let normalized = normalize(p);
   if (IS_WINDOWS) {
     normalized = normalized.replace(/\//g, "\\");
@@ -3712,8 +3729,8 @@ function isTempTarget(path, allowTmpdirVar) {
     return true;
   }
   const systemTmpdir = tmpdir();
-  const normalizedTmpdir = normalizePathForComparison(systemTmpdir);
-  const pathToCompare = normalizePathForComparison(normalized);
+  const normalizedTmpdir = normalizePathForComparison2(systemTmpdir);
+  const pathToCompare = normalizePathForComparison2(normalized);
   if (pathToCompare.startsWith(`${normalizedTmpdir}${sep3}`) || pathToCompare === normalizedTmpdir) {
     return true;
   }
@@ -3732,7 +3749,7 @@ function getHomeDirForRmPolicy() {
 }
 function isCwdHomeForRmPolicy(cwd, homeDir) {
   try {
-    return normalizePathForComparison(cwd) === normalizePathForComparison(homeDir);
+    return normalizePathForComparison2(cwd) === normalizePathForComparison2(homeDir);
   } catch {
     return false;
   }
@@ -3745,11 +3762,11 @@ function isCwdSelfTarget(target, cwd) {
     const resolved = resolve3(cwd, target);
     const realCwd = realpathSync3(cwd);
     const realResolved = realpathSync3(resolved);
-    return normalizePathForComparison(realResolved) === normalizePathForComparison(realCwd);
+    return normalizePathForComparison2(realResolved) === normalizePathForComparison2(realCwd);
   } catch {
     try {
       const resolved = resolve3(cwd, target);
-      return normalizePathForComparison(resolved) === normalizePathForComparison(cwd);
+      return normalizePathForComparison2(resolved) === normalizePathForComparison2(cwd);
     } catch {
       return false;
     }
@@ -3765,8 +3782,8 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   if (target.startsWith("/") || /^[A-Za-z]:[\\/]/.test(target)) {
     try {
-      const normalizedTarget = normalizePathForComparison(target);
-      const normalizedCwd = `${normalizePathForComparison(originalCwd)}${sep3}`;
+      const normalizedTarget = normalizePathForComparison2(target);
+      const normalizedCwd = `${normalizePathForComparison2(originalCwd)}${sep3}`;
       return normalizedTarget.startsWith(normalizedCwd);
     } catch {
       return false;
@@ -3775,8 +3792,8 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   if (target.startsWith("./") || target.startsWith(".\\") || !target.includes("/") && !target.includes("\\")) {
     try {
       const resolved = resolve3(resolveCwd, target);
-      const normalizedResolved = normalizePathForComparison(resolved);
-      const normalizedOriginalCwd = normalizePathForComparison(originalCwd);
+      const normalizedResolved = normalizePathForComparison2(resolved);
+      const normalizedOriginalCwd = normalizePathForComparison2(originalCwd);
       return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep3}`) || normalizedResolved === normalizedOriginalCwd;
     } catch {
       return false;
@@ -3787,8 +3804,8 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   try {
     const resolved = resolve3(resolveCwd, target);
-    const normalizedResolved = normalizePathForComparison(resolved);
-    const normalizedCwd = normalizePathForComparison(originalCwd);
+    const normalizedResolved = normalizePathForComparison2(resolved);
+    const normalizedCwd = normalizePathForComparison2(originalCwd);
     return normalizedResolved.startsWith(`${normalizedCwd}${sep3}`) || normalizedResolved === normalizedCwd;
   } catch {
     return false;

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -1570,7 +1570,7 @@ function hasRecursiveForceFlags(tokens) {
 
 // src/core/shell.ts
 import { lstatSync as lstatSync2, realpathSync as realpathSync2 } from "node:fs";
-import { dirname as dirname2, isAbsolute as isAbsolute2 } from "node:path";
+import { dirname as dirname2, isAbsolute as isAbsolute2, parse as parsePath2, sep as sep2 } from "node:path";
 
 // node_modules/shell-quote/index.js
 var $quote = require_quote();
@@ -1578,7 +1578,7 @@ var $parse = require_parse();
 
 // src/core/worktree.ts
 import { existsSync as existsSync4, lstatSync, readFileSync as readFileSync4, realpathSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join as join3, resolve as resolve2 } from "node:path";
+import { dirname, isAbsolute, join as join3, parse as parsePath, resolve as resolve2, sep } from "node:path";
 var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
   "-c",
   "-C",
@@ -1771,8 +1771,9 @@ function resolveGitCwd(baseCwd, target) {
   }
 }
 function resolveChdirTarget(baseCwd, target) {
-  let current = isAbsolute(target) ? "/" : baseCwd;
-  for (const component of target.split("/")) {
+  const root = isAbsolute(target) ? getPathRoot(target) : "";
+  let current = root || baseCwd;
+  for (const component of getPathComponents(root ? target.slice(root.length) : target)) {
     if (component === "" || component === ".") {
       continue;
     }
@@ -1786,7 +1787,14 @@ function resolveChdirTarget(baseCwd, target) {
   return current;
 }
 function appendPathWithoutNormalizing(base, target) {
-  return base.endsWith("/") ? `${base}${target}` : `${base}/${target}`;
+  return base.endsWith("/") || base.endsWith("\\") ? `${base}${target}` : `${base}${sep}${target}`;
+}
+function getPathRoot(target) {
+  return parsePath(target).root;
+}
+function getPathComponents(target) {
+  const separator = process.platform === "win32" ? /[\\/]+/ : /\/+/;
+  return target.split(separator);
 }
 function isDirectory(path) {
   try {
@@ -2294,6 +2302,13 @@ function _stripAttachedIoNumbers(command) {
 var ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
 var ENV_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES = new Set(GIT_CONTEXT_ENV_OVERRIDES);
+var GIT_CONFIG_AFFECTING_ENV_NAMES = new Set([
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_CONFIG_SYSTEM",
+  "HOME",
+  "XDG_CONFIG_HOME"
+]);
 function parseEnvAssignment(token) {
   if (!ENV_ASSIGNMENT_RE.test(token)) {
     return null;
@@ -2304,11 +2319,17 @@ function parseEnvAssignment(token) {
 function parseGitContextAppendEnvAssignment(token) {
   const match = token.match(ENV_APPEND_ASSIGNMENT_RE);
   const name = match?.[1];
-  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name)) {
+  if (!name || !isTrackedGitEnvName(name)) {
     return null;
   }
   const eqIdx = token.indexOf("=");
   return { name, value: token.slice(eqIdx + 1) };
+}
+function isTrackedGitEnvName(name) {
+  return GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES.has(name) || isGitConfigEnvName(name);
+}
+function isGitConfigEnvName(name) {
+  return name === "GIT_CONFIG_COUNT" || name === "GIT_CONFIG_PARAMETERS" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(name);
 }
 function stripEnvAssignmentsWithInfo(tokens) {
   const envAssignments = new Map;
@@ -2555,15 +2576,16 @@ function resolveWrapperCwd(cwd, target) {
     if (!cwd && !isAbsolute2(target)) {
       return null;
     }
-    const baseCwd = isAbsolute2(target) ? "/" : realpathSync2(cwd ?? "/");
+    const baseCwd = isAbsolute2(target) ? getPathRoot2(target) : realpathSync2(cwd ?? "/");
     return resolveChdirTarget2(baseCwd, target);
   } catch {
     return null;
   }
 }
 function resolveChdirTarget2(baseCwd, target) {
-  let current = isAbsolute2(target) ? "/" : baseCwd;
-  for (const component of target.split("/")) {
+  const root = isAbsolute2(target) ? getPathRoot2(target) : "";
+  let current = root || baseCwd;
+  for (const component of getPathComponents2(root ? target.slice(root.length) : target)) {
     if (component === "" || component === ".") {
       continue;
     }
@@ -2577,7 +2599,14 @@ function resolveChdirTarget2(baseCwd, target) {
   return current;
 }
 function appendPathWithoutNormalizing2(base, target) {
-  return base.endsWith("/") ? `${base}${target}` : `${base}/${target}`;
+  return base.endsWith("/") || base.endsWith("\\") ? `${base}${target}` : `${base}${sep2}${target}`;
+}
+function getPathRoot2(target) {
+  return parsePath2(target).root;
+}
+function getPathComponents2(target) {
+  const separator = process.platform === "win32" ? /[\\/]+/ : /\/+/;
+  return target.split(separator);
 }
 function stripCommand(tokens) {
   let i = 1;
@@ -2961,7 +2990,7 @@ var CHECKOUT_OPTS_WITH_VALUE = new Set([
 var CHECKOUT_OPTS_WITH_OPTIONAL_VALUE = new Set(["--recurse-submodules", "--track", "-t"]);
 var CHECKOUT_SHORT_OPTS_WITH_VALUE = new Set(["-b", "-B", "-U"]);
 var SWITCH_SHORT_OPTS_WITH_VALUE = new Set(["-c", "-C"]);
-var GIT_CONFIG_AFFECTING_ENV_NAMES = new Set([
+var GIT_CONFIG_AFFECTING_ENV_NAMES2 = new Set([
   "GIT_CONFIG_GLOBAL",
   "GIT_CONFIG_NOSYSTEM",
   "GIT_CONFIG_SYSTEM",
@@ -3365,7 +3394,7 @@ function hasConfigAffectingEnvAssignment(envAssignments) {
     return false;
   }
   for (const key of envAssignments.keys()) {
-    if (GIT_CONFIG_AFFECTING_ENV_NAMES.has(key)) {
+    if (GIT_CONFIG_AFFECTING_ENV_NAMES2.has(key)) {
       return true;
     }
   }
@@ -3541,7 +3570,7 @@ function analyzeGitWorktree(tokens) {
 // src/core/rules-rm.ts
 import { realpathSync as realpathSync3 } from "node:fs";
 import { homedir as homedir3, tmpdir } from "node:os";
-import { normalize, resolve as resolve3, sep } from "node:path";
+import { normalize, resolve as resolve3, sep as sep3 } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison(p) {
   let normalized = normalize(p);
@@ -3685,7 +3714,7 @@ function isTempTarget(path, allowTmpdirVar) {
   const systemTmpdir = tmpdir();
   const normalizedTmpdir = normalizePathForComparison(systemTmpdir);
   const pathToCompare = normalizePathForComparison(normalized);
-  if (pathToCompare.startsWith(`${normalizedTmpdir}${sep}`) || pathToCompare === normalizedTmpdir) {
+  if (pathToCompare.startsWith(`${normalizedTmpdir}${sep3}`) || pathToCompare === normalizedTmpdir) {
     return true;
   }
   if (allowTmpdirVar) {
@@ -3737,7 +3766,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   if (target.startsWith("/") || /^[A-Za-z]:[\\/]/.test(target)) {
     try {
       const normalizedTarget = normalizePathForComparison(target);
-      const normalizedCwd = `${normalizePathForComparison(originalCwd)}${sep}`;
+      const normalizedCwd = `${normalizePathForComparison(originalCwd)}${sep3}`;
       return normalizedTarget.startsWith(normalizedCwd);
     } catch {
       return false;
@@ -3748,7 +3777,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
       const resolved = resolve3(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison(resolved);
       const normalizedOriginalCwd = normalizePathForComparison(originalCwd);
-      return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep}`) || normalizedResolved === normalizedOriginalCwd;
+      return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep3}`) || normalizedResolved === normalizedOriginalCwd;
     } catch {
       return false;
     }
@@ -3760,7 +3789,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     const resolved = resolve3(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison(resolved);
     const normalizedCwd = normalizePathForComparison(originalCwd);
-    return normalizedResolved.startsWith(`${normalizedCwd}${sep}`) || normalizedResolved === normalizedCwd;
+    return normalizedResolved.startsWith(`${normalizedCwd}${sep3}`) || normalizedResolved === normalizedCwd;
   } catch {
     return false;
   }
@@ -3845,7 +3874,7 @@ function analyzeParallel(tokens, context) {
       for (const arg of args) {
         const expandedTokens = childTokens.map((t) => t.replace(/{}/g, arg));
         const rmResult = analyzeRm(expandedTokens, {
-          cwd: context.cwd,
+          cwd: childCwd,
           originalCwd: context.originalCwd,
           paranoid: context.paranoidRm,
           allowTmpdirVar: context.allowTmpdirVar
@@ -3859,7 +3888,7 @@ function analyzeParallel(tokens, context) {
     if (args.length > 0) {
       const expandedTokens = [...childTokens, args[0] ?? ""];
       const rmResult = analyzeRm(expandedTokens, {
-        cwd: context.cwd,
+        cwd: childCwd,
         originalCwd: context.originalCwd,
         paranoid: context.paranoidRm,
         allowTmpdirVar: context.allowTmpdirVar
@@ -4037,7 +4066,7 @@ function parseParallelCommand(tokens) {
 
 // src/core/analyze/tmpdir.ts
 import { tmpdir as tmpdir2 } from "node:os";
-import { normalize as normalize2, sep as sep2 } from "node:path";
+import { normalize as normalize2, sep as sep4 } from "node:path";
 function isTmpdirOverriddenToNonTemp(envAssignments) {
   if (!envAssignments.has("TMPDIR")) {
     return false;
@@ -4057,7 +4086,7 @@ function isPathOrSubpath(path, basePath) {
   if (path === basePath) {
     return true;
   }
-  const baseWithSlash = basePath.endsWith(sep2) ? basePath : `${basePath}${sep2}`;
+  const baseWithSlash = basePath.endsWith(sep4) ? basePath : `${basePath}${sep4}`;
   return path.startsWith(baseWithSlash);
 }
 
@@ -4087,7 +4116,7 @@ function analyzeXargs(tokens, context) {
   }
   if (head === "rm" && hasRecursiveForceFlags(childTokens)) {
     const rmResult = analyzeRm(childTokens, {
-      cwd: context.cwd,
+      cwd: childCwd,
       originalCwd: context.originalCwd,
       paranoid: context.paranoidRm,
       allowTmpdirVar: context.allowTmpdirVar
@@ -4483,7 +4512,7 @@ function stripLeadingGrouping(tokens) {
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES2 = new Set(GIT_CONTEXT_ENV_OVERRIDES);
-var GIT_CONFIG_AFFECTING_ENV_NAMES2 = new Set([
+var GIT_CONFIG_AFFECTING_ENV_NAMES3 = new Set([
   "GIT_CONFIG_GLOBAL",
   "GIT_CONFIG_NOSYSTEM",
   "GIT_CONFIG_SYSTEM",
@@ -4544,7 +4573,7 @@ function createShellGitContextEnvState(effectiveEnvAssignments) {
   return {
     effectiveEnvAssignments,
     shellAssignments: new Map,
-    exportedNames: new Set,
+    exportedNames: getInitiallyExportedGitContextNames(effectiveEnvAssignments),
     allexport: false,
     keywordExport: false
   };
@@ -4622,7 +4651,7 @@ function getShellCommandInfo(tokens) {
     if (!assignment) {
       break;
     }
-    if (isTrackedGitEnvName(assignment.name)) {
+    if (isTrackedGitEnvName2(assignment.name)) {
       leadingAssignments.set(assignment.name, assignment);
     }
     i++;
@@ -4680,7 +4709,7 @@ function parseShellAssignment(token) {
 }
 function parseGitContextEnvAssignment(token) {
   const assignment = parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment2(token);
-  if (!assignment || !isTrackedGitEnvName(assignment.name)) {
+  if (!assignment || !isTrackedGitEnvName2(assignment.name)) {
     return null;
   }
   return assignment;
@@ -4688,17 +4717,31 @@ function parseGitContextEnvAssignment(token) {
 function parseGitContextAppendEnvAssignment2(token) {
   const match = token.match(GIT_CONTEXT_APPEND_ASSIGNMENT_RE);
   const name = match?.[1];
-  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name)) {
+  if (!name || !isTrackedGitEnvName2(name)) {
     return null;
   }
   const eqIdx = token.indexOf("=");
   return { name, value: token.slice(eqIdx + 1) };
 }
-function isTrackedGitEnvName(name) {
-  return GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES2.has(name) || isGitConfigEnvName(name);
+function isTrackedGitEnvName2(name) {
+  return GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES3.has(name) || isGitConfigEnvName2(name);
 }
-function isGitConfigEnvName(name) {
+function isGitConfigEnvName2(name) {
   return name === "GIT_CONFIG_COUNT" || name === "GIT_CONFIG_PARAMETERS" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(name);
+}
+function getInitiallyExportedGitContextNames(effectiveEnvAssignments) {
+  const exportedNames = new Set;
+  for (const name of Object.keys(process.env)) {
+    if (isTrackedGitEnvName2(name)) {
+      exportedNames.add(name);
+    }
+  }
+  for (const name of effectiveEnvAssignments?.keys() ?? []) {
+    if (isTrackedGitEnvName2(name)) {
+      exportedNames.add(name);
+    }
+  }
+  return exportedNames;
 }
 function setShellGitContextAssignment(state, assignment) {
   state.shellAssignments.set(assignment.name, assignment.value);
@@ -4719,7 +4762,7 @@ function addExportedGitContextEnvAssignment(state, token) {
     setEffectiveGitContextAssignment(state, assignment);
     return;
   }
-  if (isTrackedGitEnvName(token)) {
+  if (isTrackedGitEnvName2(token)) {
     state.exportedNames.add(token);
     const value = state.shellAssignments.get(token);
     if (value !== undefined) {
@@ -4747,7 +4790,7 @@ function addTypesetGitContextEnvAssignment(state, token, exports, readonlyLeadin
     setEffectiveGitContextAssignment(state, readonlyAssignment);
     return;
   }
-  if (exports && isTrackedGitEnvName(token)) {
+  if (exports && isTrackedGitEnvName2(token)) {
     state.exportedNames.add(token);
     const value = state.shellAssignments.get(token);
     if (value !== undefined) {

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -1380,9 +1380,9 @@ All checks passed.`);
 }
 
 // src/bin/doctor/hooks.ts
-import { existsSync as existsSync6, readdirSync as readdirSync2, readFileSync as readFileSync5 } from "node:fs";
+import { existsSync as existsSync6, readdirSync as readdirSync2, readFileSync as readFileSync6 } from "node:fs";
 import { homedir as homedir4, tmpdir as tmpdir3 } from "node:os";
-import { join as join4 } from "node:path";
+import { join as join5 } from "node:path";
 
 // src/core/analyze/dangerous-text.ts
 function dangerousInText(text) {
@@ -2981,7 +2981,8 @@ function extractDashCArg(tokens) {
 
 // src/core/rules-git.ts
 import { execFileSync } from "node:child_process";
-import { existsSync as existsSync5 } from "node:fs";
+import { existsSync as existsSync5, readFileSync as readFileSync5 } from "node:fs";
+import { dirname as dirname3, isAbsolute as isAbsolute3, join as join4, resolve as resolve3 } from "node:path";
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
 var REASON_CHECKOUT_REF_PATH = "git checkout <ref> -- <path> overwrites working tree with ref version. Use 'git stash' first.";
@@ -3425,9 +3426,13 @@ function getEnvConfigValue(name, envAssignments) {
   return envAssignments?.get(name) ?? process.env[name];
 }
 function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
+  const localConfigResult = localGitConfigEnablesRecursiveSubmodules(cwd);
+  if (localConfigResult === null || localConfigResult) {
+    return true;
+  }
   const gitBinary = getTrustedGitBinary();
   if (gitBinary === null) {
-    return true;
+    return false;
   }
   try {
     const value = execFileSync(gitBinary, ["config", "--get", "submodule.recurse"], {
@@ -3440,6 +3445,22 @@ function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
   } catch (error) {
     return !isGitConfigUnsetError(error);
   }
+}
+function localGitConfigEnablesRecursiveSubmodules(cwd) {
+  const configPaths = getLocalGitConfigPaths(cwd);
+  if (configPaths === null) {
+    return null;
+  }
+  for (const configPath of configPaths) {
+    if (!existsSync5(configPath)) {
+      continue;
+    }
+    const result = gitConfigFileEnablesRecursiveSubmodules(configPath);
+    if (result) {
+      return true;
+    }
+  }
+  return false;
 }
 function getTrustedGitBinary() {
   for (const gitBinary of TRUSTED_GIT_BINARIES) {
@@ -3460,6 +3481,100 @@ function withoutGitConfigEnv(env) {
 }
 function isGitConfigUnsetError(error) {
   return typeof error === "object" && error !== null && "status" in error && error.status === 1;
+}
+function getLocalGitConfigPaths(cwd) {
+  const dotGitPath = findDotGitPath(cwd);
+  if (dotGitPath === null) {
+    return null;
+  }
+  const gitDir = resolveGitDirFromDotGit(dotGitPath);
+  if (gitDir === null) {
+    return null;
+  }
+  const commonDir = resolveCommonGitDir(gitDir);
+  if (commonDir === null) {
+    return null;
+  }
+  return [join4(commonDir, "config"), join4(gitDir, "config.worktree")];
+}
+function findDotGitPath(cwd) {
+  let current = cwd;
+  while (true) {
+    const dotGitPath = join4(current, ".git");
+    if (existsSync5(dotGitPath)) {
+      return dotGitPath;
+    }
+    const parent = dirname3(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+function resolveGitDirFromDotGit(dotGitPath) {
+  try {
+    const content = readFileSync5(dotGitPath, "utf-8");
+    const firstLine = content.split(/\r?\n/, 1)[0]?.trim() ?? "";
+    if (!firstLine.startsWith("gitdir:")) {
+      return dotGitPath;
+    }
+    const rawGitDir = firstLine.slice("gitdir:".length).trim();
+    if (rawGitDir === "") {
+      return null;
+    }
+    return isAbsolute3(rawGitDir) ? rawGitDir : resolve3(dirname3(dotGitPath), rawGitDir);
+  } catch {
+    return null;
+  }
+}
+function resolveCommonGitDir(gitDir) {
+  const commonDirPath = join4(gitDir, "commondir");
+  if (!existsSync5(commonDirPath)) {
+    return gitDir;
+  }
+  try {
+    const rawCommonDir = readFileSync5(commonDirPath, "utf-8").split(/\r?\n/, 1)[0]?.trim() ?? "";
+    if (rawCommonDir === "") {
+      return null;
+    }
+    return isAbsolute3(rawCommonDir) ? rawCommonDir : resolve3(gitDir, rawCommonDir);
+  } catch {
+    return null;
+  }
+}
+function gitConfigFileEnablesRecursiveSubmodules(configPath) {
+  let content;
+  try {
+    content = readFileSync5(configPath, "utf-8");
+  } catch {
+    return true;
+  }
+  let section = "";
+  let recursiveSubmoduleConfig = false;
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith(";")) {
+      continue;
+    }
+    const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+    if (sectionMatch) {
+      section = sectionMatch[1]?.trim().toLowerCase() ?? "";
+      continue;
+    }
+    const eqIdx = trimmed.indexOf("=");
+    const key = (eqIdx === -1 ? trimmed : trimmed.slice(0, eqIdx)).trim().toLowerCase();
+    const value = eqIdx === -1 ? "true" : trimmed.slice(eqIdx + 1).trim();
+    if (isIncludeConfigSection(section) && key === "path") {
+      return true;
+    }
+    if (section === "submodule" && key === "recurse") {
+      recursiveSubmoduleConfig = gitConfigValueEnablesRecursiveSubmodules(value);
+    }
+  }
+  return recursiveSubmoduleConfig;
+}
+function isIncludeConfigSection(section) {
+  return section === "include" || section.startsWith("includeif ");
 }
 function recursiveSubmoduleConfigValue(config) {
   if (!config) {
@@ -3591,7 +3706,7 @@ function analyzeGitWorktree(tokens) {
 // src/core/rules-rm.ts
 import { realpathSync as realpathSync3 } from "node:fs";
 import { homedir as homedir3, tmpdir } from "node:os";
-import { normalize, resolve as resolve3, sep as sep3 } from "node:path";
+import { normalize, resolve as resolve4, sep as sep3 } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison2(p) {
   let normalized = normalize(p);
@@ -3763,13 +3878,13 @@ function isCwdSelfTarget(target, cwd) {
     return true;
   }
   try {
-    const resolved = resolve3(cwd, target);
+    const resolved = resolve4(cwd, target);
     const realCwd = realpathSync3(cwd);
     const realResolved = realpathSync3(resolved);
     return normalizePathForComparison2(realResolved) === normalizePathForComparison2(realCwd);
   } catch {
     try {
-      const resolved = resolve3(cwd, target);
+      const resolved = resolve4(cwd, target);
       return normalizePathForComparison2(resolved) === normalizePathForComparison2(cwd);
     } catch {
       return false;
@@ -3795,7 +3910,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   if (target.startsWith("./") || target.startsWith(".\\") || !target.includes("/") && !target.includes("\\")) {
     try {
-      const resolved = resolve3(resolveCwd, target);
+      const resolved = resolve4(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison2(resolved);
       const normalizedOriginalCwd = normalizePathForComparison2(originalCwd);
       return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep3}`) || normalizedResolved === normalizedOriginalCwd;
@@ -3807,7 +3922,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     return false;
   }
   try {
-    const resolved = resolve3(resolveCwd, target);
+    const resolved = resolve4(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison2(resolved);
     const normalizedCwd = normalizePathForComparison2(originalCwd);
     return normalizedResolved.startsWith(`${normalizedCwd}${sep3}`) || normalizedResolved === normalizedCwd;
@@ -4934,7 +5049,7 @@ var SELF_TEST_CASES = [
 ];
 var SELF_TEST_CONFIG = { version: 1, rules: [] };
 function runSelfTest() {
-  const selfTestCwd = join4(tmpdir3(), "cc-safety-net-self-test");
+  const selfTestCwd = join5(tmpdir3(), "cc-safety-net-self-test");
   const results = SELF_TEST_CASES.map((tc) => {
     const result = analyzeCommand(tc.command, {
       cwd: selfTestCwd,
@@ -5044,11 +5159,11 @@ function stripJsonComments(content) {
 }
 function detectClaudeCode(homeDir) {
   const errors = [];
-  const settingsPath = join4(homeDir, ".claude", "settings.json");
+  const settingsPath = join5(homeDir, ".claude", "settings.json");
   const pluginKey = "safety-net@cc-marketplace";
   if (existsSync6(settingsPath)) {
     try {
-      const settings = JSON.parse(readFileSync5(settingsPath, "utf-8"));
+      const settings = JSON.parse(readFileSync6(settingsPath, "utf-8"));
       const pluginValue = settings.enabledPlugins?.[pluginKey];
       if (pluginValue === true) {
         return {
@@ -5079,13 +5194,13 @@ function detectClaudeCode(homeDir) {
 }
 function detectOpenCode(homeDir) {
   const errors = [];
-  const configDir = join4(homeDir, ".config", "opencode");
+  const configDir = join5(homeDir, ".config", "opencode");
   const candidates = ["opencode.json", "opencode.jsonc"];
   for (const filename of candidates) {
-    const configPath = join4(configDir, filename);
+    const configPath = join5(configDir, filename);
     if (existsSync6(configPath)) {
       try {
-        const content = readFileSync5(configPath, "utf-8");
+        const content = readFileSync6(configPath, "utf-8");
         const json = stripJsonComments(content);
         const config = JSON.parse(json);
         const plugins = config.plugin ?? [];
@@ -5113,13 +5228,13 @@ function detectOpenCode(homeDir) {
 }
 function checkGeminiHooksEnabled(homeDir, cwd, errors) {
   const candidates = [
-    join4(homeDir, ".gemini", "settings.json"),
-    join4(cwd, ".gemini", "settings.json")
+    join5(homeDir, ".gemini", "settings.json"),
+    join5(cwd, ".gemini", "settings.json")
   ];
   for (const settingsPath of candidates) {
     if (existsSync6(settingsPath)) {
       try {
-        const settings = JSON.parse(readFileSync5(settingsPath, "utf-8"));
+        const settings = JSON.parse(readFileSync6(settingsPath, "utf-8"));
         if (settings.tools?.enableHooks === true) {
           return { enabled: true, configPath: settingsPath };
         }
@@ -5132,14 +5247,14 @@ function checkGeminiHooksEnabled(homeDir, cwd, errors) {
 }
 function detectGeminiCLI(homeDir, cwd) {
   const errors = [];
-  const extensionPath = join4(homeDir, ".gemini", "extensions", "extension-enablement.json");
+  const extensionPath = join5(homeDir, ".gemini", "extensions", "extension-enablement.json");
   if (!existsSync6(extensionPath)) {
     return { platform: "gemini-cli", status: "n/a" };
   }
   let isInstalled = false;
   let isEnabled = false;
   try {
-    const extensionConfig = JSON.parse(readFileSync5(extensionPath, "utf-8"));
+    const extensionConfig = JSON.parse(readFileSync6(extensionPath, "utf-8"));
     const pluginConfig = extensionConfig["gemini-safety-net"];
     if (pluginConfig) {
       isInstalled = true;
@@ -5226,7 +5341,7 @@ function _supportsCopilotInlineHooks(version) {
   return comparison >= 0;
 }
 function _getCopilotConfigHome(homeDir) {
-  return process.env.COPILOT_HOME || join4(homeDir, ".copilot");
+  return process.env.COPILOT_HOME || join5(homeDir, ".copilot");
 }
 function _hasSafetyNetCopilotHook(config) {
   const preToolUseHooks = config.hooks?.preToolUse ?? [];
@@ -5238,7 +5353,7 @@ function _hasSafetyNetCopilotHook(config) {
 }
 function _readCopilotConfigFile(configPath, errors) {
   try {
-    return JSON.parse(readFileSync5(configPath, "utf-8"));
+    return JSON.parse(readFileSync6(configPath, "utf-8"));
   } catch (e) {
     errors?.push(`Failed to parse ${configPath}: ${e instanceof Error ? e.message : String(e)}`);
     return;
@@ -5257,7 +5372,7 @@ function _collectSafetyNetCopilotHookFiles(dirPath, errors) {
     return [];
   const matches = [];
   for (const filename of _listJsonFiles(dirPath, errors)) {
-    const configPath = join4(dirPath, filename);
+    const configPath = join5(dirPath, filename);
     const config = _readCopilotConfigFile(configPath, errors);
     if (config && _hasSafetyNetCopilotHook(config)) {
       matches.push(configPath);
@@ -5296,15 +5411,15 @@ function _resolveCopilotInlineDisableSource(inlineSources) {
 }
 function _checkCopilotEnabled(homeDir, cwd, copilotCliVersion, errors) {
   const configHome = _getCopilotConfigHome(homeDir);
-  const repoHookDir = join4(cwd, ".github", "hooks");
-  const userHookDir = join4(configHome, "hooks");
-  const repoConfigDir = join4(cwd, ".github", "copilot");
+  const repoHookDir = join5(cwd, ".github", "hooks");
+  const userHookDir = join5(configHome, "hooks");
+  const repoConfigDir = join5(cwd, ".github", "copilot");
   const inlineSupport = _supportsCopilotInlineHooks(copilotCliVersion);
   const inlineErrors = inlineSupport === true ? errors : undefined;
   const inlineSources = {
-    userConfig: _collectCopilotInlineConfig(join4(configHome, "config.json"), inlineErrors),
-    repoSettings: _collectCopilotInlineConfig(join4(repoConfigDir, "settings.json"), inlineErrors),
-    localSettings: _collectCopilotInlineConfig(join4(repoConfigDir, "settings.local.json"), inlineErrors)
+    userConfig: _collectCopilotInlineConfig(join5(configHome, "config.json"), inlineErrors),
+    repoSettings: _collectCopilotInlineConfig(join5(repoConfigDir, "settings.json"), inlineErrors),
+    localSettings: _collectCopilotInlineConfig(join5(repoConfigDir, "settings.local.json"), inlineErrors)
   };
   if (inlineSupport !== false) {
     const disableSource = _resolveCopilotInlineDisableSource(inlineSources);
@@ -5321,7 +5436,7 @@ function _checkCopilotEnabled(homeDir, cwd, copilotCliVersion, errors) {
   const userHookFiles = existsSync6(userHookDir) ? _listJsonFiles(userHookDir, userHookErrors) : [];
   const userHookPaths = [];
   for (const filename of userHookFiles) {
-    const configPath = join4(userHookDir, filename);
+    const configPath = join5(userHookDir, filename);
     const config = _readCopilotConfigFile(configPath, userHookErrors);
     if (config && _hasSafetyNetCopilotHook(config)) {
       userHookPaths.push(configPath);
@@ -5413,7 +5528,7 @@ var defaultVersionFetcher = async (args) => {
   const [cmd, ...rest] = args;
   if (!cmd)
     return null;
-  return new Promise((resolve4) => {
+  return new Promise((resolve5) => {
     try {
       const proc = spawn(cmd, rest, {
         stdio: ["ignore", "pipe", "pipe"]
@@ -5429,7 +5544,7 @@ var defaultVersionFetcher = async (args) => {
           return;
         isSettled = true;
         clearTimeout(timeoutId);
-        resolve4(value);
+        resolve5(value);
       };
       const timeoutId = setTimeout(() => {
         proc.kill();
@@ -5442,7 +5557,7 @@ var defaultVersionFetcher = async (args) => {
         finish(null);
       });
     } catch {
-      resolve4(null);
+      resolve5(null);
     }
   });
 };
@@ -5609,7 +5724,7 @@ function printReport(report) {
 
 // src/bin/explain/config.ts
 import { existsSync as existsSync7 } from "node:fs";
-import { resolve as resolve4 } from "node:path";
+import { resolve as resolve5 } from "node:path";
 
 // src/core/env.ts
 function envTruthy(name) {
@@ -5639,7 +5754,7 @@ function getConfigSource(options) {
   return { configSource: null, configValid: true };
 }
 function buildAnalyzeOptions(explainOptions) {
-  const cwd = resolve4(explainOptions?.cwd ?? process.cwd());
+  const cwd = resolve5(explainOptions?.cwd ?? process.cwd());
   const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
   return {
     cwd,
@@ -6633,7 +6748,7 @@ function showCommandHelp(commandName) {
 // src/core/audit.ts
 import { appendFileSync, existsSync as existsSync8, mkdirSync } from "node:fs";
 import { homedir as homedir5 } from "node:os";
-import { join as join5 } from "node:path";
+import { join as join6 } from "node:path";
 function sanitizeSessionIdForFilename(sessionId) {
   const raw = sessionId.trim();
   if (!raw) {
@@ -6652,12 +6767,12 @@ function writeAuditLog(sessionId, command, segment, reason, cwd, options = {}) {
     return;
   }
   const home = options.homeDir ?? homedir5();
-  const logsDir = join5(home, ".cc-safety-net", "logs");
+  const logsDir = join6(home, ".cc-safety-net", "logs");
   try {
     if (!existsSync8(logsDir)) {
       mkdirSync(logsDir, { recursive: true });
     }
-    const logFile = join5(logsDir, `${safeSessionId}.jsonl`);
+    const logFile = join6(logsDir, `${safeSessionId}.jsonl`);
     const entry = {
       ts: new Date().toISOString(),
       command: redactSecrets(command).slice(0, 300),
@@ -6912,14 +7027,14 @@ async function runGeminiCLIHook() {
 }
 
 // src/bin/statusline.ts
-import { existsSync as existsSync9, readFileSync as readFileSync6 } from "node:fs";
+import { existsSync as existsSync9, readFileSync as readFileSync7 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { join as join6 } from "node:path";
+import { join as join7 } from "node:path";
 async function readStdinAsync() {
   if (process.stdin.isTTY) {
     return null;
   }
-  return new Promise((resolve5) => {
+  return new Promise((resolve6) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => {
@@ -6927,10 +7042,10 @@ async function readStdinAsync() {
     });
     process.stdin.on("end", () => {
       const trimmed = data.trim();
-      resolve5(trimmed || null);
+      resolve6(trimmed || null);
     });
     process.stdin.on("error", () => {
-      resolve5(null);
+      resolve6(null);
     });
   });
 }
@@ -6938,7 +7053,7 @@ function getSettingsPath() {
   if (process.env.CLAUDE_SETTINGS_PATH) {
     return process.env.CLAUDE_SETTINGS_PATH;
   }
-  return join6(homedir6(), ".claude", "settings.json");
+  return join7(homedir6(), ".claude", "settings.json");
 }
 function isPluginEnabled() {
   const settingsPath = getSettingsPath();
@@ -6946,7 +7061,7 @@ function isPluginEnabled() {
     return false;
   }
   try {
-    const content = readFileSync6(settingsPath, "utf-8");
+    const content = readFileSync7(settingsPath, "utf-8");
     const settings = JSON.parse(content);
     if (!settings.enabledPlugins) {
       return false;
@@ -6997,8 +7112,8 @@ async function printStatusline() {
 }
 
 // src/bin/verify-config.ts
-import { existsSync as existsSync10, readFileSync as readFileSync7, writeFileSync } from "node:fs";
-import { resolve as resolve5 } from "node:path";
+import { existsSync as existsSync10, readFileSync as readFileSync8, writeFileSync } from "node:fs";
+import { resolve as resolve6 } from "node:path";
 var HEADER = "Safety Net Config";
 var SEPARATOR = "═".repeat(HEADER.length);
 var SCHEMA_URL = "https://raw.githubusercontent.com/kenryu42/claude-code-safety-net/main/assets/cc-safety-net.schema.json";
@@ -7034,7 +7149,7 @@ function printInvalidConfig(scope, path, errors) {
 }
 function addSchemaIfMissing(path) {
   try {
-    const content = readFileSync7(path, "utf-8");
+    const content = readFileSync8(path, "utf-8");
     const parsed = JSON.parse(content);
     if (parsed.$schema) {
       return false;
@@ -7063,7 +7178,7 @@ function verifyConfig(options = {}) {
     const result = validateConfigFile(projectConfig);
     configsChecked.push({
       scope: "Project",
-      path: resolve5(projectConfig),
+      path: resolve6(projectConfig),
       result
     });
     if (result.errors.length > 0) {

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -3032,7 +3032,9 @@ var SWITCH_SHORT_OPTS_WITH_VALUE = new Set(["-c", "-C"]);
 var TRUSTED_GIT_BINARIES = [
   "/usr/bin/git",
   "/usr/local/bin/git",
-  "/opt/homebrew/bin/git"
+  "/opt/homebrew/bin/git",
+  "C:\\Program Files\\Git\\cmd\\git.exe",
+  "C:\\Program Files\\Git\\bin\\git.exe"
 ];
 var CHECKOUT_KNOWN_OPTS_NO_VALUE = new Set([
   "-q",
@@ -3439,14 +3441,13 @@ function hasConfigAffectingEnvAssignment(envAssignments) {
 function getEnvConfigValue(name, envAssignments) {
   return envAssignments?.get(name) ?? process.env[name];
 }
-function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
+function effectiveGitConfigEnablesRecursiveSubmodules(cwd, gitBinary = getTrustedGitBinary()) {
   const localConfigResult = localGitConfigEnablesRecursiveSubmodules(cwd);
   if (localConfigResult === null || localConfigResult) {
     return true;
   }
-  const gitBinary = getTrustedGitBinary();
   if (gitBinary === null) {
-    return false;
+    return true;
   }
   try {
     const value = execFileSync(gitBinary, ["config", "--get", "submodule.recurse"], {

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -2090,7 +2090,11 @@ function stripWrappersWithInfo(tokens, cwd) {
       break;
     }
     if (head === "sudo") {
-      result = stripSudo(result);
+      const sudoResult = stripSudoWithInfo(result, currentCwd);
+      result = sudoResult.tokens;
+      if (sudoResult.cwd !== undefined) {
+        currentCwd = sudoResult.cwd;
+      }
     }
     if (head === "env") {
       const envResult = stripEnvWithInfo(result, currentCwd);
@@ -2115,17 +2119,24 @@ function stripWrappersWithInfo(tokens, cwd) {
   return { tokens: finalTokens, envAssignments: allEnvAssignments, cwd: currentCwd };
 }
 var SUDO_OPTS_WITH_VALUE = new Set(["-u", "-g", "-C", "-D", "-h", "-p", "-r", "-t", "-T", "-U"]);
-function stripSudo(tokens) {
+function stripSudoWithInfo(tokens, cwd) {
   let i = 1;
+  let currentCwd = cwd;
   while (i < tokens.length) {
     const token = tokens[i];
     if (!token)
       break;
     if (token === "--") {
-      return tokens.slice(i + 1);
+      return { tokens: tokens.slice(i + 1), cwd: currentCwd };
     }
     if (!token.startsWith("-")) {
       break;
+    }
+    if (token === "-D") {
+      const target = tokens[i + 1];
+      currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
+      i += 2;
+      continue;
     }
     if (SUDO_OPTS_WITH_VALUE.has(token)) {
       i += 2;
@@ -2133,7 +2144,7 @@ function stripSudo(tokens) {
     }
     i++;
   }
-  return tokens.slice(i);
+  return { tokens: tokens.slice(i), cwd: currentCwd };
 }
 var ENV_OPTS_NO_VALUE = new Set(["-i", "-0", "--null"]);
 var ENV_OPTS_WITH_VALUE = new Set([
@@ -2148,21 +2159,65 @@ var ENV_OPTS_WITH_VALUE = new Set([
 function stripEnvWithInfo(tokens, cwd) {
   const envAssignments = new Map;
   let currentCwd = cwd;
+  let expandedTokens = tokens;
   let i = 1;
-  while (i < tokens.length) {
-    const token = tokens[i];
+  while (i < expandedTokens.length) {
+    const token = expandedTokens[i];
     if (!token)
       break;
     if (token === "--") {
-      return { tokens: tokens.slice(i + 1), envAssignments };
+      return { tokens: expandedTokens.slice(i + 1), envAssignments, cwd: currentCwd };
     }
     if (ENV_OPTS_NO_VALUE.has(token)) {
       i++;
       continue;
     }
+    if (token === "-S" || token === "--split-string") {
+      const splitValue = expandedTokens[i + 1];
+      const splitTokens = splitValue !== undefined ? parseEnvSplitString(splitValue) : null;
+      if (!splitTokens) {
+        currentCwd = null;
+        i += 2;
+        continue;
+      }
+      expandedTokens = [
+        ...expandedTokens.slice(0, i),
+        ...splitTokens,
+        ...expandedTokens.slice(i + 2)
+      ];
+      continue;
+    }
+    if (token.startsWith("-S") && token.length > 2) {
+      const splitTokens = parseEnvSplitString(token.slice("-S".length));
+      if (!splitTokens) {
+        currentCwd = null;
+        i++;
+        continue;
+      }
+      expandedTokens = [
+        ...expandedTokens.slice(0, i),
+        ...splitTokens,
+        ...expandedTokens.slice(i + 1)
+      ];
+      continue;
+    }
+    if (token.startsWith("--split-string=")) {
+      const splitTokens = parseEnvSplitString(token.slice("--split-string=".length));
+      if (!splitTokens) {
+        currentCwd = null;
+        i++;
+        continue;
+      }
+      expandedTokens = [
+        ...expandedTokens.slice(0, i),
+        ...splitTokens,
+        ...expandedTokens.slice(i + 1)
+      ];
+      continue;
+    }
     if (ENV_OPTS_WITH_VALUE.has(token)) {
       if (token === "-C" || token === "--chdir") {
-        const target = tokens[i + 1];
+        const target = expandedTokens[i + 1];
         currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
       }
       i += 2;
@@ -2172,8 +2227,8 @@ function stripEnvWithInfo(tokens, cwd) {
       i++;
       continue;
     }
-    if (token.startsWith("-C=") || token.startsWith("--chdir=")) {
-      const target = token.startsWith("-C=") ? token.slice("-C=".length) : token.slice("--chdir=".length);
+    if (token.startsWith("-C") && token.length > 2 || token.startsWith("--chdir=")) {
+      const target = token.startsWith("--chdir=") ? token.slice("--chdir=".length) : token.startsWith("-C=") ? token.slice("-C=".length) : token.slice("-C".length);
       currentCwd = resolveWrapperCwd(currentCwd, target);
       i++;
       continue;
@@ -2193,7 +2248,22 @@ function stripEnvWithInfo(tokens, cwd) {
     envAssignments.set(assignment.name, assignment.value);
     i++;
   }
-  return { tokens: tokens.slice(i), envAssignments, cwd: currentCwd };
+  return { tokens: expandedTokens.slice(i), envAssignments, cwd: currentCwd };
+}
+function parseEnvSplitString(value) {
+  if (hasUnclosedQuotes(value)) {
+    return null;
+  }
+  const parsed = $parse(value, ENV_PROXY);
+  const result = [];
+  for (const entry of parsed) {
+    const token = _getCommandTokenText(entry);
+    if (token === null) {
+      return null;
+    }
+    result.push(token);
+  }
+  return result;
 }
 function resolveWrapperCwd(cwd, target) {
   if (target === "") {
@@ -3298,7 +3368,7 @@ function analyzeParallel(tokens, context) {
   }
   const { template, args, hasPlaceholder, runsRemotely } = parseResult;
   if (template.length === 0) {
-    const nestedOverrides2 = runsRemotely ? { worktreeMode: false } : undefined;
+    const nestedOverrides2 = buildCommandsModeOverrides(context, runsRemotely);
     for (const arg of args) {
       const reason = context.analyzeNested(arg, nestedOverrides2);
       if (reason) {
@@ -3398,13 +3468,16 @@ function analyzeParallel(tokens, context) {
     }
   }
   if (head === "git") {
-    const gitResult = analyzeGit(childTokens, {
-      cwd: childCwd,
-      envAssignments: childEnvAssignments,
-      worktreeMode: runsRemotely ? false : context.worktreeMode
-    });
-    if (gitResult) {
-      return gitResult;
+    const gitTokenSets = !hasPlaceholder && args.length > 0 ? args.map((arg) => [...childTokens, arg]) : [childTokens];
+    for (const gitTokens of gitTokenSets) {
+      const gitResult = analyzeGit(gitTokens, {
+        cwd: childCwd,
+        envAssignments: childEnvAssignments,
+        worktreeMode: runsRemotely ? false : context.worktreeMode
+      });
+      if (gitResult) {
+        return gitResult;
+      }
     }
   }
   return null;
@@ -3418,6 +3491,19 @@ function buildNestedOverrides(envAssignments, cwd, runsRemotely) {
     overrides.worktreeMode = false;
   }
   return overrides;
+}
+function buildCommandsModeOverrides(context, runsRemotely) {
+  const overrides = {};
+  if (context.envAssignments) {
+    overrides.envAssignments = context.envAssignments;
+  }
+  if (context.cwd !== undefined) {
+    overrides.effectiveCwd = context.cwd;
+  }
+  if (runsRemotely) {
+    overrides.worktreeMode = false;
+  }
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 function parseParallelCommand(tokens) {
   const parallelOptsWithValue = new Set([
@@ -3552,8 +3638,9 @@ function isPathOrSubpath(path, basePath) {
 // src/core/analyze/xargs.ts
 var REASON_XARGS_RM = "xargs rm -rf with dynamic input is dangerous. Use explicit file list instead.";
 var REASON_XARGS_SHELL = "xargs with shell -c can execute arbitrary commands from dynamic input.";
+var XARGS_APPENDED_INPUT = "__CC_SAFETY_NET_XARGS_INPUT__";
 function analyzeXargs(tokens, context) {
-  const { childTokens: rawChildTokens } = extractXargsChildCommandWithInfo(tokens);
+  const { childTokens: rawChildTokens, replacementToken } = extractXargsChildCommandWithInfo(tokens);
   const childWrapperInfo = stripWrappersWithInfo(rawChildTokens, context.cwd);
   let childTokens = childWrapperInfo.tokens;
   const childEnvAssignments = new Map(context.envAssignments ?? []);
@@ -3591,7 +3678,8 @@ function analyzeXargs(tokens, context) {
     }
   }
   if (head === "git") {
-    const gitResult = analyzeGit(childTokens, {
+    const gitTokens = replacementToken === null ? [...childTokens, XARGS_APPENDED_INPUT] : childTokens;
+    const gitResult = analyzeGit(gitTokens, {
       cwd: childCwd,
       envAssignments: childEnvAssignments,
       worktreeMode: context.worktreeMode
@@ -3806,7 +3894,10 @@ function analyzeSegment(tokens, depth, options) {
       if (options.paranoidInterpreters) {
         return REASON_INTERPRETER_BLOCKED + PARANOID_INTERPRETERS_SUFFIX;
       }
-      const innerReason = options.analyzeNested(codeArg);
+      const innerReason = options.analyzeNested(codeArg, {
+        effectiveCwd: nestedEffectiveCwd,
+        envAssignments
+      });
       if (innerReason) {
         return innerReason;
       }
@@ -3816,7 +3907,11 @@ function analyzeSegment(tokens, depth, options) {
     }
   }
   if (normalizedHead === "busybox" && stripped.length > 1) {
-    return analyzeSegment(stripped.slice(1), depth, options);
+    return analyzeSegment(stripped.slice(1), depth, {
+      ...options,
+      effectiveCwd: nestedEffectiveCwd,
+      envAssignments
+    });
   }
   const isGit = basename.toLowerCase() === "git";
   const isRm = basename === "rm";
@@ -3960,6 +4055,7 @@ function stripLeadingGrouping(tokens) {
 // src/core/analyze/analyze-command.ts
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
+var GIT_CONTEXT_ENV_OVERRIDE_NAMES = new Set(GIT_CONTEXT_ENV_OVERRIDES);
 function analyzeCommandInternal(command, depth, options) {
   if (depth >= MAX_RECURSION_DEPTH) {
     return { reason: REASON_RECURSION_LIMIT, segment: command };
@@ -3970,8 +4066,10 @@ function analyzeCommandInternal(command, depth, options) {
   }
   const originalCwd = options.cwd;
   let effectiveCwd = options.effectiveCwd !== undefined ? options.effectiveCwd : options.cwd;
+  let effectiveEnvAssignments = options.envAssignments;
   for (const segment of segments) {
     const segmentStr = segment.join(" ");
+    const segmentEnvAssignments = effectiveEnvAssignments;
     if (segment.length === 1 && segment[0]?.includes(" ")) {
       const textReason = dangerousInText(segment[0]);
       if (textReason) {
@@ -3986,12 +4084,13 @@ function analyzeCommandInternal(command, depth, options) {
       ...options,
       cwd: originalCwd,
       effectiveCwd,
+      envAssignments: segmentEnvAssignments,
       analyzeNested: (nestedCommand, overrides) => {
         const nestedEffectiveCwd = overrides && Object.hasOwn(overrides, "effectiveCwd") ? overrides.effectiveCwd : effectiveCwd;
         return analyzeCommandInternal(nestedCommand, depth + 1, {
           ...options,
           effectiveCwd: nestedEffectiveCwd,
-          envAssignments: overrides?.envAssignments ?? options.envAssignments,
+          envAssignments: overrides?.envAssignments ?? segmentEnvAssignments,
           worktreeMode: overrides?.worktreeMode ?? options.worktreeMode
         })?.reason ?? null;
       }
@@ -4002,8 +4101,32 @@ function analyzeCommandInternal(command, depth, options) {
     if (segmentChangesCwd(segment)) {
       effectiveCwd = null;
     }
+    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment);
+    if (exportedEnvAssignments.size > 0) {
+      const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
+      for (const [k, v] of exportedEnvAssignments) {
+        nextEnvAssignments.set(k, v);
+      }
+      effectiveEnvAssignments = nextEnvAssignments;
+    }
   }
   return null;
+}
+function getExportedGitContextEnvAssignments(tokens) {
+  const result = new Map;
+  if (tokens[0] !== "export") {
+    return result;
+  }
+  for (const token of tokens.slice(1)) {
+    if (token.startsWith("-")) {
+      return new Map;
+    }
+    const assignment = parseEnvAssignment(token);
+    if (assignment && GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
+      result.set(assignment.name, assignment.value);
+    }
+  }
+  return result;
 }
 
 // src/core/analyze.ts
@@ -4842,7 +4965,11 @@ function explainSegment(tokens, depth, options, steps) {
       output: envResult.tokens
     });
   }
-  const wrapperResult = stripWrappersWithInfo(envResult.tokens);
+  const effectiveCwd = options.effectiveCwd === undefined ? options.cwd : options.effectiveCwd;
+  const cwdUnknown = effectiveCwd === null;
+  const baseCwdForRm = cwdUnknown ? undefined : effectiveCwd ?? options.cwd;
+  const originalCwd = cwdUnknown ? undefined : options.cwd;
+  const wrapperResult = stripWrappersWithInfo(envResult.tokens, baseCwdForRm);
   const removed = envResult.tokens.slice(0, envResult.tokens.length - wrapperResult.tokens.length);
   if (removed.length > 0) {
     steps.push({
@@ -4935,10 +5062,7 @@ function explainSegment(tokens, depth, options, steps) {
   }
   const allowTmpdirVar = !isTmpdirOverriddenToNonTemp(envAssignments);
   const tmpdirValue = envAssignments.get("TMPDIR") ?? process.env.TMPDIR ?? null;
-  const effectiveCwd = options.effectiveCwd === undefined ? options.cwd : options.effectiveCwd;
-  const cwdUnknown = effectiveCwd === null;
-  const cwdForRm = cwdUnknown ? undefined : effectiveCwd ?? options.cwd;
-  const originalCwd = cwdUnknown ? undefined : options.cwd;
+  const cwdForRm = wrapperResult.cwd === null ? undefined : wrapperResult.cwd ?? baseCwdForRm;
   const isGit = baseNameLower === "git";
   const isRm = baseName === "rm";
   const isFind = baseName === "find";
@@ -5077,7 +5201,7 @@ function explainSegment(tokens, depth, options, steps) {
         const gitOptions = {
           cwd: cwdForRm,
           envAssignments,
-          worktreeMode: options.worktreeMode
+          worktreeMode: false
         };
         fallbackRelaxation = getGitWorktreeRelaxation(gitTokens, gitOptions);
         fallbackReason = analyzeGit(gitTokens, gitOptions);

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -2912,6 +2912,7 @@ function extractDashCArg(tokens) {
 }
 
 // src/core/rules-git.ts
+import { execFileSync } from "node:child_process";
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
 var REASON_CHECKOUT_REF_PATH = "git checkout <ref> -- <path> overwrites working tree with ref version. Use 'git stash' first.";
@@ -3039,7 +3040,7 @@ function sharedState(reason) {
   return reason ? { reason, localDiscard: false } : null;
 }
 function getGitWorktreeRelaxationForMatch(tokens, match, options) {
-  if (!match.localDiscard || !options.worktreeMode || hasGitContextEnvOverride(options.envAssignments) || isNonRelaxableLocalDiscard(tokens)) {
+  if (!match.localDiscard || !options.worktreeMode || hasGitContextEnvOverride(options.envAssignments)) {
     return null;
   }
   const context = getGitExecutionContext(tokens, options.cwd);
@@ -3047,6 +3048,9 @@ function getGitWorktreeRelaxationForMatch(tokens, match, options) {
     return null;
   }
   if (!isLinkedWorktree(context.gitCwd)) {
+    return null;
+  }
+  if (isNonRelaxableLocalDiscard(tokens, options, context.gitCwd)) {
     return null;
   }
   return {
@@ -3230,48 +3234,67 @@ function analyzeGitClean(tokens) {
   }
   return null;
 }
-function isNonRelaxableLocalDiscard(tokens) {
+function isNonRelaxableLocalDiscard(tokens, options, gitCwd) {
   const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
   const normalizedSubcommand = subcommand?.toLowerCase();
-  if (hasRecursiveSubmoduleConfig(tokens) || hasRecurseSubmodulesOption(rest) || isForcedBranchReset(normalizedSubcommand, rest)) {
+  if (hasDynamicGitArgument(rest) || hasRecursiveSubmoduleConfig(tokens, options, gitCwd) || hasRecurseSubmodulesOption(rest) || isForcedBranchReset(normalizedSubcommand, rest)) {
     return true;
   }
   return normalizedSubcommand === "clean" && countCleanForceFlags(rest) > 1;
 }
-function hasRecursiveSubmoduleConfig(tokens) {
+function hasDynamicGitArgument(tokens) {
+  return tokens.some((token) => token.includes("$"));
+}
+function hasRecursiveSubmoduleConfig(tokens, options, gitCwd) {
+  const commandLineConfig = commandLineRecursiveSubmoduleConfig(tokens, options.envAssignments);
+  if (commandLineConfig !== null) {
+    return commandLineConfig;
+  }
+  const envConfig = envRecursiveSubmoduleConfig(options.envAssignments);
+  if (envConfig !== null) {
+    return envConfig;
+  }
+  return effectiveGitConfigEnablesRecursiveSubmodules(gitCwd);
+}
+function commandLineRecursiveSubmoduleConfig(tokens, envAssignments) {
+  let recursiveSubmoduleConfig = null;
   let i = 1;
   while (i < tokens.length) {
     const token = tokens[i];
     if (!token || token === "--") {
-      return false;
+      return recursiveSubmoduleConfig;
     }
     if (!token.startsWith("-")) {
-      return false;
+      return recursiveSubmoduleConfig;
     }
     if (token === "-c") {
-      if (configEnablesRecursiveSubmodules(tokens[i + 1])) {
-        return true;
+      const configValue = recursiveSubmoduleConfigValue(tokens[i + 1]);
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i += 2;
       continue;
     }
     if (token.startsWith("-c") && token.length > 2) {
-      if (configEnablesRecursiveSubmodules(token.slice(2))) {
-        return true;
+      const configValue = recursiveSubmoduleConfigValue(token.slice(2));
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i++;
       continue;
     }
     if (token === "--config-env") {
-      if (configEnvTargetsRecursiveSubmodules(tokens[i + 1])) {
-        return true;
+      const configValue = recursiveSubmoduleConfigEnvValue(tokens[i + 1], envAssignments);
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i += 2;
       continue;
     }
     if (token.startsWith("--config-env=")) {
-      if (configEnvTargetsRecursiveSubmodules(token.slice("--config-env=".length))) {
-        return true;
+      const configValue = recursiveSubmoduleConfigEnvValue(token.slice("--config-env=".length), envAssignments);
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i++;
       continue;
@@ -3282,26 +3305,82 @@ function hasRecursiveSubmoduleConfig(tokens) {
       i++;
     }
   }
-  return false;
+  return recursiveSubmoduleConfig;
 }
-function configEnablesRecursiveSubmodules(config) {
+function envRecursiveSubmoduleConfig(envAssignments) {
+  const countValue = getEnvConfigValue("GIT_CONFIG_COUNT", envAssignments);
+  if (countValue === undefined) {
+    return null;
+  }
+  const count = Number.parseInt(countValue, 10);
+  if (!Number.isInteger(count) || count < 0) {
+    return true;
+  }
+  let recursiveSubmoduleConfig = null;
+  for (let i = 0;i < count; i++) {
+    const key = getEnvConfigValue(`GIT_CONFIG_KEY_${i}`, envAssignments);
+    if (key?.toLowerCase() !== "submodule.recurse") {
+      continue;
+    }
+    const value = getEnvConfigValue(`GIT_CONFIG_VALUE_${i}`, envAssignments);
+    recursiveSubmoduleConfig = value === undefined || gitConfigValueEnablesRecursiveSubmodules(value);
+  }
+  return recursiveSubmoduleConfig;
+}
+function getEnvConfigValue(name, envAssignments) {
+  return envAssignments?.get(name) ?? process.env[name];
+}
+function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
+  try {
+    const value = execFileSync("git", ["config", "--get", "submodule.recurse"], {
+      cwd,
+      encoding: "utf8",
+      env: withoutGitConfigEnv(process.env),
+      stdio: ["ignore", "pipe", "ignore"]
+    }).trim();
+    return gitConfigValueEnablesRecursiveSubmodules(value);
+  } catch (error) {
+    return !isGitConfigUnsetError(error);
+  }
+}
+function withoutGitConfigEnv(env) {
+  const nextEnv = { ...env };
+  for (const key of Object.keys(nextEnv)) {
+    if (key === "GIT_CONFIG_COUNT" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(key)) {
+      delete nextEnv[key];
+    }
+  }
+  return nextEnv;
+}
+function isGitConfigUnsetError(error) {
+  return typeof error === "object" && error !== null && "status" in error && error.status === 1;
+}
+function recursiveSubmoduleConfigValue(config) {
   if (!config) {
-    return false;
+    return null;
   }
   const eqIdx = config.indexOf("=");
   const key = (eqIdx === -1 ? config : config.slice(0, eqIdx)).toLowerCase();
   if (key !== "submodule.recurse") {
-    return false;
+    return null;
   }
   const value = eqIdx === -1 ? "true" : config.slice(eqIdx + 1).toLowerCase();
-  return value !== "false" && value !== "no" && value !== "off" && value !== "0";
+  return gitConfigValueEnablesRecursiveSubmodules(value);
 }
-function configEnvTargetsRecursiveSubmodules(configEnv) {
+function gitConfigValueEnablesRecursiveSubmodules(value) {
+  const normalizedValue = value.toLowerCase();
+  return normalizedValue !== "false" && normalizedValue !== "no" && normalizedValue !== "off" && normalizedValue !== "0";
+}
+function recursiveSubmoduleConfigEnvValue(configEnv, envAssignments) {
   const eqIdx = configEnv?.indexOf("=") ?? -1;
   if (!configEnv || eqIdx === -1) {
-    return false;
+    return null;
   }
-  return configEnv.slice(0, eqIdx).toLowerCase() === "submodule.recurse";
+  if (configEnv.slice(0, eqIdx).toLowerCase() !== "submodule.recurse") {
+    return null;
+  }
+  const value = getEnvConfigValue(configEnv.slice(eqIdx + 1), envAssignments);
+  return value === undefined || gitConfigValueEnablesRecursiveSubmodules(value);
 }
 function isForcedBranchReset(subcommand, rest) {
   if (subcommand === "checkout") {
@@ -3310,15 +3389,16 @@ function isForcedBranchReset(subcommand, rest) {
       shortOptsWithValue: CHECKOUT_SHORT_OPTS_WITH_VALUE
     });
     const hasForce = before.includes("--force") || shortOpts.has("-f");
-    return hasForce && before.some((token) => token === "-B" || token.startsWith("-B"));
+    const hasBranchReset = shortOpts.has("-B") || before.some((token) => token === "-B" || token.startsWith("-B"));
+    return hasForce && hasBranchReset;
   }
   if (subcommand === "switch") {
     const { before } = splitAtDoubleDash(rest);
     const shortOpts = extractShortOpts(before, {
       shortOptsWithValue: SWITCH_SHORT_OPTS_WITH_VALUE
     });
-    const hasForce = before.includes("--force") || shortOpts.has("-f");
-    const hasForceCreate = before.some((token) => token === "-C" || token.startsWith("-C") || token === "--force-create" || token.startsWith("--force-create="));
+    const hasForce = before.includes("--force") || before.includes("--discard-changes") || shortOpts.has("-f");
+    const hasForceCreate = before.some((token) => token === "-C" || token.startsWith("-C") || token === "--force-create" || token.startsWith("--force-create=")) || shortOpts.has("-C");
     return hasForce && hasForceCreate;
   }
   return false;
@@ -3625,6 +3705,7 @@ function analyzeParallel(tokens, context) {
     return null;
   }
   const { template, args, hasPlaceholder, runsRemotely, usesStdin } = parseResult;
+  const hasDynamicStdinPlaceholder = usesStdin && hasPlaceholder;
   if (template.length === 0) {
     const nestedOverrides2 = buildCommandsModeOverrides(context, runsRemotely);
     for (const arg of args) {
@@ -3642,7 +3723,7 @@ function analyzeParallel(tokens, context) {
     childEnvAssignments.set(k, v);
   }
   const childCwd = childWrapperInfo.cwd === null ? undefined : childWrapperInfo.cwd ?? context.cwd;
-  const nestedOverrides = buildNestedOverrides(childEnvAssignments, childWrapperInfo.cwd, runsRemotely);
+  const nestedOverrides = buildNestedOverrides(childEnvAssignments, childWrapperInfo.cwd, runsRemotely || hasDynamicStdinPlaceholder);
   let head = getBasename(childTokens[0] ?? "").toLowerCase();
   if (head === "busybox" && childTokens.length > 1) {
     childTokens = childTokens.slice(1);
@@ -3947,10 +4028,11 @@ function analyzeXargs(tokens, context) {
   }
   if (head === "git") {
     const gitTokens = replacementToken === null ? [...childTokens, XARGS_APPENDED_INPUT] : childTokens;
+    const hasDynamicReplacement = replacementToken !== null && childTokens.some((token) => token.includes(replacementToken));
     const gitResult = analyzeGit(gitTokens, {
       cwd: childCwd,
       envAssignments: childEnvAssignments,
-      worktreeMode: replacementToken === null ? false : context.worktreeMode
+      worktreeMode: replacementToken === null || hasDynamicReplacement ? false : context.worktreeMode
     });
     if (gitResult) {
       return gitResult;
@@ -4338,7 +4420,7 @@ function analyzeCommandInternal(command, depth, options) {
   const shellGitContextState = createShellGitContextEnvState(options.envAssignments);
   for (const segment of segments) {
     const segmentStr = segment.join(" ");
-    const segmentEnvAssignments = shellGitContextState.effectiveEnvAssignments;
+    const segmentEnvAssignments = getSegmentGitContextEnvAssignments(segment, shellGitContextState);
     if (segment.length === 1 && segment[0]?.includes(" ")) {
       const textReason = dangerousInText(segment[0]);
       if (textReason) {
@@ -4379,7 +4461,8 @@ function createShellGitContextEnvState(effectiveEnvAssignments) {
     effectiveEnvAssignments,
     shellAssignments: new Map,
     exportedNames: new Set,
-    allexport: false
+    allexport: false,
+    keywordExport: false
   };
 }
 function applyShellGitContextEnvSegment(tokens, state) {
@@ -4395,13 +4478,16 @@ function applyShellGitContextEnvSegment(tokens, state) {
     return;
   }
   if (command === "set") {
-    const allexport = getAllexportChange(tokens, commandIndex);
-    if (allexport !== null) {
-      state.allexport = allexport;
+    const changes = getSetOptionChanges(tokens, commandIndex);
+    if (changes.allexport !== null) {
+      state.allexport = changes.allexport;
+    }
+    if (changes.keywordExport !== null) {
+      state.keywordExport = changes.keywordExport;
     }
     return;
   }
-  if (command !== "export" && command !== "typeset" && command !== "declare") {
+  if (command !== "export" && command !== "typeset" && command !== "declare" && command !== "readonly") {
     return;
   }
   for (const assignment of leadingAssignments.values()) {
@@ -4425,6 +4511,21 @@ function applyShellGitContextEnvSegment(tokens, state) {
     addTypesetGitContextEnvAssignment(state, token, operandsInfo.exports);
   }
 }
+function getSegmentGitContextEnvAssignments(tokens, state) {
+  if (!state.keywordExport) {
+    return state.effectiveEnvAssignments;
+  }
+  let nextEnvAssignments = null;
+  for (const token of tokens) {
+    const assignment = parseGitContextEnvAssignment(token);
+    if (!assignment) {
+      continue;
+    }
+    nextEnvAssignments ??= new Map(state.effectiveEnvAssignments ?? []);
+    nextEnvAssignments.set(assignment.name, assignment.value);
+  }
+  return nextEnvAssignments ?? state.effectiveEnvAssignments;
+}
 function getShellCommandInfo(tokens) {
   const leadingAssignments = new Map;
   let i = 0;
@@ -4447,14 +4548,45 @@ function getShellCommandInfo(tokens) {
   }
   let commandIndex = i;
   let command = tokens[commandIndex] ?? null;
-  if (command === "builtin" || command === "command") {
+  if (command === "builtin") {
     commandIndex++;
     command = tokens[commandIndex] ?? null;
+  }
+  if (command === "command") {
+    const commandBuiltinInfo = getCommandBuiltinTarget(tokens, commandIndex);
+    if (!commandBuiltinInfo) {
+      return null;
+    }
+    commandIndex = commandBuiltinInfo.commandIndex;
+    command = commandBuiltinInfo.command;
   }
   if (command === null) {
     return null;
   }
   return { command, commandIndex, leadingAssignments };
+}
+function getCommandBuiltinTarget(tokens, commandIndex) {
+  let i = commandIndex + 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    if (token === "--") {
+      i++;
+      break;
+    }
+    if (token === "-p") {
+      i++;
+      continue;
+    }
+    if (token === "-v" || token === "-V") {
+      return null;
+    }
+    break;
+  }
+  const command = tokens[i];
+  return command ? { command, commandIndex: i } : null;
 }
 function parseShellAssignment(token) {
   return parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment2(token);
@@ -4523,17 +4655,25 @@ function addTypesetGitContextEnvAssignment(state, token, exports) {
   }
 }
 function getExportOperandsStart(tokens, commandIndex) {
-  const firstOperand = tokens[commandIndex + 1];
-  if (firstOperand === undefined) {
-    return commandIndex + 1;
+  let i = commandIndex + 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    if (token === "--") {
+      return i + 1;
+    }
+    if (token === "-p") {
+      i++;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return null;
+    }
+    return i;
   }
-  if (firstOperand === "--") {
-    return commandIndex + 2;
-  }
-  if (firstOperand.startsWith("-")) {
-    return null;
-  }
-  return commandIndex + 1;
+  return i;
 }
 function getTypesetOperandsInfo(tokens, commandIndex) {
   let i = commandIndex + 1;
@@ -4547,40 +4687,69 @@ function getTypesetOperandsInfo(tokens, commandIndex) {
       return { operandsStart: i + 1, exports: hasExportFlag };
     }
     if (token.startsWith("-")) {
-      hasExportFlag = hasExportFlag || token.slice(1).includes("x");
+      if (token.slice(1).includes("x")) {
+        hasExportFlag = true;
+      }
       i++;
       continue;
     }
     if (token.startsWith("+")) {
-      return null;
+      if (token.slice(1).includes("x")) {
+        hasExportFlag = false;
+      }
+      i++;
+      continue;
     }
     return { operandsStart: i, exports: hasExportFlag };
   }
   return { operandsStart: i, exports: hasExportFlag };
 }
-function getAllexportChange(tokens, commandIndex) {
+function getSetOptionChanges(tokens, commandIndex) {
+  const changes = { allexport: null, keywordExport: null };
   let i = commandIndex + 1;
   while (i < tokens.length) {
     const token = tokens[i];
     if (!token) {
-      return null;
+      return changes;
+    }
+    if (token === "--") {
+      return changes;
     }
     if (token === "-o" || token === "+o") {
       if (tokens[i + 1] === "allexport") {
-        return token === "-o";
+        changes.allexport = token === "-o";
+      }
+      if (tokens[i + 1] === "keyword") {
+        changes.keywordExport = token === "-o";
       }
       i += 2;
       continue;
     }
-    if (token.startsWith("-") && token.slice(1).includes("a")) {
-      return true;
+    if (token.startsWith("-") && token.length > 1) {
+      const flags = token.slice(1);
+      if (flags.includes("a")) {
+        changes.allexport = true;
+      }
+      if (flags.includes("k")) {
+        changes.keywordExport = true;
+      }
+      i++;
+      continue;
     }
-    if (token.startsWith("+") && token.slice(1).includes("a")) {
-      return false;
+    if (token.startsWith("+") && token.length > 1) {
+      const flags = token.slice(1);
+      if (flags.includes("a")) {
+        changes.allexport = false;
+      }
+      if (flags.includes("k")) {
+        changes.keywordExport = false;
+      }
+      i++;
+      continue;
     }
-    i++;
+    return changes;
   }
-  return null;
+  return changes;
 }
 
 // src/core/analyze.ts

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -871,6 +871,11 @@ var ENV_VARS = [
     name: "SAFETY_NET_PARANOID_INTERPRETERS",
     description: "Block interpreter one-liners",
     defaultBehavior: "off"
+  },
+  {
+    name: "SAFETY_NET_WORKTREE",
+    description: "Allow local git discards in linked worktrees",
+    defaultBehavior: "off"
   }
 ];
 function getEnvironmentInfo() {
@@ -1375,9 +1380,9 @@ All checks passed.`);
 }
 
 // src/bin/doctor/hooks.ts
-import { existsSync as existsSync4, readdirSync as readdirSync2, readFileSync as readFileSync4 } from "node:fs";
+import { existsSync as existsSync5, readdirSync as readdirSync2, readFileSync as readFileSync5 } from "node:fs";
 import { homedir as homedir4, tmpdir as tmpdir3 } from "node:os";
-import { join as join3 } from "node:path";
+import { join as join4 } from "node:path";
 
 // src/core/analyze/dangerous-text.ts
 function dangerousInText(text) {
@@ -2526,6 +2531,145 @@ function extractDashCArg(tokens) {
   return null;
 }
 
+// src/core/worktree.ts
+import { existsSync as existsSync4, readFileSync as readFileSync4, realpathSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join as join3, resolve as resolve2 } from "node:path";
+var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
+  "-c",
+  "-C",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--super-prefix",
+  "--config-env"
+]);
+var GIT_CONTEXT_ENV_OVERRIDES = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"];
+function hasGitContextEnvOverride(envAssignments) {
+  for (const name of GIT_CONTEXT_ENV_OVERRIDES) {
+    if (envAssignments?.has(name) || Object.hasOwn(process.env, name)) {
+      return true;
+    }
+  }
+  return false;
+}
+function getGitExecutionContext(tokens, cwd) {
+  if (!cwd) {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
+  let gitCwd = resolve2(cwd);
+  if (!isDirectory(gitCwd)) {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
+  let hasExplicitGitContext = false;
+  let i = 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token)
+      break;
+    if (token === "--") {
+      break;
+    }
+    if (!token.startsWith("-")) {
+      break;
+    }
+    if (token === "-C") {
+      const target = tokens[i + 1];
+      if (!target) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      const resolvedCwd = resolveGitCwd(gitCwd, target);
+      if (!resolvedCwd) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      gitCwd = resolvedCwd;
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("-C") && token.length > 2) {
+      const resolvedCwd = resolveGitCwd(gitCwd, token.slice(2));
+      if (!resolvedCwd) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      gitCwd = resolvedCwd;
+      i++;
+      continue;
+    }
+    if (token === "--git-dir" || token === "--work-tree") {
+      hasExplicitGitContext = true;
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("--git-dir=") || token.startsWith("--work-tree=")) {
+      hasExplicitGitContext = true;
+      i++;
+      continue;
+    }
+    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(token)) {
+      i += 2;
+    } else if (token.startsWith("-c") && token.length > 2) {
+      i++;
+    } else {
+      i++;
+    }
+  }
+  return { gitCwd, hasExplicitGitContext };
+}
+function isLinkedWorktree(cwd) {
+  const dotGitPath = findDotGit(cwd);
+  if (!dotGitPath) {
+    return false;
+  }
+  try {
+    const stat = statSync(dotGitPath);
+    if (!stat.isFile()) {
+      return false;
+    }
+    const content = readFileSync4(dotGitPath, "utf-8");
+    const firstLine = content.split(/\r?\n/, 1)[0]?.trim() ?? "";
+    if (!firstLine.startsWith("gitdir:")) {
+      return false;
+    }
+    const rawGitDir = firstLine.slice("gitdir:".length).trim();
+    if (rawGitDir === "") {
+      return false;
+    }
+    const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve2(dirname(dotGitPath), rawGitDir);
+    return existsSync4(join3(gitDir, "commondir"));
+  } catch {
+    return false;
+  }
+}
+function resolveGitCwd(baseCwd, target) {
+  const resolved = isAbsolute(target) ? target : resolve2(baseCwd, target);
+  return isDirectory(resolved) ? resolved : null;
+}
+function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+function findDotGit(cwd) {
+  let current;
+  try {
+    current = realpathSync(cwd);
+  } catch {
+    return null;
+  }
+  while (true) {
+    const dotGitPath = join3(current, ".git");
+    if (existsSync4(dotGitPath)) {
+      return dotGitPath;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
 // src/core/rules-git.ts
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
@@ -2544,15 +2688,6 @@ var REASON_BRANCH_DELETE = "git branch -D force-deletes without merge check. Use
 var REASON_STASH_DROP = "git stash drop permanently deletes stashed changes. Consider 'git stash list' first.";
 var REASON_STASH_CLEAR = "git stash clear deletes ALL stashed changes permanently.";
 var REASON_WORKTREE_REMOVE_FORCE = "git worktree remove --force can delete uncommitted changes. Remove --force flag.";
-var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
-  "-c",
-  "-C",
-  "--git-dir",
-  "--work-tree",
-  "--namespace",
-  "--super-prefix",
-  "--config-env"
-]);
 var CHECKOUT_OPTS_WITH_VALUE = new Set([
   "-b",
   "-B",
@@ -2611,33 +2746,72 @@ function splitAtDoubleDash(tokens) {
     after: tokens.slice(index + 1)
   };
 }
-function analyzeGit(tokens) {
+function analyzeGit(tokens, options = {}) {
+  const match = analyzeGitRule(tokens);
+  if (!match) {
+    return null;
+  }
+  if (getGitWorktreeRelaxationForMatch(tokens, match, options)) {
+    return null;
+  }
+  return match.reason;
+}
+function getGitWorktreeRelaxation(tokens, options = {}) {
+  const match = analyzeGitRule(tokens);
+  if (!match) {
+    return null;
+  }
+  return getGitWorktreeRelaxationForMatch(tokens, match, options);
+}
+function analyzeGitRule(tokens) {
   const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
   if (!subcommand) {
     return null;
   }
   switch (subcommand.toLowerCase()) {
     case "checkout":
-      return analyzeGitCheckout(rest);
+      return localDiscard(analyzeGitCheckout(rest));
     case "switch":
-      return analyzeGitSwitch(rest);
+      return localDiscard(analyzeGitSwitch(rest));
     case "restore":
-      return analyzeGitRestore(rest);
+      return localDiscard(analyzeGitRestore(rest));
     case "reset":
-      return analyzeGitReset(rest);
+      return localDiscard(analyzeGitReset(rest));
     case "clean":
-      return analyzeGitClean(rest);
+      return localDiscard(analyzeGitClean(rest));
     case "push":
-      return analyzeGitPush(rest);
+      return sharedState(analyzeGitPush(rest));
     case "branch":
-      return analyzeGitBranch(rest);
+      return sharedState(analyzeGitBranch(rest));
     case "stash":
-      return analyzeGitStash(rest);
+      return sharedState(analyzeGitStash(rest));
     case "worktree":
-      return analyzeGitWorktree(rest);
+      return sharedState(analyzeGitWorktree(rest));
     default:
       return null;
   }
+}
+function localDiscard(reason) {
+  return reason ? { reason, localDiscard: true } : null;
+}
+function sharedState(reason) {
+  return reason ? { reason, localDiscard: false } : null;
+}
+function getGitWorktreeRelaxationForMatch(tokens, match, options) {
+  if (!match.localDiscard || !options.worktreeMode || hasGitContextEnvOverride(options.envAssignments)) {
+    return null;
+  }
+  const context = getGitExecutionContext(tokens, options.cwd);
+  if (!context.gitCwd || context.hasExplicitGitContext) {
+    return null;
+  }
+  if (!isLinkedWorktree(context.gitCwd)) {
+    return null;
+  }
+  return {
+    originalReason: match.reason,
+    gitCwd: context.gitCwd
+  };
 }
 function extractGitSubcommandAndRest(tokens) {
   if (tokens.length === 0) {
@@ -2844,9 +3018,9 @@ function analyzeGitWorktree(tokens) {
 }
 
 // src/core/rules-rm.ts
-import { realpathSync } from "node:fs";
+import { realpathSync as realpathSync2 } from "node:fs";
 import { homedir as homedir3, tmpdir } from "node:os";
-import { normalize, resolve as resolve2, sep } from "node:path";
+import { normalize, resolve as resolve3, sep } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison(p) {
   let normalized = normalize(p);
@@ -3018,13 +3192,13 @@ function isCwdSelfTarget(target, cwd) {
     return true;
   }
   try {
-    const resolved = resolve2(cwd, target);
-    const realCwd = realpathSync(cwd);
-    const realResolved = realpathSync(resolved);
+    const resolved = resolve3(cwd, target);
+    const realCwd = realpathSync2(cwd);
+    const realResolved = realpathSync2(resolved);
     return normalizePathForComparison(realResolved) === normalizePathForComparison(realCwd);
   } catch {
     try {
-      const resolved = resolve2(cwd, target);
+      const resolved = resolve3(cwd, target);
       return normalizePathForComparison(resolved) === normalizePathForComparison(cwd);
     } catch {
       return false;
@@ -3050,7 +3224,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   if (target.startsWith("./") || target.startsWith(".\\") || !target.includes("/") && !target.includes("\\")) {
     try {
-      const resolved = resolve2(resolveCwd, target);
+      const resolved = resolve3(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison(resolved);
       const normalizedOriginalCwd = normalizePathForComparison(originalCwd);
       return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep}`) || normalizedResolved === normalizedOriginalCwd;
@@ -3062,7 +3236,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     return false;
   }
   try {
-    const resolved = resolve2(resolveCwd, target);
+    const resolved = resolve3(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison(resolved);
     const normalizedCwd = normalizePathForComparison(originalCwd);
     return normalizedResolved.startsWith(`${normalizedCwd}${sep}`) || normalizedResolved === normalizedCwd;
@@ -3173,7 +3347,11 @@ function analyzeParallel(tokens, context) {
     }
   }
   if (head === "git") {
-    const gitResult = analyzeGit(childTokens);
+    const gitResult = analyzeGit(childTokens, {
+      cwd: context.cwd,
+      envAssignments: context.envAssignments,
+      worktreeMode: context.worktreeMode
+    });
     if (gitResult) {
       return gitResult;
     }
@@ -3330,7 +3508,11 @@ function analyzeXargs(tokens, context) {
     }
   }
   if (head === "git") {
-    const gitResult = analyzeGit(childTokens);
+    const gitResult = analyzeGit(childTokens, {
+      cwd: context.cwd,
+      envAssignments: context.envAssignments,
+      worktreeMode: context.worktreeMode
+    });
     if (gitResult) {
       return gitResult;
     }
@@ -3547,7 +3729,11 @@ function analyzeSegment(tokens, depth, options) {
   const isXargs = basename === "xargs";
   const isParallel = basename === "parallel";
   if (isGit) {
-    const gitResult = analyzeGit(stripped);
+    const gitResult = analyzeGit(stripped, {
+      cwd: cwdForRm,
+      envAssignments,
+      worktreeMode: options.worktreeMode
+    });
     if (gitResult) {
       return gitResult;
     }
@@ -3574,7 +3760,9 @@ function analyzeSegment(tokens, depth, options) {
       cwd: cwdForRm,
       originalCwd,
       paranoidRm: options.paranoidRm,
-      allowTmpdirVar
+      allowTmpdirVar,
+      envAssignments,
+      worktreeMode: options.worktreeMode
     });
     if (xargsResult) {
       return xargsResult;
@@ -3586,6 +3774,8 @@ function analyzeSegment(tokens, depth, options) {
       originalCwd,
       paranoidRm: options.paranoidRm,
       allowTmpdirVar,
+      envAssignments,
+      worktreeMode: options.worktreeMode,
       analyzeNested: options.analyzeNested
     });
     if (parallelResult) {
@@ -3614,7 +3804,11 @@ function analyzeSegment(tokens, depth, options) {
         }
         if (cmd === "git") {
           const gitTokens = ["git", ...stripped.slice(i + 1)];
-          const reason = analyzeGit(gitTokens);
+          const reason = analyzeGit(gitTokens, {
+            cwd: cwdForRm,
+            envAssignments,
+            worktreeMode: options.worktreeMode
+          });
           if (reason) {
             return reason;
           }
@@ -3726,7 +3920,7 @@ var SELF_TEST_CASES = [
 ];
 var SELF_TEST_CONFIG = { version: 1, rules: [] };
 function runSelfTest() {
-  const selfTestCwd = join3(tmpdir3(), "cc-safety-net-self-test");
+  const selfTestCwd = join4(tmpdir3(), "cc-safety-net-self-test");
   const results = SELF_TEST_CASES.map((tc) => {
     const result = analyzeCommand(tc.command, {
       cwd: selfTestCwd,
@@ -3836,11 +4030,11 @@ function stripJsonComments(content) {
 }
 function detectClaudeCode(homeDir) {
   const errors = [];
-  const settingsPath = join3(homeDir, ".claude", "settings.json");
+  const settingsPath = join4(homeDir, ".claude", "settings.json");
   const pluginKey = "safety-net@cc-marketplace";
-  if (existsSync4(settingsPath)) {
+  if (existsSync5(settingsPath)) {
     try {
-      const settings = JSON.parse(readFileSync4(settingsPath, "utf-8"));
+      const settings = JSON.parse(readFileSync5(settingsPath, "utf-8"));
       const pluginValue = settings.enabledPlugins?.[pluginKey];
       if (pluginValue === true) {
         return {
@@ -3871,13 +4065,13 @@ function detectClaudeCode(homeDir) {
 }
 function detectOpenCode(homeDir) {
   const errors = [];
-  const configDir = join3(homeDir, ".config", "opencode");
+  const configDir = join4(homeDir, ".config", "opencode");
   const candidates = ["opencode.json", "opencode.jsonc"];
   for (const filename of candidates) {
-    const configPath = join3(configDir, filename);
-    if (existsSync4(configPath)) {
+    const configPath = join4(configDir, filename);
+    if (existsSync5(configPath)) {
       try {
-        const content = readFileSync4(configPath, "utf-8");
+        const content = readFileSync5(configPath, "utf-8");
         const json = stripJsonComments(content);
         const config = JSON.parse(json);
         const plugins = config.plugin ?? [];
@@ -3905,13 +4099,13 @@ function detectOpenCode(homeDir) {
 }
 function checkGeminiHooksEnabled(homeDir, cwd, errors) {
   const candidates = [
-    join3(homeDir, ".gemini", "settings.json"),
-    join3(cwd, ".gemini", "settings.json")
+    join4(homeDir, ".gemini", "settings.json"),
+    join4(cwd, ".gemini", "settings.json")
   ];
   for (const settingsPath of candidates) {
-    if (existsSync4(settingsPath)) {
+    if (existsSync5(settingsPath)) {
       try {
-        const settings = JSON.parse(readFileSync4(settingsPath, "utf-8"));
+        const settings = JSON.parse(readFileSync5(settingsPath, "utf-8"));
         if (settings.tools?.enableHooks === true) {
           return { enabled: true, configPath: settingsPath };
         }
@@ -3924,14 +4118,14 @@ function checkGeminiHooksEnabled(homeDir, cwd, errors) {
 }
 function detectGeminiCLI(homeDir, cwd) {
   const errors = [];
-  const extensionPath = join3(homeDir, ".gemini", "extensions", "extension-enablement.json");
-  if (!existsSync4(extensionPath)) {
+  const extensionPath = join4(homeDir, ".gemini", "extensions", "extension-enablement.json");
+  if (!existsSync5(extensionPath)) {
     return { platform: "gemini-cli", status: "n/a" };
   }
   let isInstalled = false;
   let isEnabled = false;
   try {
-    const extensionConfig = JSON.parse(readFileSync4(extensionPath, "utf-8"));
+    const extensionConfig = JSON.parse(readFileSync5(extensionPath, "utf-8"));
     const pluginConfig = extensionConfig["gemini-safety-net"];
     if (pluginConfig) {
       isInstalled = true;
@@ -4018,7 +4212,7 @@ function _supportsCopilotInlineHooks(version) {
   return comparison >= 0;
 }
 function _getCopilotConfigHome(homeDir) {
-  return process.env.COPILOT_HOME || join3(homeDir, ".copilot");
+  return process.env.COPILOT_HOME || join4(homeDir, ".copilot");
 }
 function _hasSafetyNetCopilotHook(config) {
   const preToolUseHooks = config.hooks?.preToolUse ?? [];
@@ -4030,7 +4224,7 @@ function _hasSafetyNetCopilotHook(config) {
 }
 function _readCopilotConfigFile(configPath, errors) {
   try {
-    return JSON.parse(readFileSync4(configPath, "utf-8"));
+    return JSON.parse(readFileSync5(configPath, "utf-8"));
   } catch (e) {
     errors?.push(`Failed to parse ${configPath}: ${e instanceof Error ? e.message : String(e)}`);
     return;
@@ -4045,11 +4239,11 @@ function _listJsonFiles(dirPath, errors) {
   }
 }
 function _collectSafetyNetCopilotHookFiles(dirPath, errors) {
-  if (!existsSync4(dirPath))
+  if (!existsSync5(dirPath))
     return [];
   const matches = [];
   for (const filename of _listJsonFiles(dirPath, errors)) {
-    const configPath = join3(dirPath, filename);
+    const configPath = join4(dirPath, filename);
     const config = _readCopilotConfigFile(configPath, errors);
     if (config && _hasSafetyNetCopilotHook(config)) {
       matches.push(configPath);
@@ -4058,7 +4252,7 @@ function _collectSafetyNetCopilotHookFiles(dirPath, errors) {
   return matches;
 }
 function _collectCopilotInlineConfig(configPath, errors) {
-  if (!existsSync4(configPath))
+  if (!existsSync5(configPath))
     return;
   const config = _readCopilotConfigFile(configPath, errors);
   if (!config)
@@ -4088,15 +4282,15 @@ function _resolveCopilotInlineDisableSource(inlineSources) {
 }
 function _checkCopilotEnabled(homeDir, cwd, copilotCliVersion, errors) {
   const configHome = _getCopilotConfigHome(homeDir);
-  const repoHookDir = join3(cwd, ".github", "hooks");
-  const userHookDir = join3(configHome, "hooks");
-  const repoConfigDir = join3(cwd, ".github", "copilot");
+  const repoHookDir = join4(cwd, ".github", "hooks");
+  const userHookDir = join4(configHome, "hooks");
+  const repoConfigDir = join4(cwd, ".github", "copilot");
   const inlineSupport = _supportsCopilotInlineHooks(copilotCliVersion);
   const inlineErrors = inlineSupport === true ? errors : undefined;
   const inlineSources = {
-    userConfig: _collectCopilotInlineConfig(join3(configHome, "config.json"), inlineErrors),
-    repoSettings: _collectCopilotInlineConfig(join3(repoConfigDir, "settings.json"), inlineErrors),
-    localSettings: _collectCopilotInlineConfig(join3(repoConfigDir, "settings.local.json"), inlineErrors)
+    userConfig: _collectCopilotInlineConfig(join4(configHome, "config.json"), inlineErrors),
+    repoSettings: _collectCopilotInlineConfig(join4(repoConfigDir, "settings.json"), inlineErrors),
+    localSettings: _collectCopilotInlineConfig(join4(repoConfigDir, "settings.local.json"), inlineErrors)
   };
   if (inlineSupport !== false) {
     const disableSource = _resolveCopilotInlineDisableSource(inlineSources);
@@ -4110,10 +4304,10 @@ function _checkCopilotEnabled(homeDir, cwd, copilotCliVersion, errors) {
   const repoHookPaths = _collectSafetyNetCopilotHookFiles(repoHookDir, errors);
   const userHookSupport = _supportsCopilotUserHookFiles(copilotCliVersion);
   const userHookErrors = userHookSupport === true ? errors : undefined;
-  const userHookFiles = existsSync4(userHookDir) ? _listJsonFiles(userHookDir, userHookErrors) : [];
+  const userHookFiles = existsSync5(userHookDir) ? _listJsonFiles(userHookDir, userHookErrors) : [];
   const userHookPaths = [];
   for (const filename of userHookFiles) {
-    const configPath = join3(userHookDir, filename);
+    const configPath = join4(userHookDir, filename);
     const config = _readCopilotConfigFile(configPath, userHookErrors);
     if (config && _hasSafetyNetCopilotHook(config)) {
       userHookPaths.push(configPath);
@@ -4205,7 +4399,7 @@ var defaultVersionFetcher = async (args) => {
   const [cmd, ...rest] = args;
   if (!cmd)
     return null;
-  return new Promise((resolve3) => {
+  return new Promise((resolve4) => {
     try {
       const proc = spawn(cmd, rest, {
         stdio: ["ignore", "pipe", "pipe"]
@@ -4221,7 +4415,7 @@ var defaultVersionFetcher = async (args) => {
           return;
         isSettled = true;
         clearTimeout(timeoutId);
-        resolve3(value);
+        resolve4(value);
       };
       const timeoutId = setTimeout(() => {
         proc.kill();
@@ -4234,7 +4428,7 @@ var defaultVersionFetcher = async (args) => {
         finish(null);
       });
     } catch {
-      resolve3(null);
+      resolve4(null);
     }
   });
 };
@@ -4400,8 +4594,8 @@ function printReport(report) {
 }
 
 // src/bin/explain/config.ts
-import { existsSync as existsSync5 } from "node:fs";
-import { resolve as resolve3 } from "node:path";
+import { existsSync as existsSync6 } from "node:fs";
+import { resolve as resolve4 } from "node:path";
 
 // src/core/env.ts
 function envTruthy(name) {
@@ -4413,7 +4607,7 @@ function envTruthy(name) {
 function getConfigSource(options) {
   const projectPath = getProjectConfigPath(options?.cwd);
   let invalidProjectPath = null;
-  if (existsSync5(projectPath)) {
+  if (existsSync6(projectPath)) {
     const validation = validateConfigFile(projectPath);
     if (validation.errors.length === 0) {
       return { configSource: projectPath, configValid: true };
@@ -4421,7 +4615,7 @@ function getConfigSource(options) {
     invalidProjectPath = projectPath;
   }
   const userPath = options?.userConfigPath ?? getUserConfigPath();
-  if (existsSync5(userPath)) {
+  if (existsSync6(userPath)) {
     const validation = validateConfigFile(userPath);
     return { configSource: userPath, configValid: validation.errors.length === 0 };
   }
@@ -4431,7 +4625,7 @@ function getConfigSource(options) {
   return { configSource: null, configValid: true };
 }
 function buildAnalyzeOptions(explainOptions) {
-  const cwd = resolve3(explainOptions?.cwd ?? process.cwd());
+  const cwd = resolve4(explainOptions?.cwd ?? process.cwd());
   const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
   return {
     cwd,
@@ -4439,7 +4633,8 @@ function buildAnalyzeOptions(explainOptions) {
     config: explainOptions?.config ?? loadConfig(cwd),
     strict: explainOptions?.strict ?? envTruthy("SAFETY_NET_STRICT"),
     paranoidRm: paranoidAll || envTruthy("SAFETY_NET_PARANOID_RM"),
-    paranoidInterpreters: paranoidAll || envTruthy("SAFETY_NET_PARANOID_INTERPRETERS")
+    paranoidInterpreters: paranoidAll || envTruthy("SAFETY_NET_PARANOID_INTERPRETERS"),
+    worktreeMode: envTruthy("SAFETY_NET_WORKTREE")
   };
 }
 
@@ -4657,14 +4852,27 @@ function explainSegment(tokens, depth, options, steps) {
     });
   }
   if (isGit) {
-    const reason = analyzeGit(strippedTokens);
+    const gitOptions = {
+      cwd: cwdForRm,
+      envAssignments,
+      worktreeMode: options.worktreeMode
+    };
+    const relaxation = getGitWorktreeRelaxation(strippedTokens, gitOptions);
+    const reason = analyzeGit(strippedTokens, gitOptions);
     steps.push({
       type: "rule-check",
       ruleModule: "rules-git.ts",
       ruleFunction: "analyzeGit",
-      matched: !!reason,
-      reason: reason ?? undefined
+      matched: !!reason || !!relaxation,
+      reason: reason ?? relaxation?.originalReason
     });
+    if (relaxation) {
+      steps.push({
+        type: "worktree-relaxation",
+        originalReason: relaxation.originalReason,
+        gitCwd: relaxation.gitCwd
+      });
+    }
     if (reason)
       return { reason };
   }
@@ -4702,7 +4910,9 @@ function explainSegment(tokens, depth, options, steps) {
       cwd: cwdForRm,
       originalCwd,
       paranoidRm: options.paranoidRm,
-      allowTmpdirVar
+      allowTmpdirVar,
+      envAssignments,
+      worktreeMode: options.worktreeMode
     });
     steps.push({
       type: "rule-check",
@@ -4724,6 +4934,8 @@ function explainSegment(tokens, depth, options, steps) {
       originalCwd,
       paranoidRm: options.paranoidRm,
       allowTmpdirVar,
+      envAssignments,
+      worktreeMode: options.worktreeMode,
       analyzeNested
     });
     steps.push({
@@ -4739,6 +4951,7 @@ function explainSegment(tokens, depth, options, steps) {
   const matchedKnown = isGit || isRm || isFind || isXargs || isParallel;
   const tokensScanned = [];
   let fallbackReason = null;
+  let fallbackRelaxation = null;
   let embeddedCommandFound;
   if (!matchedKnown && !DISPLAY_COMMANDS.has(normalizeCommandToken(head))) {
     for (let i = 1;i < strippedTokens.length && !fallbackReason; i++) {
@@ -4760,7 +4973,13 @@ function explainSegment(tokens, depth, options, steps) {
       if (!fallbackReason && cmd === "git") {
         embeddedCommandFound = "git";
         const gitTokens = ["git", ...strippedTokens.slice(i + 1)];
-        fallbackReason = analyzeGit(gitTokens);
+        const gitOptions = {
+          cwd: cwdForRm,
+          envAssignments,
+          worktreeMode: options.worktreeMode
+        };
+        fallbackRelaxation = getGitWorktreeRelaxation(gitTokens, gitOptions);
+        fallbackReason = analyzeGit(gitTokens, gitOptions);
       }
       if (!fallbackReason && cmd === "find") {
         embeddedCommandFound = "find";
@@ -4774,6 +4993,13 @@ function explainSegment(tokens, depth, options, steps) {
     tokensScanned,
     embeddedCommandFound
   });
+  if (fallbackRelaxation) {
+    steps.push({
+      type: "worktree-relaxation",
+      originalReason: fallbackRelaxation.originalReason,
+      gitCwd: fallbackRelaxation.gitCwd
+    });
+  }
   if (fallbackReason)
     return { reason: fallbackReason };
   const shouldCheckCustomRules = depth === 0 || !matchedKnown;
@@ -5077,6 +5303,14 @@ function formatStepStyleD(step, stepNum, box) {
       }
       return { lines, incrementStep: true };
     }
+    case "worktree-relaxation": {
+      lines.push("");
+      lines.push(`STEP ${stepNum} ${box.h} Worktree relaxation`);
+      lines.push(`  Mode:   SAFETY_NET_WORKTREE`);
+      lines.push(`  Git cwd: ${step.gitCwd}`);
+      lines.push(`  Result: Allowed local discard in linked worktree`);
+      return { lines, incrementStep: true };
+    }
     case "tmpdir-check":
       return null;
     case "fallback-scan": {
@@ -5334,6 +5568,7 @@ function printHelp() {
   lines.push(`${INDENT}SAFETY_NET_PARANOID=1             Enable all paranoid checks`);
   lines.push(`${INDENT}SAFETY_NET_PARANOID_RM=1          Block non-temp rm -rf within cwd`);
   lines.push(`${INDENT}SAFETY_NET_PARANOID_INTERPRETERS=1  Block interpreter one-liners`);
+  lines.push(`${INDENT}SAFETY_NET_WORKTREE=1             Allow local git discards in linked worktrees`);
   lines.push("");
   lines.push("CONFIG FILES:");
   lines.push(`${INDENT}~/.cc-safety-net/config.json      User-scope config`);
@@ -5354,9 +5589,9 @@ function showCommandHelp(commandName) {
 }
 
 // src/core/audit.ts
-import { appendFileSync, existsSync as existsSync6, mkdirSync } from "node:fs";
+import { appendFileSync, existsSync as existsSync7, mkdirSync } from "node:fs";
 import { homedir as homedir5 } from "node:os";
-import { join as join4 } from "node:path";
+import { join as join5 } from "node:path";
 function sanitizeSessionIdForFilename(sessionId) {
   const raw = sessionId.trim();
   if (!raw) {
@@ -5375,12 +5610,12 @@ function writeAuditLog(sessionId, command, segment, reason, cwd, options = {}) {
     return;
   }
   const home = options.homeDir ?? homedir5();
-  const logsDir = join4(home, ".cc-safety-net", "logs");
+  const logsDir = join5(home, ".cc-safety-net", "logs");
   try {
-    if (!existsSync6(logsDir)) {
+    if (!existsSync7(logsDir)) {
       mkdirSync(logsDir, { recursive: true });
     }
-    const logFile = join4(logsDir, `${safeSessionId}.jsonl`);
+    const logFile = join5(logsDir, `${safeSessionId}.jsonl`);
     const entry = {
       ts: new Date().toISOString(),
       command: redactSecrets(command).slice(0, 300),
@@ -5478,13 +5713,15 @@ async function runClaudeCodeHook() {
   const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
   const paranoidRm = paranoidAll || envTruthy("SAFETY_NET_PARANOID_RM");
   const paranoidInterpreters = paranoidAll || envTruthy("SAFETY_NET_PARANOID_INTERPRETERS");
+  const worktreeMode = envTruthy("SAFETY_NET_WORKTREE");
   const config = loadConfig(cwd);
   const result = analyzeCommand(command, {
     cwd,
     config,
     strict,
     paranoidRm,
-    paranoidInterpreters
+    paranoidInterpreters,
+    worktreeMode
   });
   if (result) {
     const sessionId = input.session_id;
@@ -5548,13 +5785,15 @@ async function runCopilotCliHook() {
   const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
   const paranoidRm = paranoidAll || envTruthy("SAFETY_NET_PARANOID_RM");
   const paranoidInterpreters = paranoidAll || envTruthy("SAFETY_NET_PARANOID_INTERPRETERS");
+  const worktreeMode = envTruthy("SAFETY_NET_WORKTREE");
   const config = loadConfig(cwd);
   const result = analyzeCommand(command, {
     cwd,
     config,
     strict,
     paranoidRm,
-    paranoidInterpreters
+    paranoidInterpreters,
+    worktreeMode
   });
   if (result) {
     const sessionId = `copilot-${input.timestamp ?? Date.now()}`;
@@ -5611,13 +5850,15 @@ async function runGeminiCLIHook() {
   const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
   const paranoidRm = paranoidAll || envTruthy("SAFETY_NET_PARANOID_RM");
   const paranoidInterpreters = paranoidAll || envTruthy("SAFETY_NET_PARANOID_INTERPRETERS");
+  const worktreeMode = envTruthy("SAFETY_NET_WORKTREE");
   const config = loadConfig(cwd);
   const result = analyzeCommand(command, {
     cwd,
     config,
     strict,
     paranoidRm,
-    paranoidInterpreters
+    paranoidInterpreters,
+    worktreeMode
   });
   if (result) {
     const sessionId = input.session_id;
@@ -5629,14 +5870,14 @@ async function runGeminiCLIHook() {
 }
 
 // src/bin/statusline.ts
-import { existsSync as existsSync7, readFileSync as readFileSync5 } from "node:fs";
+import { existsSync as existsSync8, readFileSync as readFileSync6 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { join as join5 } from "node:path";
+import { join as join6 } from "node:path";
 async function readStdinAsync() {
   if (process.stdin.isTTY) {
     return null;
   }
-  return new Promise((resolve4) => {
+  return new Promise((resolve5) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => {
@@ -5644,10 +5885,10 @@ async function readStdinAsync() {
     });
     process.stdin.on("end", () => {
       const trimmed = data.trim();
-      resolve4(trimmed || null);
+      resolve5(trimmed || null);
     });
     process.stdin.on("error", () => {
-      resolve4(null);
+      resolve5(null);
     });
   });
 }
@@ -5655,15 +5896,15 @@ function getSettingsPath() {
   if (process.env.CLAUDE_SETTINGS_PATH) {
     return process.env.CLAUDE_SETTINGS_PATH;
   }
-  return join5(homedir6(), ".claude", "settings.json");
+  return join6(homedir6(), ".claude", "settings.json");
 }
 function isPluginEnabled() {
   const settingsPath = getSettingsPath();
-  if (!existsSync7(settingsPath)) {
+  if (!existsSync8(settingsPath)) {
     return false;
   }
   try {
-    const content = readFileSync5(settingsPath, "utf-8");
+    const content = readFileSync6(settingsPath, "utf-8");
     const settings = JSON.parse(content);
     if (!settings.enabledPlugins) {
       return false;
@@ -5687,6 +5928,7 @@ async function printStatusline() {
     const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
     const paranoidRm = paranoidAll || envTruthy("SAFETY_NET_PARANOID_RM");
     const paranoidInterpreters = paranoidAll || envTruthy("SAFETY_NET_PARANOID_INTERPRETERS");
+    const worktreeMode = envTruthy("SAFETY_NET_WORKTREE");
     let modeEmojis = "";
     if (strict) {
       modeEmojis += "\uD83D\uDD12";
@@ -5697,6 +5939,9 @@ async function printStatusline() {
       modeEmojis += "\uD83D\uDDD1️";
     } else if (paranoidInterpreters) {
       modeEmojis += "\uD83D\uDC1A";
+    }
+    if (worktreeMode) {
+      modeEmojis += "\uD83C\uDF33";
     }
     const statusEmoji = modeEmojis || "✅";
     status = `\uD83D\uDEE1️ Safety Net ${statusEmoji}`;
@@ -5710,8 +5955,8 @@ async function printStatusline() {
 }
 
 // src/bin/verify-config.ts
-import { existsSync as existsSync8, readFileSync as readFileSync6, writeFileSync } from "node:fs";
-import { resolve as resolve4 } from "node:path";
+import { existsSync as existsSync9, readFileSync as readFileSync7, writeFileSync } from "node:fs";
+import { resolve as resolve5 } from "node:path";
 var HEADER = "Safety Net Config";
 var SEPARATOR = "═".repeat(HEADER.length);
 var SCHEMA_URL = "https://raw.githubusercontent.com/kenryu42/claude-code-safety-net/main/assets/cc-safety-net.schema.json";
@@ -5747,7 +5992,7 @@ function printInvalidConfig(scope, path, errors) {
 }
 function addSchemaIfMissing(path) {
   try {
-    const content = readFileSync6(path, "utf-8");
+    const content = readFileSync7(path, "utf-8");
     const parsed = JSON.parse(content);
     if (parsed.$schema) {
       return false;
@@ -5765,18 +6010,18 @@ function verifyConfig(options = {}) {
   let hasErrors = false;
   const configsChecked = [];
   printHeader();
-  if (existsSync8(userConfig)) {
+  if (existsSync9(userConfig)) {
     const result = validateConfigFile(userConfig);
     configsChecked.push({ scope: "User", path: userConfig, result });
     if (result.errors.length > 0) {
       hasErrors = true;
     }
   }
-  if (existsSync8(projectConfig)) {
+  if (existsSync9(projectConfig)) {
     const result = validateConfigFile(projectConfig);
     configsChecked.push({
       scope: "Project",
-      path: resolve4(projectConfig),
+      path: resolve5(projectConfig),
       result
     });
     if (result.errors.length > 0) {

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -1569,11 +1569,198 @@ function hasRecursiveForceFlags(tokens) {
 }
 
 // src/core/shell.ts
-import { isAbsolute, resolve as resolve2 } from "node:path";
+import { isAbsolute as isAbsolute2, resolve as resolve3 } from "node:path";
 
 // node_modules/shell-quote/index.js
 var $quote = require_quote();
 var $parse = require_parse();
+
+// src/core/worktree.ts
+import { existsSync as existsSync4, readFileSync as readFileSync4, realpathSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join as join3, resolve as resolve2 } from "node:path";
+var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
+  "-c",
+  "-C",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--super-prefix",
+  "--config-env"
+]);
+var GIT_CONTEXT_ENV_OVERRIDES = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"];
+function hasGitContextEnvOverride(envAssignments) {
+  for (const name of GIT_CONTEXT_ENV_OVERRIDES) {
+    if (envAssignments?.has(name) || Object.hasOwn(process.env, name)) {
+      return true;
+    }
+  }
+  return false;
+}
+function getGitExecutionContext(tokens, cwd) {
+  if (!cwd) {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
+  let gitCwd = resolve2(cwd);
+  if (!isDirectory(gitCwd)) {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
+  let hasExplicitGitContext = false;
+  let i = 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token)
+      break;
+    if (token === "--") {
+      break;
+    }
+    if (!token.startsWith("-")) {
+      break;
+    }
+    if (token === "-C") {
+      const target = tokens[i + 1];
+      if (!target) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      const resolvedCwd = resolveGitCwd(gitCwd, target);
+      if (!resolvedCwd) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      gitCwd = resolvedCwd;
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("-C") && token.length > 2) {
+      const resolvedCwd = resolveGitCwd(gitCwd, token.slice(2));
+      if (!resolvedCwd) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      gitCwd = resolvedCwd;
+      i++;
+      continue;
+    }
+    if (token === "--git-dir" || token === "--work-tree") {
+      hasExplicitGitContext = true;
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("--git-dir=") || token.startsWith("--work-tree=")) {
+      hasExplicitGitContext = true;
+      i++;
+      continue;
+    }
+    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(token)) {
+      i += 2;
+    } else if (token.startsWith("-c") && token.length > 2) {
+      i++;
+    } else {
+      i++;
+    }
+  }
+  return { gitCwd, hasExplicitGitContext };
+}
+function isLinkedWorktree(cwd) {
+  const dotGitPath = findDotGit(cwd);
+  if (!dotGitPath) {
+    return false;
+  }
+  try {
+    const stat = statSync(dotGitPath);
+    if (!stat.isFile()) {
+      return false;
+    }
+    const content = readFileSync4(dotGitPath, "utf-8");
+    const firstLine = content.split(/\r?\n/, 1)[0]?.trim() ?? "";
+    if (!firstLine.startsWith("gitdir:")) {
+      return false;
+    }
+    const rawGitDir = firstLine.slice("gitdir:".length).trim();
+    if (rawGitDir === "") {
+      return false;
+    }
+    const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve2(dirname(dotGitPath), rawGitDir);
+    if (!existsSync4(join3(gitDir, "commondir"))) {
+      return false;
+    }
+    return worktreeConfigMatchesRoot(gitDir, dirname(dotGitPath));
+  } catch {
+    return false;
+  }
+}
+function worktreeConfigMatchesRoot(gitDir, worktreeRoot) {
+  const configWorktreePath = join3(gitDir, "config.worktree");
+  if (!existsSync4(configWorktreePath)) {
+    return true;
+  }
+  const configuredWorktree = readCoreWorktree(configWorktreePath);
+  if (configuredWorktree === null) {
+    return true;
+  }
+  const resolvedConfiguredWorktree = isAbsolute(configuredWorktree) ? configuredWorktree : resolve2(gitDir, configuredWorktree);
+  try {
+    return realpathSync(resolvedConfiguredWorktree) === realpathSync(worktreeRoot);
+  } catch {
+    return false;
+  }
+}
+function readCoreWorktree(configPath) {
+  const content = readFileSync4(configPath, "utf-8");
+  let inCore = false;
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith(";")) {
+      continue;
+    }
+    if (trimmed.startsWith("[")) {
+      inCore = /^\[core\]$/i.test(trimmed);
+      continue;
+    }
+    if (!inCore) {
+      continue;
+    }
+    const match = trimmed.match(/^worktree\s*=\s*(.*)$/i);
+    if (match) {
+      return unquoteGitConfigValue(match[1] ?? "");
+    }
+  }
+  return null;
+}
+function unquoteGitConfigValue(value) {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') || trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+function resolveGitCwd(baseCwd, target) {
+  const resolved = isAbsolute(target) ? target : resolve2(baseCwd, target);
+  return isDirectory(resolved) ? resolved : null;
+}
+function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+function findDotGit(cwd) {
+  let current;
+  try {
+    current = realpathSync(cwd);
+  } catch {
+    return null;
+  }
+  while (true) {
+    const dotGitPath = join3(current, ".git");
+    if (existsSync4(dotGitPath)) {
+      return dotGitPath;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
 
 // src/core/shell.ts
 var ENV_PROXY = new Proxy({}, {
@@ -2040,12 +2227,23 @@ function _stripAttachedIoNumbers(command) {
   return result;
 }
 var ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
+var ENV_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
+var GIT_CONTEXT_ENV_OVERRIDE_NAMES = new Set(GIT_CONTEXT_ENV_OVERRIDES);
 function parseEnvAssignment(token) {
   if (!ENV_ASSIGNMENT_RE.test(token)) {
     return null;
   }
   const eqIdx = token.indexOf("=");
   return { name: token.slice(0, eqIdx), value: token.slice(eqIdx + 1) };
+}
+function parseGitContextAppendEnvAssignment(token) {
+  const match = token.match(ENV_APPEND_ASSIGNMENT_RE);
+  const name = match?.[1];
+  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name)) {
+    return null;
+  }
+  const eqIdx = token.indexOf("=");
+  return { name, value: token.slice(eqIdx + 1) };
 }
 function stripEnvAssignmentsWithInfo(tokens) {
   const envAssignments = new Map;
@@ -2081,6 +2279,10 @@ function stripWrappersWithInfo(tokens, cwd) {
     if (result.length === 0)
       break;
     while (result.length > 0 && result[0]?.includes("=") && !ENV_ASSIGNMENT_RE.test(result[0] ?? "")) {
+      const appendAssignment = parseGitContextAppendEnvAssignment(result[0] ?? "");
+      if (appendAssignment) {
+        allEnvAssignments.set(appendAssignment.name, appendAssignment.value);
+      }
       result = result.slice(1);
     }
     if (result.length === 0)
@@ -2132,10 +2334,15 @@ function stripSudoWithInfo(tokens, cwd) {
     if (!token.startsWith("-")) {
       break;
     }
-    if (token === "-D") {
+    if (token === "-D" || token === "--chdir") {
       const target = tokens[i + 1];
       currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
       i += 2;
+      continue;
+    }
+    if (token.startsWith("--chdir=")) {
+      currentCwd = resolveWrapperCwd(currentCwd, token.slice("--chdir=".length));
+      i++;
       continue;
     }
     if (SUDO_OPTS_WITH_VALUE.has(token)) {
@@ -2269,13 +2476,13 @@ function resolveWrapperCwd(cwd, target) {
   if (target === "") {
     return null;
   }
-  if (isAbsolute(target)) {
-    return resolve2(target);
+  if (isAbsolute2(target)) {
+    return resolve3(target);
   }
   if (!cwd) {
     return null;
   }
-  return resolve2(cwd, target);
+  return resolve3(cwd, target);
 }
 function stripCommand(tokens) {
   let i = 1;
@@ -2627,145 +2834,6 @@ function extractDashCArg(tokens) {
   return null;
 }
 
-// src/core/worktree.ts
-import { existsSync as existsSync4, readFileSync as readFileSync4, realpathSync, statSync } from "node:fs";
-import { dirname, isAbsolute as isAbsolute2, join as join3, resolve as resolve3 } from "node:path";
-var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
-  "-c",
-  "-C",
-  "--git-dir",
-  "--work-tree",
-  "--namespace",
-  "--super-prefix",
-  "--config-env"
-]);
-var GIT_CONTEXT_ENV_OVERRIDES = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"];
-function hasGitContextEnvOverride(envAssignments) {
-  for (const name of GIT_CONTEXT_ENV_OVERRIDES) {
-    if (envAssignments?.has(name) || Object.hasOwn(process.env, name)) {
-      return true;
-    }
-  }
-  return false;
-}
-function getGitExecutionContext(tokens, cwd) {
-  if (!cwd) {
-    return { gitCwd: null, hasExplicitGitContext: false };
-  }
-  let gitCwd = resolve3(cwd);
-  if (!isDirectory(gitCwd)) {
-    return { gitCwd: null, hasExplicitGitContext: false };
-  }
-  let hasExplicitGitContext = false;
-  let i = 1;
-  while (i < tokens.length) {
-    const token = tokens[i];
-    if (!token)
-      break;
-    if (token === "--") {
-      break;
-    }
-    if (!token.startsWith("-")) {
-      break;
-    }
-    if (token === "-C") {
-      const target = tokens[i + 1];
-      if (!target) {
-        return { gitCwd: null, hasExplicitGitContext };
-      }
-      const resolvedCwd = resolveGitCwd(gitCwd, target);
-      if (!resolvedCwd) {
-        return { gitCwd: null, hasExplicitGitContext };
-      }
-      gitCwd = resolvedCwd;
-      i += 2;
-      continue;
-    }
-    if (token.startsWith("-C") && token.length > 2) {
-      const resolvedCwd = resolveGitCwd(gitCwd, token.slice(2));
-      if (!resolvedCwd) {
-        return { gitCwd: null, hasExplicitGitContext };
-      }
-      gitCwd = resolvedCwd;
-      i++;
-      continue;
-    }
-    if (token === "--git-dir" || token === "--work-tree") {
-      hasExplicitGitContext = true;
-      i += 2;
-      continue;
-    }
-    if (token.startsWith("--git-dir=") || token.startsWith("--work-tree=")) {
-      hasExplicitGitContext = true;
-      i++;
-      continue;
-    }
-    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(token)) {
-      i += 2;
-    } else if (token.startsWith("-c") && token.length > 2) {
-      i++;
-    } else {
-      i++;
-    }
-  }
-  return { gitCwd, hasExplicitGitContext };
-}
-function isLinkedWorktree(cwd) {
-  const dotGitPath = findDotGit(cwd);
-  if (!dotGitPath) {
-    return false;
-  }
-  try {
-    const stat = statSync(dotGitPath);
-    if (!stat.isFile()) {
-      return false;
-    }
-    const content = readFileSync4(dotGitPath, "utf-8");
-    const firstLine = content.split(/\r?\n/, 1)[0]?.trim() ?? "";
-    if (!firstLine.startsWith("gitdir:")) {
-      return false;
-    }
-    const rawGitDir = firstLine.slice("gitdir:".length).trim();
-    if (rawGitDir === "") {
-      return false;
-    }
-    const gitDir = isAbsolute2(rawGitDir) ? rawGitDir : resolve3(dirname(dotGitPath), rawGitDir);
-    return existsSync4(join3(gitDir, "commondir"));
-  } catch {
-    return false;
-  }
-}
-function resolveGitCwd(baseCwd, target) {
-  const resolved = isAbsolute2(target) ? target : resolve3(baseCwd, target);
-  return isDirectory(resolved) ? resolved : null;
-}
-function isDirectory(path) {
-  try {
-    return statSync(path).isDirectory();
-  } catch {
-    return false;
-  }
-}
-function findDotGit(cwd) {
-  let current;
-  try {
-    current = realpathSync(cwd);
-  } catch {
-    return null;
-  }
-  while (true) {
-    const dotGitPath = join3(current, ".git");
-    if (existsSync4(dotGitPath)) {
-      return dotGitPath;
-    }
-    const parent = dirname(current);
-    if (parent === current) {
-      return null;
-    }
-    current = parent;
-  }
-}
-
 // src/core/rules-git.ts
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
@@ -2894,7 +2962,7 @@ function sharedState(reason) {
   return reason ? { reason, localDiscard: false } : null;
 }
 function getGitWorktreeRelaxationForMatch(tokens, match, options) {
-  if (!match.localDiscard || !options.worktreeMode || hasGitContextEnvOverride(options.envAssignments)) {
+  if (!match.localDiscard || !options.worktreeMode || hasGitContextEnvOverride(options.envAssignments) || isNonRelaxableLocalDiscard(tokens)) {
     return null;
   }
   const context = getGitExecutionContext(tokens, options.cwd);
@@ -3084,6 +3152,34 @@ function analyzeGitClean(tokens) {
     return REASON_CLEAN;
   }
   return null;
+}
+function isNonRelaxableLocalDiscard(tokens) {
+  const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
+  const normalizedSubcommand = subcommand?.toLowerCase();
+  if (hasRecurseSubmodulesOption(rest)) {
+    return true;
+  }
+  return normalizedSubcommand === "clean" && countCleanForceFlags(rest) > 1;
+}
+function hasRecurseSubmodulesOption(tokens) {
+  return tokens.some((token) => token === "--recurse-submodules" || token.startsWith("--recurse-submodules="));
+}
+function countCleanForceFlags(tokens) {
+  let count = 0;
+  for (const token of tokens) {
+    if (token === "--force") {
+      count++;
+      continue;
+    }
+    if (token.startsWith("-") && !token.startsWith("--")) {
+      for (const opt of token.slice(1)) {
+        if (opt === "f") {
+          count++;
+        }
+      }
+    }
+  }
+  return count;
 }
 function analyzeGitPush(tokens) {
   let hasForceWithLease = false;
@@ -4055,7 +4151,7 @@ function stripLeadingGrouping(tokens) {
 // src/core/analyze/analyze-command.ts
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
-var GIT_CONTEXT_ENV_OVERRIDE_NAMES = new Set(GIT_CONTEXT_ENV_OVERRIDES);
+var GIT_CONTEXT_ENV_OVERRIDE_NAMES2 = new Set(GIT_CONTEXT_ENV_OVERRIDES);
 function analyzeCommandInternal(command, depth, options) {
   if (depth >= MAX_RECURSION_DEPTH) {
     return { reason: REASON_RECURSION_LIMIT, segment: command };
@@ -4067,6 +4163,7 @@ function analyzeCommandInternal(command, depth, options) {
   const originalCwd = options.cwd;
   let effectiveCwd = options.effectiveCwd !== undefined ? options.effectiveCwd : options.cwd;
   let effectiveEnvAssignments = options.envAssignments;
+  const shellGitContextAssignments = new Map;
   for (const segment of segments) {
     const segmentStr = segment.join(" ");
     const segmentEnvAssignments = effectiveEnvAssignments;
@@ -4101,7 +4198,11 @@ function analyzeCommandInternal(command, depth, options) {
     if (segmentChangesCwd(segment)) {
       effectiveCwd = null;
     }
-    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment);
+    const shellAssignments = getShellGitContextEnvAssignments(segment);
+    for (const [k, v] of shellAssignments) {
+      shellGitContextAssignments.set(k, v);
+    }
+    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment, shellGitContextAssignments);
     if (exportedEnvAssignments.size > 0) {
       const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
       for (const [k, v] of exportedEnvAssignments) {
@@ -4112,21 +4213,84 @@ function analyzeCommandInternal(command, depth, options) {
   }
   return null;
 }
-function getExportedGitContextEnvAssignments(tokens) {
+function getShellGitContextEnvAssignments(tokens) {
   const result = new Map;
-  if (tokens[0] !== "export") {
-    return result;
-  }
-  for (const token of tokens.slice(1)) {
-    if (token.startsWith("-")) {
+  for (const token of tokens) {
+    const assignment = parseEnvAssignment(token);
+    if (!assignment) {
       return new Map;
     }
-    const assignment = parseEnvAssignment(token);
-    if (assignment && GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
+    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
       result.set(assignment.name, assignment.value);
     }
   }
   return result;
+}
+function getExportedGitContextEnvAssignments(tokens, shellGitContextAssignments) {
+  const result = new Map;
+  const command = tokens[0];
+  if (!command) {
+    return result;
+  }
+  const operandsStart = command === "export" ? getExportOperandsStart(tokens) : command === "typeset" || command === "declare" ? getTypesetExportOperandsStart(tokens) : null;
+  if (operandsStart === null) {
+    return result;
+  }
+  for (const token of tokens.slice(operandsStart)) {
+    addExportedGitContextEnvAssignment(result, shellGitContextAssignments, token);
+  }
+  return result;
+}
+function getExportOperandsStart(tokens) {
+  const firstOperand = tokens[1];
+  if (firstOperand === undefined) {
+    return 1;
+  }
+  if (firstOperand === "--") {
+    return 2;
+  }
+  if (firstOperand.startsWith("-")) {
+    return null;
+  }
+  return 1;
+}
+function getTypesetExportOperandsStart(tokens) {
+  let i = 1;
+  let hasExportFlag = false;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    if (token === "--") {
+      return hasExportFlag ? i + 1 : null;
+    }
+    if (token.startsWith("-")) {
+      hasExportFlag = hasExportFlag || token.slice(1).includes("x");
+      i++;
+      continue;
+    }
+    if (token.startsWith("+")) {
+      return null;
+    }
+    return hasExportFlag ? i : null;
+  }
+  return hasExportFlag ? i : null;
+}
+function addExportedGitContextEnvAssignment(result, shellGitContextAssignments, token) {
+  const assignment = parseEnvAssignment(token);
+  if (assignment) {
+    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
+      result.set(assignment.name, assignment.value);
+    }
+    return;
+  }
+  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
+    const value = shellGitContextAssignments.get(token);
+    if (value !== undefined) {
+      result.set(token, value);
+    }
+  }
 }
 
 // src/core/analyze.ts
@@ -4980,6 +5144,20 @@ function explainSegment(tokens, depth, options, steps) {
     });
   }
   const strippedTokens = wrapperResult.tokens;
+  const envAssignments = new Map(options.envAssignments ?? []);
+  for (const [k, v] of envResult.envAssignments) {
+    envAssignments.set(k, v);
+  }
+  for (const [k, v] of wrapperResult.envAssignments) {
+    envAssignments.set(k, v);
+  }
+  const cwdForRm = wrapperResult.cwd === null ? undefined : wrapperResult.cwd ?? baseCwdForRm;
+  const nestedEffectiveCwd = wrapperResult.cwd === undefined ? options.effectiveCwd : wrapperResult.cwd;
+  const nestedOptions = {
+    ...options,
+    effectiveCwd: nestedEffectiveCwd,
+    envAssignments
+  };
   if (strippedTokens.length === 0) {
     return null;
   }
@@ -5003,7 +5181,7 @@ function explainSegment(tokens, depth, options, steps) {
         innerCommand: redactedInnerCmd,
         depth: depth + 1
       });
-      return explainInnerSegments(innerCmd, depth, options, steps);
+      return explainInnerSegments(innerCmd, depth, nestedOptions, steps);
     }
   }
   if (INTERPRETERS.has(baseNameLower)) {
@@ -5026,7 +5204,7 @@ function explainSegment(tokens, depth, options, steps) {
         innerCommand: redactedCodeArg,
         depth: depth + 1
       });
-      const nestedResult = explainInnerSegments(codeArg, depth, options, steps);
+      const nestedResult = explainInnerSegments(codeArg, depth, nestedOptions, steps);
       if (nestedResult)
         return nestedResult;
       if (containsDangerousCode(codeArg)) {
@@ -5054,15 +5232,10 @@ function explainSegment(tokens, depth, options, steps) {
       innerCommand: redactEnvAssignmentsInString(busyboxInnerCmd),
       depth: depth + 1
     });
-    return explainSegment(strippedTokens.slice(1), depth + 1, options, steps);
-  }
-  const envAssignments = new Map(envResult.envAssignments);
-  for (const [k, v] of wrapperResult.envAssignments) {
-    envAssignments.set(k, v);
+    return explainSegment(strippedTokens.slice(1), depth + 1, nestedOptions, steps);
   }
   const allowTmpdirVar = !isTmpdirOverriddenToNonTemp(envAssignments);
   const tmpdirValue = envAssignments.get("TMPDIR") ?? process.env.TMPDIR ?? null;
-  const cwdForRm = wrapperResult.cwd === null ? undefined : wrapperResult.cwd ?? baseCwdForRm;
   const isGit = baseNameLower === "git";
   const isRm = baseName === "rm";
   const isFind = baseName === "find";
@@ -5150,8 +5323,14 @@ function explainSegment(tokens, depth, options, steps) {
       return { reason };
   }
   if (isParallel) {
-    const analyzeNested = (cmd) => {
-      const result = explainInnerSegments(cmd, depth, options, steps);
+    const analyzeNested = (cmd, overrides) => {
+      const overriddenOptions = {
+        ...nestedOptions,
+        effectiveCwd: overrides && Object.hasOwn(overrides, "effectiveCwd") ? overrides.effectiveCwd : nestedOptions.effectiveCwd,
+        envAssignments: overrides?.envAssignments ?? nestedOptions.envAssignments,
+        worktreeMode: overrides?.worktreeMode ?? nestedOptions.worktreeMode
+      };
+      const result = explainInnerSegments(cmd, depth, overriddenOptions, steps);
       return result?.reason ?? null;
     };
     const reason = analyzeParallel(strippedTokens, {
@@ -5290,6 +5469,8 @@ function explainCommand2(command, options) {
   let blockReason;
   let blockSegment;
   let effectiveCwd = analyzeOpts.effectiveCwd;
+  let effectiveEnvAssignments = analyzeOpts.envAssignments;
+  const shellGitContextAssignments = new Map;
   for (let i = 0;i < segments.length; i++) {
     const segment = segments[i];
     if (!segment)
@@ -5335,7 +5516,7 @@ function explainCommand2(command, options) {
       trace.segments.push({ index: i, steps: segmentSteps });
       continue;
     }
-    const result = explainSegment(segment, 0, { ...analyzeOpts, effectiveCwd }, segmentSteps);
+    const result = explainSegment(segment, 0, { ...analyzeOpts, effectiveCwd, envAssignments: effectiveEnvAssignments }, segmentSteps);
     if (result) {
       blocked = true;
       blockReason = result.reason;
@@ -5348,6 +5529,18 @@ function explainCommand2(command, options) {
         effectiveCwdNowUnknown: true
       });
       effectiveCwd = null;
+    }
+    const shellAssignments = getShellGitContextEnvAssignments(segment);
+    for (const [k, v] of shellAssignments) {
+      shellGitContextAssignments.set(k, v);
+    }
+    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment, shellGitContextAssignments);
+    if (exportedEnvAssignments.size > 0) {
+      const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
+      for (const [k, v] of exportedEnvAssignments) {
+        nextEnvAssignments.set(k, v);
+      }
+      effectiveEnvAssignments = nextEnvAssignments;
     }
     trace.segments.push({ index: i, steps: segmentSteps });
   }

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -1568,6 +1568,9 @@ function hasRecursiveForceFlags(tokens) {
   return hasRecursive && hasForce;
 }
 
+// src/core/shell.ts
+import { isAbsolute, resolve as resolve2 } from "node:path";
+
 // node_modules/shell-quote/index.js
 var $quote = require_quote();
 var $parse = require_parse();
@@ -2061,12 +2064,13 @@ function stripEnvAssignmentsWithInfo(tokens) {
   }
   return { tokens: tokens.slice(i), envAssignments };
 }
-function stripWrappers(tokens) {
-  return stripWrappersWithInfo(tokens).tokens;
+function stripWrappers(tokens, cwd) {
+  return stripWrappersWithInfo(tokens, cwd).tokens;
 }
-function stripWrappersWithInfo(tokens) {
+function stripWrappersWithInfo(tokens, cwd) {
   let result = [...tokens];
   const allEnvAssignments = new Map;
+  let currentCwd = cwd;
   for (let iteration = 0;iteration < MAX_STRIP_ITERATIONS; iteration++) {
     const before = result.join(" ");
     const { tokens: strippedTokens, envAssignments } = stripEnvAssignmentsWithInfo(result);
@@ -2089,8 +2093,11 @@ function stripWrappersWithInfo(tokens) {
       result = stripSudo(result);
     }
     if (head === "env") {
-      const envResult = stripEnvWithInfo(result);
+      const envResult = stripEnvWithInfo(result, currentCwd);
       result = envResult.tokens;
+      if (envResult.cwd !== undefined) {
+        currentCwd = envResult.cwd;
+      }
       for (const [k, v] of envResult.envAssignments) {
         allEnvAssignments.set(k, v);
       }
@@ -2105,7 +2112,7 @@ function stripWrappersWithInfo(tokens) {
   for (const [k, v] of finalAssignments) {
     allEnvAssignments.set(k, v);
   }
-  return { tokens: finalTokens, envAssignments: allEnvAssignments };
+  return { tokens: finalTokens, envAssignments: allEnvAssignments, cwd: currentCwd };
 }
 var SUDO_OPTS_WITH_VALUE = new Set(["-u", "-g", "-C", "-D", "-h", "-p", "-r", "-t", "-T", "-U"]);
 function stripSudo(tokens) {
@@ -2138,8 +2145,9 @@ var ENV_OPTS_WITH_VALUE = new Set([
   "--split-string",
   "-P"
 ]);
-function stripEnvWithInfo(tokens) {
+function stripEnvWithInfo(tokens, cwd) {
   const envAssignments = new Map;
+  let currentCwd = cwd;
   let i = 1;
   while (i < tokens.length) {
     const token = tokens[i];
@@ -2153,6 +2161,10 @@ function stripEnvWithInfo(tokens) {
       continue;
     }
     if (ENV_OPTS_WITH_VALUE.has(token)) {
+      if (token === "-C" || token === "--chdir") {
+        const target = tokens[i + 1];
+        currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
+      }
       i += 2;
       continue;
     }
@@ -2161,6 +2173,8 @@ function stripEnvWithInfo(tokens) {
       continue;
     }
     if (token.startsWith("-C=") || token.startsWith("--chdir=")) {
+      const target = token.startsWith("-C=") ? token.slice("-C=".length) : token.slice("--chdir=".length);
+      currentCwd = resolveWrapperCwd(currentCwd, target);
       i++;
       continue;
     }
@@ -2179,7 +2193,19 @@ function stripEnvWithInfo(tokens) {
     envAssignments.set(assignment.name, assignment.value);
     i++;
   }
-  return { tokens: tokens.slice(i), envAssignments };
+  return { tokens: tokens.slice(i), envAssignments, cwd: currentCwd };
+}
+function resolveWrapperCwd(cwd, target) {
+  if (target === "") {
+    return null;
+  }
+  if (isAbsolute(target)) {
+    return resolve2(target);
+  }
+  if (!cwd) {
+    return null;
+  }
+  return resolve2(cwd, target);
 }
 function stripCommand(tokens) {
   let i = 1;
@@ -2533,7 +2559,7 @@ function extractDashCArg(tokens) {
 
 // src/core/worktree.ts
 import { existsSync as existsSync4, readFileSync as readFileSync4, realpathSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join as join3, resolve as resolve2 } from "node:path";
+import { dirname, isAbsolute as isAbsolute2, join as join3, resolve as resolve3 } from "node:path";
 var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
   "-c",
   "-C",
@@ -2556,7 +2582,7 @@ function getGitExecutionContext(tokens, cwd) {
   if (!cwd) {
     return { gitCwd: null, hasExplicitGitContext: false };
   }
-  let gitCwd = resolve2(cwd);
+  let gitCwd = resolve3(cwd);
   if (!isDirectory(gitCwd)) {
     return { gitCwd: null, hasExplicitGitContext: false };
   }
@@ -2633,14 +2659,14 @@ function isLinkedWorktree(cwd) {
     if (rawGitDir === "") {
       return false;
     }
-    const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve2(dirname(dotGitPath), rawGitDir);
+    const gitDir = isAbsolute2(rawGitDir) ? rawGitDir : resolve3(dirname(dotGitPath), rawGitDir);
     return existsSync4(join3(gitDir, "commondir"));
   } catch {
     return false;
   }
 }
 function resolveGitCwd(baseCwd, target) {
-  const resolved = isAbsolute(target) ? target : resolve2(baseCwd, target);
+  const resolved = isAbsolute2(target) ? target : resolve3(baseCwd, target);
   return isDirectory(resolved) ? resolved : null;
 }
 function isDirectory(path) {
@@ -2776,7 +2802,7 @@ function analyzeGitRule(tokens) {
     case "restore":
       return localDiscard(analyzeGitRestore(rest));
     case "reset":
-      return localDiscard(analyzeGitReset(rest));
+      return analyzeGitReset(rest);
     case "clean":
       return localDiscard(analyzeGitClean(rest));
     case "push":
@@ -2950,15 +2976,32 @@ function analyzeGitRestore(tokens) {
   return hasStaged ? null : REASON_RESTORE;
 }
 function analyzeGitReset(tokens) {
+  let reason = null;
   for (const token of tokens) {
     if (token === "--hard") {
-      return REASON_RESET_HARD;
+      reason = REASON_RESET_HARD;
+      break;
     }
     if (token === "--merge") {
-      return REASON_RESET_MERGE;
+      reason = REASON_RESET_MERGE;
+      break;
     }
   }
-  return null;
+  if (!reason) {
+    return null;
+  }
+  return resetHasRef(tokens) ? sharedState(reason) : localDiscard(reason);
+}
+function resetHasRef(tokens) {
+  for (const token of tokens) {
+    if (token === "--") {
+      return false;
+    }
+    if (!token.startsWith("-")) {
+      return true;
+    }
+  }
+  return false;
 }
 function analyzeGitClean(tokens) {
   for (const token of tokens) {
@@ -3020,7 +3063,7 @@ function analyzeGitWorktree(tokens) {
 // src/core/rules-rm.ts
 import { realpathSync as realpathSync2 } from "node:fs";
 import { homedir as homedir3, tmpdir } from "node:os";
-import { normalize, resolve as resolve3, sep } from "node:path";
+import { normalize, resolve as resolve4, sep } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison(p) {
   let normalized = normalize(p);
@@ -3192,13 +3235,13 @@ function isCwdSelfTarget(target, cwd) {
     return true;
   }
   try {
-    const resolved = resolve3(cwd, target);
+    const resolved = resolve4(cwd, target);
     const realCwd = realpathSync2(cwd);
     const realResolved = realpathSync2(resolved);
     return normalizePathForComparison(realResolved) === normalizePathForComparison(realCwd);
   } catch {
     try {
-      const resolved = resolve3(cwd, target);
+      const resolved = resolve4(cwd, target);
       return normalizePathForComparison(resolved) === normalizePathForComparison(cwd);
     } catch {
       return false;
@@ -3224,7 +3267,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   if (target.startsWith("./") || target.startsWith(".\\") || !target.includes("/") && !target.includes("\\")) {
     try {
-      const resolved = resolve3(resolveCwd, target);
+      const resolved = resolve4(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison(resolved);
       const normalizedOriginalCwd = normalizePathForComparison(originalCwd);
       return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep}`) || normalizedResolved === normalizedOriginalCwd;
@@ -3236,7 +3279,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     return false;
   }
   try {
-    const resolved = resolve3(resolveCwd, target);
+    const resolved = resolve4(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison(resolved);
     const normalizedCwd = normalizePathForComparison(originalCwd);
     return normalizedResolved.startsWith(`${normalizedCwd}${sep}`) || normalizedResolved === normalizedCwd;
@@ -3253,17 +3296,25 @@ function analyzeParallel(tokens, context) {
   if (!parseResult) {
     return null;
   }
-  const { template, args, hasPlaceholder } = parseResult;
+  const { template, args, hasPlaceholder, runsRemotely } = parseResult;
   if (template.length === 0) {
+    const nestedOverrides2 = runsRemotely ? { worktreeMode: false } : undefined;
     for (const arg of args) {
-      const reason = context.analyzeNested(arg);
+      const reason = context.analyzeNested(arg, nestedOverrides2);
       if (reason) {
         return reason;
       }
     }
     return null;
   }
-  let childTokens = stripWrappers([...template]);
+  const childWrapperInfo = stripWrappersWithInfo([...template], context.cwd);
+  let childTokens = childWrapperInfo.tokens;
+  const childEnvAssignments = new Map(context.envAssignments ?? []);
+  for (const [k, v] of childWrapperInfo.envAssignments) {
+    childEnvAssignments.set(k, v);
+  }
+  const childCwd = childWrapperInfo.cwd === null ? undefined : childWrapperInfo.cwd ?? context.cwd;
+  const nestedOverrides = buildNestedOverrides(childEnvAssignments, childWrapperInfo.cwd, runsRemotely);
   let head = getBasename(childTokens[0] ?? "").toLowerCase();
   if (head === "busybox" && childTokens.length > 1) {
     childTokens = childTokens.slice(1);
@@ -3279,20 +3330,20 @@ function analyzeParallel(tokens, context) {
         if (args.length > 0) {
           for (const arg of args) {
             const expandedScript = dashCArg.replace(/{}/g, arg);
-            const reason3 = context.analyzeNested(expandedScript);
+            const reason3 = context.analyzeNested(expandedScript, nestedOverrides);
             if (reason3) {
               return reason3;
             }
           }
           return null;
         }
-        const reason2 = context.analyzeNested(dashCArg);
+        const reason2 = context.analyzeNested(dashCArg, nestedOverrides);
         if (reason2) {
           return reason2;
         }
         return null;
       }
-      const reason = context.analyzeNested(dashCArg);
+      const reason = context.analyzeNested(dashCArg, nestedOverrides);
       if (reason) {
         return reason;
       }
@@ -3348,15 +3399,25 @@ function analyzeParallel(tokens, context) {
   }
   if (head === "git") {
     const gitResult = analyzeGit(childTokens, {
-      cwd: context.cwd,
-      envAssignments: context.envAssignments,
-      worktreeMode: context.worktreeMode
+      cwd: childCwd,
+      envAssignments: childEnvAssignments,
+      worktreeMode: runsRemotely ? false : context.worktreeMode
     });
     if (gitResult) {
       return gitResult;
     }
   }
   return null;
+}
+function buildNestedOverrides(envAssignments, cwd, runsRemotely) {
+  const overrides = { envAssignments };
+  if (cwd !== undefined) {
+    overrides.effectiveCwd = cwd;
+  }
+  if (runsRemotely) {
+    overrides.worktreeMode = false;
+  }
+  return overrides;
 }
 function parseParallelCommand(tokens) {
   const parallelOptsWithValue = new Set([
@@ -3376,6 +3437,7 @@ function parseParallelCommand(tokens) {
   let i = 1;
   const templateTokens = [];
   let markerIndex = -1;
+  let runsRemotely = false;
   while (i < tokens.length) {
     const token = tokens[i];
     if (!token)
@@ -3399,6 +3461,21 @@ function parseParallelCommand(tokens) {
       break;
     }
     if (token.startsWith("-")) {
+      if (token === "-S" || token === "--sshlogin" || token === "--slf" || token === "--sshloginfile") {
+        runsRemotely = true;
+        i += 2;
+        continue;
+      }
+      if (token.startsWith("-S") && token.length > 2) {
+        runsRemotely = true;
+        i++;
+        continue;
+      }
+      if (token.startsWith("--sshlogin=") || token.startsWith("--slf=") || token.startsWith("--sshloginfile=")) {
+        runsRemotely = true;
+        i++;
+        continue;
+      }
       if (token.startsWith("-j") && token.length > 2 && /^\d+$/.test(token.slice(2))) {
         i++;
         continue;
@@ -3443,7 +3520,7 @@ function parseParallelCommand(tokens) {
   if (templateTokens.length === 0 && markerIndex === -1) {
     return null;
   }
-  return { template: templateTokens, args, hasPlaceholder };
+  return { template: templateTokens, args, hasPlaceholder, runsRemotely };
 }
 
 // src/core/analyze/tmpdir.ts
@@ -3477,7 +3554,13 @@ var REASON_XARGS_RM = "xargs rm -rf with dynamic input is dangerous. Use explici
 var REASON_XARGS_SHELL = "xargs with shell -c can execute arbitrary commands from dynamic input.";
 function analyzeXargs(tokens, context) {
   const { childTokens: rawChildTokens } = extractXargsChildCommandWithInfo(tokens);
-  let childTokens = stripWrappers(rawChildTokens);
+  const childWrapperInfo = stripWrappersWithInfo(rawChildTokens, context.cwd);
+  let childTokens = childWrapperInfo.tokens;
+  const childEnvAssignments = new Map(context.envAssignments ?? []);
+  for (const [k, v] of childWrapperInfo.envAssignments) {
+    childEnvAssignments.set(k, v);
+  }
+  const childCwd = childWrapperInfo.cwd === null ? undefined : childWrapperInfo.cwd ?? context.cwd;
   if (childTokens.length === 0) {
     return null;
   }
@@ -3509,8 +3592,8 @@ function analyzeXargs(tokens, context) {
   }
   if (head === "git") {
     const gitResult = analyzeGit(childTokens, {
-      cwd: context.cwd,
-      envAssignments: context.envAssignments,
+      cwd: childCwd,
+      envAssignments: childEnvAssignments,
       worktreeMode: context.worktreeMode
     });
     if (gitResult) {
@@ -3682,9 +3765,17 @@ function analyzeSegment(tokens, depth, options) {
   if (tokens.length === 0) {
     return null;
   }
+  const { cwdForRm: baseCwdForRm, originalCwd } = deriveCwdContext(options);
   const { tokens: strippedEnv, envAssignments: leadingEnvAssignments } = stripEnvAssignmentsWithInfo(tokens);
-  const { tokens: stripped, envAssignments: wrapperEnvAssignments } = stripWrappersWithInfo(strippedEnv);
-  const envAssignments = new Map(leadingEnvAssignments);
+  const {
+    tokens: stripped,
+    envAssignments: wrapperEnvAssignments,
+    cwd: wrapperCwd
+  } = stripWrappersWithInfo(strippedEnv, baseCwdForRm);
+  const envAssignments = new Map(options.envAssignments ?? []);
+  for (const [k, v] of leadingEnvAssignments) {
+    envAssignments.set(k, v);
+  }
   for (const [k, v] of wrapperEnvAssignments) {
     envAssignments.set(k, v);
   }
@@ -3697,12 +3788,16 @@ function analyzeSegment(tokens, depth, options) {
   }
   const normalizedHead = normalizeCommandToken(head);
   const basename = getBasename(head);
-  const { cwdForRm, originalCwd } = deriveCwdContext(options);
+  const cwdForRm = wrapperCwd === null ? undefined : wrapperCwd ?? baseCwdForRm;
+  const nestedEffectiveCwd = wrapperCwd === undefined ? options.effectiveCwd : wrapperCwd;
   const allowTmpdirVar = !isTmpdirOverriddenToNonTemp(envAssignments);
   if (SHELL_WRAPPERS.has(normalizedHead)) {
     const dashCArg = extractDashCArg(stripped);
     if (dashCArg) {
-      return options.analyzeNested(dashCArg);
+      return options.analyzeNested(dashCArg, {
+        effectiveCwd: nestedEffectiveCwd,
+        envAssignments
+      });
     }
   }
   if (INTERPRETERS.has(normalizedHead)) {
@@ -3807,7 +3902,7 @@ function analyzeSegment(tokens, depth, options) {
           const reason = analyzeGit(gitTokens, {
             cwd: cwdForRm,
             envAssignments,
-            worktreeMode: options.worktreeMode
+            worktreeMode: false
           });
           if (reason) {
             return reason;
@@ -3891,8 +3986,14 @@ function analyzeCommandInternal(command, depth, options) {
       ...options,
       cwd: originalCwd,
       effectiveCwd,
-      analyzeNested: (nestedCommand) => {
-        return analyzeCommandInternal(nestedCommand, depth + 1, { ...options, effectiveCwd })?.reason ?? null;
+      analyzeNested: (nestedCommand, overrides) => {
+        const nestedEffectiveCwd = overrides && Object.hasOwn(overrides, "effectiveCwd") ? overrides.effectiveCwd : effectiveCwd;
+        return analyzeCommandInternal(nestedCommand, depth + 1, {
+          ...options,
+          effectiveCwd: nestedEffectiveCwd,
+          envAssignments: overrides?.envAssignments ?? options.envAssignments,
+          worktreeMode: overrides?.worktreeMode ?? options.worktreeMode
+        })?.reason ?? null;
       }
     });
     if (reason) {
@@ -4399,7 +4500,7 @@ var defaultVersionFetcher = async (args) => {
   const [cmd, ...rest] = args;
   if (!cmd)
     return null;
-  return new Promise((resolve4) => {
+  return new Promise((resolve5) => {
     try {
       const proc = spawn(cmd, rest, {
         stdio: ["ignore", "pipe", "pipe"]
@@ -4415,7 +4516,7 @@ var defaultVersionFetcher = async (args) => {
           return;
         isSettled = true;
         clearTimeout(timeoutId);
-        resolve4(value);
+        resolve5(value);
       };
       const timeoutId = setTimeout(() => {
         proc.kill();
@@ -4428,7 +4529,7 @@ var defaultVersionFetcher = async (args) => {
         finish(null);
       });
     } catch {
-      resolve4(null);
+      resolve5(null);
     }
   });
 };
@@ -4595,7 +4696,7 @@ function printReport(report) {
 
 // src/bin/explain/config.ts
 import { existsSync as existsSync6 } from "node:fs";
-import { resolve as resolve4 } from "node:path";
+import { resolve as resolve5 } from "node:path";
 
 // src/core/env.ts
 function envTruthy(name) {
@@ -4625,7 +4726,7 @@ function getConfigSource(options) {
   return { configSource: null, configValid: true };
 }
 function buildAnalyzeOptions(explainOptions) {
-  const cwd = resolve4(explainOptions?.cwd ?? process.cwd());
+  const cwd = resolve5(explainOptions?.cwd ?? process.cwd());
   const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
   return {
     cwd,
@@ -5877,7 +5978,7 @@ async function readStdinAsync() {
   if (process.stdin.isTTY) {
     return null;
   }
-  return new Promise((resolve5) => {
+  return new Promise((resolve6) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => {
@@ -5885,10 +5986,10 @@ async function readStdinAsync() {
     });
     process.stdin.on("end", () => {
       const trimmed = data.trim();
-      resolve5(trimmed || null);
+      resolve6(trimmed || null);
     });
     process.stdin.on("error", () => {
-      resolve5(null);
+      resolve6(null);
     });
   });
 }
@@ -5956,7 +6057,7 @@ async function printStatusline() {
 
 // src/bin/verify-config.ts
 import { existsSync as existsSync9, readFileSync as readFileSync7, writeFileSync } from "node:fs";
-import { resolve as resolve5 } from "node:path";
+import { resolve as resolve6 } from "node:path";
 var HEADER = "Safety Net Config";
 var SEPARATOR = "═".repeat(HEADER.length);
 var SCHEMA_URL = "https://raw.githubusercontent.com/kenryu42/claude-code-safety-net/main/assets/cc-safety-net.schema.json";
@@ -6021,7 +6122,7 @@ function verifyConfig(options = {}) {
     const result = validateConfigFile(projectConfig);
     configsChecked.push({
       scope: "Project",
-      path: resolve5(projectConfig),
+      path: resolve6(projectConfig),
       result
     });
     if (result.errors.length > 0) {

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -1569,14 +1569,15 @@ function hasRecursiveForceFlags(tokens) {
 }
 
 // src/core/shell.ts
-import { isAbsolute as isAbsolute2, resolve as resolve3 } from "node:path";
+import { lstatSync as lstatSync2, realpathSync as realpathSync2 } from "node:fs";
+import { dirname as dirname2, isAbsolute as isAbsolute2 } from "node:path";
 
 // node_modules/shell-quote/index.js
 var $quote = require_quote();
 var $parse = require_parse();
 
 // src/core/worktree.ts
-import { existsSync as existsSync4, readFileSync as readFileSync4, realpathSync, statSync } from "node:fs";
+import { existsSync as existsSync4, lstatSync, readFileSync as readFileSync4, realpathSync, statSync } from "node:fs";
 import { dirname, isAbsolute, join as join3, resolve as resolve2 } from "node:path";
 var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
   "-c",
@@ -1587,7 +1588,12 @@ var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
   "--super-prefix",
   "--config-env"
 ]);
-var GIT_CONTEXT_ENV_OVERRIDES = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"];
+var GIT_CONTEXT_ENV_OVERRIDES = [
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_COMMON_DIR",
+  "GIT_INDEX_FILE"
+];
 function hasGitContextEnvOverride(envAssignments) {
   for (const name of GIT_CONTEXT_ENV_OVERRIDES) {
     if (envAssignments?.has(name) || Object.hasOwn(process.env, name)) {
@@ -1681,7 +1687,26 @@ function isLinkedWorktree(cwd) {
     if (!existsSync4(join3(gitDir, "commondir"))) {
       return false;
     }
+    if (!worktreeGitdirBacklinkMatches(gitDir, dotGitPath)) {
+      return false;
+    }
     return worktreeConfigMatchesRoot(gitDir, dirname(dotGitPath));
+  } catch {
+    return false;
+  }
+}
+function worktreeGitdirBacklinkMatches(gitDir, dotGitPath) {
+  const backlinkPath = join3(gitDir, "gitdir");
+  if (!existsSync4(backlinkPath)) {
+    return false;
+  }
+  const rawBacklink = readFileSync4(backlinkPath, "utf-8").split(/\r?\n/, 1)[0]?.trim() ?? "";
+  if (rawBacklink === "") {
+    return false;
+  }
+  const linkedDotGitPath = isAbsolute(rawBacklink) ? rawBacklink : resolve2(gitDir, rawBacklink);
+  try {
+    return realpathSync(linkedDotGitPath) === realpathSync(dotGitPath);
   } catch {
     return false;
   }
@@ -1705,6 +1730,7 @@ function worktreeConfigMatchesRoot(gitDir, worktreeRoot) {
 function readCoreWorktree(configPath) {
   const content = readFileSync4(configPath, "utf-8");
   let inCore = false;
+  let configuredWorktree = null;
   for (const line of content.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith(";")) {
@@ -1719,10 +1745,10 @@ function readCoreWorktree(configPath) {
     }
     const match = trimmed.match(/^worktree\s*=\s*(.*)$/i);
     if (match) {
-      return unquoteGitConfigValue(match[1] ?? "");
+      configuredWorktree = unquoteGitConfigValue(match[1] ?? "");
     }
   }
-  return null;
+  return configuredWorktree;
 }
 function unquoteGitConfigValue(value) {
   const trimmed = value.trim();
@@ -1732,8 +1758,30 @@ function unquoteGitConfigValue(value) {
   return trimmed;
 }
 function resolveGitCwd(baseCwd, target) {
-  const resolved = isAbsolute(target) ? target : resolve2(baseCwd, target);
-  return isDirectory(resolved) ? resolved : null;
+  try {
+    const resolved = resolveChdirTarget(baseCwd, target);
+    return isDirectory(resolved) ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+function resolveChdirTarget(baseCwd, target) {
+  let current = isAbsolute(target) ? "/" : baseCwd;
+  for (const component of target.split("/")) {
+    if (component === "" || component === ".") {
+      continue;
+    }
+    if (component === "..") {
+      current = dirname(current);
+      continue;
+    }
+    const candidate = appendPathWithoutNormalizing(current, component);
+    current = lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
+  }
+  return current;
+}
+function appendPathWithoutNormalizing(base, target) {
+  return base.endsWith("/") ? `${base}${target}` : `${base}/${target}`;
 }
 function isDirectory(path) {
   try {
@@ -2345,6 +2393,16 @@ function stripSudoWithInfo(tokens, cwd) {
       i++;
       continue;
     }
+    if (token.startsWith("-D") && token.length > 2) {
+      currentCwd = resolveWrapperCwd(currentCwd, token.slice(2));
+      i++;
+      continue;
+    }
+    if (token === "-i" || token === "--login") {
+      currentCwd = null;
+      i++;
+      continue;
+    }
     if (SUDO_OPTS_WITH_VALUE.has(token)) {
       i += 2;
       continue;
@@ -2476,13 +2534,32 @@ function resolveWrapperCwd(cwd, target) {
   if (target === "") {
     return null;
   }
-  if (isAbsolute2(target)) {
-    return resolve3(target);
-  }
-  if (!cwd) {
+  try {
+    if (!cwd && !isAbsolute2(target)) {
+      return null;
+    }
+    return resolveChdirTarget2(cwd ?? "/", target);
+  } catch {
     return null;
   }
-  return resolve3(cwd, target);
+}
+function resolveChdirTarget2(baseCwd, target) {
+  let current = isAbsolute2(target) ? "/" : baseCwd;
+  for (const component of target.split("/")) {
+    if (component === "" || component === ".") {
+      continue;
+    }
+    if (component === "..") {
+      current = dirname2(current);
+      continue;
+    }
+    const candidate = appendPathWithoutNormalizing2(current, component);
+    current = lstatSync2(candidate).isSymbolicLink() ? realpathSync2(candidate) : candidate;
+  }
+  return current;
+}
+function appendPathWithoutNormalizing2(base, target) {
+  return base.endsWith("/") ? `${base}${target}` : `${base}/${target}`;
 }
 function stripCommand(tokens) {
   let i = 1;
@@ -3156,10 +3233,95 @@ function analyzeGitClean(tokens) {
 function isNonRelaxableLocalDiscard(tokens) {
   const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
   const normalizedSubcommand = subcommand?.toLowerCase();
-  if (hasRecurseSubmodulesOption(rest)) {
+  if (hasRecursiveSubmoduleConfig(tokens) || hasRecurseSubmodulesOption(rest) || isForcedBranchReset(normalizedSubcommand, rest)) {
     return true;
   }
   return normalizedSubcommand === "clean" && countCleanForceFlags(rest) > 1;
+}
+function hasRecursiveSubmoduleConfig(tokens) {
+  let i = 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token || token === "--") {
+      return false;
+    }
+    if (!token.startsWith("-")) {
+      return false;
+    }
+    if (token === "-c") {
+      if (configEnablesRecursiveSubmodules(tokens[i + 1])) {
+        return true;
+      }
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("-c") && token.length > 2) {
+      if (configEnablesRecursiveSubmodules(token.slice(2))) {
+        return true;
+      }
+      i++;
+      continue;
+    }
+    if (token === "--config-env") {
+      if (configEnvTargetsRecursiveSubmodules(tokens[i + 1])) {
+        return true;
+      }
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("--config-env=")) {
+      if (configEnvTargetsRecursiveSubmodules(token.slice("--config-env=".length))) {
+        return true;
+      }
+      i++;
+      continue;
+    }
+    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(token)) {
+      i += 2;
+    } else {
+      i++;
+    }
+  }
+  return false;
+}
+function configEnablesRecursiveSubmodules(config) {
+  if (!config) {
+    return false;
+  }
+  const eqIdx = config.indexOf("=");
+  const key = (eqIdx === -1 ? config : config.slice(0, eqIdx)).toLowerCase();
+  if (key !== "submodule.recurse") {
+    return false;
+  }
+  const value = eqIdx === -1 ? "true" : config.slice(eqIdx + 1).toLowerCase();
+  return value !== "false" && value !== "no" && value !== "off" && value !== "0";
+}
+function configEnvTargetsRecursiveSubmodules(configEnv) {
+  const eqIdx = configEnv?.indexOf("=") ?? -1;
+  if (!configEnv || eqIdx === -1) {
+    return false;
+  }
+  return configEnv.slice(0, eqIdx).toLowerCase() === "submodule.recurse";
+}
+function isForcedBranchReset(subcommand, rest) {
+  if (subcommand === "checkout") {
+    const { before } = splitAtDoubleDash(rest);
+    const shortOpts = extractShortOpts(before, {
+      shortOptsWithValue: CHECKOUT_SHORT_OPTS_WITH_VALUE
+    });
+    const hasForce = before.includes("--force") || shortOpts.has("-f");
+    return hasForce && before.some((token) => token === "-B" || token.startsWith("-B"));
+  }
+  if (subcommand === "switch") {
+    const { before } = splitAtDoubleDash(rest);
+    const shortOpts = extractShortOpts(before, {
+      shortOptsWithValue: SWITCH_SHORT_OPTS_WITH_VALUE
+    });
+    const hasForce = before.includes("--force") || shortOpts.has("-f");
+    const hasForceCreate = before.some((token) => token === "-C" || token.startsWith("-C") || token === "--force-create" || token.startsWith("--force-create="));
+    return hasForce && hasForceCreate;
+  }
+  return false;
 }
 function hasRecurseSubmodulesOption(tokens) {
   return tokens.some((token) => token === "--recurse-submodules" || token.startsWith("--recurse-submodules="));
@@ -3227,9 +3389,9 @@ function analyzeGitWorktree(tokens) {
 }
 
 // src/core/rules-rm.ts
-import { realpathSync as realpathSync2 } from "node:fs";
+import { realpathSync as realpathSync3 } from "node:fs";
 import { homedir as homedir3, tmpdir } from "node:os";
-import { normalize, resolve as resolve4, sep } from "node:path";
+import { normalize, resolve as resolve3, sep } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison(p) {
   let normalized = normalize(p);
@@ -3401,13 +3563,13 @@ function isCwdSelfTarget(target, cwd) {
     return true;
   }
   try {
-    const resolved = resolve4(cwd, target);
-    const realCwd = realpathSync2(cwd);
-    const realResolved = realpathSync2(resolved);
+    const resolved = resolve3(cwd, target);
+    const realCwd = realpathSync3(cwd);
+    const realResolved = realpathSync3(resolved);
     return normalizePathForComparison(realResolved) === normalizePathForComparison(realCwd);
   } catch {
     try {
-      const resolved = resolve4(cwd, target);
+      const resolved = resolve3(cwd, target);
       return normalizePathForComparison(resolved) === normalizePathForComparison(cwd);
     } catch {
       return false;
@@ -3433,7 +3595,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   if (target.startsWith("./") || target.startsWith(".\\") || !target.includes("/") && !target.includes("\\")) {
     try {
-      const resolved = resolve4(resolveCwd, target);
+      const resolved = resolve3(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison(resolved);
       const normalizedOriginalCwd = normalizePathForComparison(originalCwd);
       return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep}`) || normalizedResolved === normalizedOriginalCwd;
@@ -3445,7 +3607,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     return false;
   }
   try {
-    const resolved = resolve4(resolveCwd, target);
+    const resolved = resolve3(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison(resolved);
     const normalizedCwd = normalizePathForComparison(originalCwd);
     return normalizedResolved.startsWith(`${normalizedCwd}${sep}`) || normalizedResolved === normalizedCwd;
@@ -3462,7 +3624,7 @@ function analyzeParallel(tokens, context) {
   if (!parseResult) {
     return null;
   }
-  const { template, args, hasPlaceholder, runsRemotely } = parseResult;
+  const { template, args, hasPlaceholder, runsRemotely, usesStdin } = parseResult;
   if (template.length === 0) {
     const nestedOverrides2 = buildCommandsModeOverrides(context, runsRemotely);
     for (const arg of args) {
@@ -3564,12 +3726,13 @@ function analyzeParallel(tokens, context) {
     }
   }
   if (head === "git") {
-    const gitTokenSets = !hasPlaceholder && args.length > 0 ? args.map((arg) => [...childTokens, arg]) : [childTokens];
+    const gitTokenSets = hasPlaceholder && args.length > 0 ? args.map((arg) => childTokens.map((token) => replaceParallelPlaceholder(token, arg))) : !hasPlaceholder && args.length > 0 ? args.map((arg) => [...childTokens, arg]) : [childTokens];
+    const dynamicGitArgs = usesStdin || hasPlaceholder && args.length === 0;
     for (const gitTokens of gitTokenSets) {
       const gitResult = analyzeGit(gitTokens, {
         cwd: childCwd,
         envAssignments: childEnvAssignments,
-        worktreeMode: runsRemotely ? false : context.worktreeMode
+        worktreeMode: runsRemotely || dynamicGitArgs ? false : context.worktreeMode
       });
       if (gitResult) {
         return gitResult;
@@ -3600,6 +3763,9 @@ function buildCommandsModeOverrides(context, runsRemotely) {
     overrides.worktreeMode = false;
   }
   return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
+function replaceParallelPlaceholder(token, arg) {
+  return token.replace(/\{\}/g, arg).replace(/\{1\}/g, arg).replace(/\{\.\}/g, arg);
 }
 function parseParallelCommand(tokens) {
   const parallelOptsWithValue = new Set([
@@ -3702,7 +3868,13 @@ function parseParallelCommand(tokens) {
   if (templateTokens.length === 0 && markerIndex === -1) {
     return null;
   }
-  return { template: templateTokens, args, hasPlaceholder, runsRemotely };
+  return {
+    template: templateTokens,
+    args,
+    hasPlaceholder,
+    runsRemotely,
+    usesStdin: markerIndex === -1
+  };
 }
 
 // src/core/analyze/tmpdir.ts
@@ -3778,7 +3950,7 @@ function analyzeXargs(tokens, context) {
     const gitResult = analyzeGit(gitTokens, {
       cwd: childCwd,
       envAssignments: childEnvAssignments,
-      worktreeMode: context.worktreeMode
+      worktreeMode: replacementToken === null ? false : context.worktreeMode
     });
     if (gitResult) {
       return gitResult;
@@ -4152,6 +4324,7 @@ function stripLeadingGrouping(tokens) {
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES2 = new Set(GIT_CONTEXT_ENV_OVERRIDES);
+var GIT_CONTEXT_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 function analyzeCommandInternal(command, depth, options) {
   if (depth >= MAX_RECURSION_DEPTH) {
     return { reason: REASON_RECURSION_LIMIT, segment: command };
@@ -4162,11 +4335,10 @@ function analyzeCommandInternal(command, depth, options) {
   }
   const originalCwd = options.cwd;
   let effectiveCwd = options.effectiveCwd !== undefined ? options.effectiveCwd : options.cwd;
-  let effectiveEnvAssignments = options.envAssignments;
-  const shellGitContextAssignments = new Map;
+  const shellGitContextState = createShellGitContextEnvState(options.envAssignments);
   for (const segment of segments) {
     const segmentStr = segment.join(" ");
-    const segmentEnvAssignments = effectiveEnvAssignments;
+    const segmentEnvAssignments = shellGitContextState.effectiveEnvAssignments;
     if (segment.length === 1 && segment[0]?.includes(" ")) {
       const textReason = dangerousInText(segment[0]);
       if (textReason) {
@@ -4198,64 +4370,173 @@ function analyzeCommandInternal(command, depth, options) {
     if (segmentChangesCwd(segment)) {
       effectiveCwd = null;
     }
-    const shellAssignments = getShellGitContextEnvAssignments(segment);
-    for (const [k, v] of shellAssignments) {
-      shellGitContextAssignments.set(k, v);
-    }
-    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment, shellGitContextAssignments);
-    if (exportedEnvAssignments.size > 0) {
-      const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
-      for (const [k, v] of exportedEnvAssignments) {
-        nextEnvAssignments.set(k, v);
-      }
-      effectiveEnvAssignments = nextEnvAssignments;
-    }
+    applyShellGitContextEnvSegment(segment, shellGitContextState);
   }
   return null;
 }
-function getShellGitContextEnvAssignments(tokens) {
-  const result = new Map;
-  for (const token of tokens) {
-    const assignment = parseEnvAssignment(token);
+function createShellGitContextEnvState(effectiveEnvAssignments) {
+  return {
+    effectiveEnvAssignments,
+    shellAssignments: new Map,
+    exportedNames: new Set,
+    allexport: false
+  };
+}
+function applyShellGitContextEnvSegment(tokens, state) {
+  const commandInfo = getShellCommandInfo(tokens);
+  if (!commandInfo) {
+    return;
+  }
+  const { command, commandIndex, leadingAssignments } = commandInfo;
+  if (command === null) {
+    for (const assignment of leadingAssignments.values()) {
+      setShellGitContextAssignment(state, assignment);
+    }
+    return;
+  }
+  if (command === "set") {
+    const allexport = getAllexportChange(tokens, commandIndex);
+    if (allexport !== null) {
+      state.allexport = allexport;
+    }
+    return;
+  }
+  if (command !== "export" && command !== "typeset" && command !== "declare") {
+    return;
+  }
+  for (const assignment of leadingAssignments.values()) {
+    setShellGitContextAssignment(state, assignment);
+  }
+  if (command === "export") {
+    const operandsStart = getExportOperandsStart(tokens, commandIndex);
+    if (operandsStart === null) {
+      return;
+    }
+    for (const token of tokens.slice(operandsStart)) {
+      addExportedGitContextEnvAssignment(state, token);
+    }
+    return;
+  }
+  const operandsInfo = getTypesetOperandsInfo(tokens, commandIndex);
+  if (operandsInfo === null) {
+    return;
+  }
+  for (const token of tokens.slice(operandsInfo.operandsStart)) {
+    addTypesetGitContextEnvAssignment(state, token, operandsInfo.exports);
+  }
+}
+function getShellCommandInfo(tokens) {
+  const leadingAssignments = new Map;
+  let i = 0;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    const assignment = parseShellAssignment(token);
     if (!assignment) {
-      return new Map;
+      break;
     }
     if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
-      result.set(assignment.name, assignment.value);
+      leadingAssignments.set(assignment.name, assignment);
+    }
+    i++;
+  }
+  if (i >= tokens.length) {
+    return { command: null, commandIndex: i, leadingAssignments };
+  }
+  let commandIndex = i;
+  let command = tokens[commandIndex] ?? null;
+  if (command === "builtin" || command === "command") {
+    commandIndex++;
+    command = tokens[commandIndex] ?? null;
+  }
+  if (command === null) {
+    return null;
+  }
+  return { command, commandIndex, leadingAssignments };
+}
+function parseShellAssignment(token) {
+  return parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment2(token);
+}
+function parseGitContextEnvAssignment(token) {
+  const assignment = parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment2(token);
+  if (!assignment || !GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
+    return null;
+  }
+  return assignment;
+}
+function parseGitContextAppendEnvAssignment2(token) {
+  const match = token.match(GIT_CONTEXT_APPEND_ASSIGNMENT_RE);
+  const name = match?.[1];
+  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name)) {
+    return null;
+  }
+  const eqIdx = token.indexOf("=");
+  return { name, value: token.slice(eqIdx + 1) };
+}
+function setShellGitContextAssignment(state, assignment) {
+  state.shellAssignments.set(assignment.name, assignment.value);
+  if (state.allexport || state.exportedNames.has(assignment.name)) {
+    setEffectiveGitContextAssignment(state, assignment);
+  }
+}
+function setEffectiveGitContextAssignment(state, assignment) {
+  const nextEnvAssignments = new Map(state.effectiveEnvAssignments ?? []);
+  nextEnvAssignments.set(assignment.name, assignment.value);
+  state.effectiveEnvAssignments = nextEnvAssignments;
+}
+function addExportedGitContextEnvAssignment(state, token) {
+  const assignment = parseGitContextEnvAssignment(token);
+  if (assignment) {
+    state.shellAssignments.set(assignment.name, assignment.value);
+    state.exportedNames.add(assignment.name);
+    setEffectiveGitContextAssignment(state, assignment);
+    return;
+  }
+  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
+    state.exportedNames.add(token);
+    const value = state.shellAssignments.get(token);
+    if (value !== undefined) {
+      setEffectiveGitContextAssignment(state, { name: token, value });
     }
   }
-  return result;
 }
-function getExportedGitContextEnvAssignments(tokens, shellGitContextAssignments) {
-  const result = new Map;
-  const command = tokens[0];
-  if (!command) {
-    return result;
+function addTypesetGitContextEnvAssignment(state, token, exports) {
+  const assignment = parseGitContextEnvAssignment(token);
+  if (assignment) {
+    state.shellAssignments.set(assignment.name, assignment.value);
+    if (exports) {
+      state.exportedNames.add(assignment.name);
+      setEffectiveGitContextAssignment(state, assignment);
+    } else if (state.allexport || state.exportedNames.has(assignment.name)) {
+      setEffectiveGitContextAssignment(state, assignment);
+    }
+    return;
   }
-  const operandsStart = command === "export" ? getExportOperandsStart(tokens) : command === "typeset" || command === "declare" ? getTypesetExportOperandsStart(tokens) : null;
-  if (operandsStart === null) {
-    return result;
+  if (exports && GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
+    state.exportedNames.add(token);
+    const value = state.shellAssignments.get(token);
+    if (value !== undefined) {
+      setEffectiveGitContextAssignment(state, { name: token, value });
+    }
   }
-  for (const token of tokens.slice(operandsStart)) {
-    addExportedGitContextEnvAssignment(result, shellGitContextAssignments, token);
-  }
-  return result;
 }
-function getExportOperandsStart(tokens) {
-  const firstOperand = tokens[1];
+function getExportOperandsStart(tokens, commandIndex) {
+  const firstOperand = tokens[commandIndex + 1];
   if (firstOperand === undefined) {
-    return 1;
+    return commandIndex + 1;
   }
   if (firstOperand === "--") {
-    return 2;
+    return commandIndex + 2;
   }
   if (firstOperand.startsWith("-")) {
     return null;
   }
-  return 1;
+  return commandIndex + 1;
 }
-function getTypesetExportOperandsStart(tokens) {
-  let i = 1;
+function getTypesetOperandsInfo(tokens, commandIndex) {
+  let i = commandIndex + 1;
   let hasExportFlag = false;
   while (i < tokens.length) {
     const token = tokens[i];
@@ -4263,7 +4544,7 @@ function getTypesetExportOperandsStart(tokens) {
       return null;
     }
     if (token === "--") {
-      return hasExportFlag ? i + 1 : null;
+      return { operandsStart: i + 1, exports: hasExportFlag };
     }
     if (token.startsWith("-")) {
       hasExportFlag = hasExportFlag || token.slice(1).includes("x");
@@ -4273,24 +4554,33 @@ function getTypesetExportOperandsStart(tokens) {
     if (token.startsWith("+")) {
       return null;
     }
-    return hasExportFlag ? i : null;
+    return { operandsStart: i, exports: hasExportFlag };
   }
-  return hasExportFlag ? i : null;
+  return { operandsStart: i, exports: hasExportFlag };
 }
-function addExportedGitContextEnvAssignment(result, shellGitContextAssignments, token) {
-  const assignment = parseEnvAssignment(token);
-  if (assignment) {
-    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
-      result.set(assignment.name, assignment.value);
+function getAllexportChange(tokens, commandIndex) {
+  let i = commandIndex + 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
     }
-    return;
-  }
-  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
-    const value = shellGitContextAssignments.get(token);
-    if (value !== undefined) {
-      result.set(token, value);
+    if (token === "-o" || token === "+o") {
+      if (tokens[i + 1] === "allexport") {
+        return token === "-o";
+      }
+      i += 2;
+      continue;
     }
+    if (token.startsWith("-") && token.slice(1).includes("a")) {
+      return true;
+    }
+    if (token.startsWith("+") && token.slice(1).includes("a")) {
+      return false;
+    }
+    i++;
   }
+  return null;
 }
 
 // src/core/analyze.ts
@@ -4787,7 +5077,7 @@ var defaultVersionFetcher = async (args) => {
   const [cmd, ...rest] = args;
   if (!cmd)
     return null;
-  return new Promise((resolve5) => {
+  return new Promise((resolve4) => {
     try {
       const proc = spawn(cmd, rest, {
         stdio: ["ignore", "pipe", "pipe"]
@@ -4803,7 +5093,7 @@ var defaultVersionFetcher = async (args) => {
           return;
         isSettled = true;
         clearTimeout(timeoutId);
-        resolve5(value);
+        resolve4(value);
       };
       const timeoutId = setTimeout(() => {
         proc.kill();
@@ -4816,7 +5106,7 @@ var defaultVersionFetcher = async (args) => {
         finish(null);
       });
     } catch {
-      resolve5(null);
+      resolve4(null);
     }
   });
 };
@@ -4983,7 +5273,7 @@ function printReport(report) {
 
 // src/bin/explain/config.ts
 import { existsSync as existsSync6 } from "node:fs";
-import { resolve as resolve5 } from "node:path";
+import { resolve as resolve4 } from "node:path";
 
 // src/core/env.ts
 function envTruthy(name) {
@@ -5013,7 +5303,7 @@ function getConfigSource(options) {
   return { configSource: null, configValid: true };
 }
 function buildAnalyzeOptions(explainOptions) {
-  const cwd = resolve5(explainOptions?.cwd ?? process.cwd());
+  const cwd = resolve4(explainOptions?.cwd ?? process.cwd());
   const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
   return {
     cwd,
@@ -5071,6 +5361,7 @@ function explainInnerSegments(innerCmd, depth, options, steps) {
     return { reason: REASON_STRICT_UNPARSEABLE2 };
   }
   let effectiveCwd = options.effectiveCwd === undefined ? options.cwd : options.effectiveCwd;
+  const shellGitContextState = createShellGitContextEnvState(options.envAssignments);
   for (const segment of innerSegments) {
     if (segment.length === 1 && segment[0]?.includes(" ")) {
       const textReason = dangerousInText(segment[0]);
@@ -5098,7 +5389,11 @@ function explainInnerSegments(innerCmd, depth, options, steps) {
       }
       continue;
     }
-    const result = explainSegment(segment, depth + 1, { ...options, effectiveCwd }, steps);
+    const result = explainSegment(segment, depth + 1, {
+      ...options,
+      effectiveCwd,
+      envAssignments: shellGitContextState.effectiveEnvAssignments
+    }, steps);
     if (result)
       return result;
     if (segmentChangesCwd(segment)) {
@@ -5109,6 +5404,7 @@ function explainInnerSegments(innerCmd, depth, options, steps) {
       });
       effectiveCwd = null;
     }
+    applyShellGitContextEnvSegment(segment, shellGitContextState);
   }
   return null;
 }
@@ -5469,8 +5765,7 @@ function explainCommand2(command, options) {
   let blockReason;
   let blockSegment;
   let effectiveCwd = analyzeOpts.effectiveCwd;
-  let effectiveEnvAssignments = analyzeOpts.envAssignments;
-  const shellGitContextAssignments = new Map;
+  const shellGitContextState = createShellGitContextEnvState(analyzeOpts.envAssignments);
   for (let i = 0;i < segments.length; i++) {
     const segment = segments[i];
     if (!segment)
@@ -5516,7 +5811,11 @@ function explainCommand2(command, options) {
       trace.segments.push({ index: i, steps: segmentSteps });
       continue;
     }
-    const result = explainSegment(segment, 0, { ...analyzeOpts, effectiveCwd, envAssignments: effectiveEnvAssignments }, segmentSteps);
+    const result = explainSegment(segment, 0, {
+      ...analyzeOpts,
+      effectiveCwd,
+      envAssignments: shellGitContextState.effectiveEnvAssignments
+    }, segmentSteps);
     if (result) {
       blocked = true;
       blockReason = result.reason;
@@ -5530,18 +5829,7 @@ function explainCommand2(command, options) {
       });
       effectiveCwd = null;
     }
-    const shellAssignments = getShellGitContextEnvAssignments(segment);
-    for (const [k, v] of shellAssignments) {
-      shellGitContextAssignments.set(k, v);
-    }
-    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment, shellGitContextAssignments);
-    if (exportedEnvAssignments.size > 0) {
-      const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
-      for (const [k, v] of exportedEnvAssignments) {
-        nextEnvAssignments.set(k, v);
-      }
-      effectiveEnvAssignments = nextEnvAssignments;
-    }
+    applyShellGitContextEnvSegment(segment, shellGitContextState);
     trace.segments.push({ index: i, steps: segmentSteps });
   }
   return {
@@ -6295,7 +6583,7 @@ async function readStdinAsync() {
   if (process.stdin.isTTY) {
     return null;
   }
-  return new Promise((resolve6) => {
+  return new Promise((resolve5) => {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => {
@@ -6303,10 +6591,10 @@ async function readStdinAsync() {
     });
     process.stdin.on("end", () => {
       const trimmed = data.trim();
-      resolve6(trimmed || null);
+      resolve5(trimmed || null);
     });
     process.stdin.on("error", () => {
-      resolve6(null);
+      resolve5(null);
     });
   });
 }
@@ -6374,7 +6662,7 @@ async function printStatusline() {
 
 // src/bin/verify-config.ts
 import { existsSync as existsSync9, readFileSync as readFileSync7, writeFileSync } from "node:fs";
-import { resolve as resolve6 } from "node:path";
+import { resolve as resolve5 } from "node:path";
 var HEADER = "Safety Net Config";
 var SEPARATOR = "═".repeat(HEADER.length);
 var SCHEMA_URL = "https://raw.githubusercontent.com/kenryu42/claude-code-safety-net/main/assets/cc-safety-net.schema.json";
@@ -6439,7 +6727,7 @@ function verifyConfig(options = {}) {
     const result = validateConfigFile(projectConfig);
     configsChecked.push({
       scope: "Project",
-      path: resolve6(projectConfig),
+      path: resolve5(projectConfig),
       result
     });
     if (result.errors.length > 0) {

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -1740,10 +1740,14 @@ function sameFilesystemPath(left, right) {
       return true;
     }
   } catch {}
-  return normalizePathForComparison(realpathSync(left)) === normalizePathForComparison(realpathSync(right));
+  return getCanonicalPathForComparison(left) === getCanonicalPathForComparison(right);
+}
+function getCanonicalPathForComparison(path) {
+  return normalizePathForComparison(realpathSync.native(path));
 }
 function normalizePathForComparison(path) {
-  let normalized = path.replace(/\\/g, "/");
+  let normalized = path.replace(/^\\\\\?\\UNC\\/i, "//").replace(/^\\\\\?\\/i, "");
+  normalized = normalized.replace(/\\/g, "/");
   if (normalized.length > 1 && normalized.endsWith("/")) {
     normalized = normalized.slice(0, -1);
   }

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -1569,16 +1569,46 @@ function hasRecursiveForceFlags(tokens) {
 }
 
 // src/core/shell.ts
-import { lstatSync as lstatSync2, realpathSync as realpathSync2 } from "node:fs";
-import { dirname as dirname2, isAbsolute as isAbsolute2, parse as parsePath2, sep as sep2 } from "node:path";
+import { realpathSync as realpathSync3 } from "node:fs";
+import { isAbsolute as isAbsolute3, parse as parsePath2 } from "node:path";
 
 // node_modules/shell-quote/index.js
 var $quote = require_quote();
 var $parse = require_parse();
 
+// src/core/path.ts
+import { lstatSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, parse as parsePath, sep } from "node:path";
+function resolveChdirTarget(baseCwd, target) {
+  const root = isAbsolute(target) ? getPathRoot(target) : "";
+  let current = root || baseCwd;
+  for (const component of getPathComponents(root ? target.slice(root.length) : target)) {
+    if (component === "" || component === ".") {
+      continue;
+    }
+    if (component === "..") {
+      current = dirname(current);
+      continue;
+    }
+    const candidate = appendPathWithoutNormalizing(current, component);
+    current = lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
+  }
+  return current;
+}
+function appendPathWithoutNormalizing(base, target) {
+  return base.endsWith("/") || base.endsWith("\\") ? `${base}${target}` : `${base}${sep}${target}`;
+}
+function getPathRoot(target) {
+  return parsePath(target).root;
+}
+function getPathComponents(target) {
+  const separator = process.platform === "win32" ? /[\\/]+/ : /\/+/;
+  return target.split(separator);
+}
+
 // src/core/worktree.ts
-import { existsSync as existsSync4, lstatSync, readFileSync as readFileSync4, realpathSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join as join3, parse as parsePath, resolve as resolve2, sep } from "node:path";
+import { existsSync as existsSync4, lstatSync as lstatSync2, readFileSync as readFileSync4, realpathSync as realpathSync2, statSync } from "node:fs";
+import { dirname as dirname2, isAbsolute as isAbsolute2, join as join3, resolve as resolve2 } from "node:path";
 var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
   "-c",
   "-C",
@@ -1594,6 +1624,13 @@ var GIT_CONTEXT_ENV_OVERRIDES = [
   "GIT_COMMON_DIR",
   "GIT_INDEX_FILE"
 ];
+var GIT_CONFIG_AFFECTING_ENV_NAMES = new Set([
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_CONFIG_SYSTEM",
+  "HOME",
+  "XDG_CONFIG_HOME"
+]);
 function hasGitContextEnvOverride(envAssignments) {
   for (const name of GIT_CONTEXT_ENV_OVERRIDES) {
     if (envAssignments?.has(name) || Object.hasOwn(process.env, name)) {
@@ -1608,7 +1645,7 @@ function getGitExecutionContext(tokens, cwd) {
   }
   let gitCwd;
   try {
-    gitCwd = realpathSync(resolve2(cwd));
+    gitCwd = realpathSync2(resolve2(cwd));
   } catch {
     return { gitCwd: null, hasExplicitGitContext: false };
   }
@@ -1675,7 +1712,7 @@ function isLinkedWorktree(cwd) {
     return false;
   }
   try {
-    const stat = lstatSync(dotGitPath);
+    const stat = lstatSync2(dotGitPath);
     if (stat.isSymbolicLink() || !stat.isFile()) {
       return false;
     }
@@ -1688,14 +1725,14 @@ function isLinkedWorktree(cwd) {
     if (rawGitDir === "") {
       return false;
     }
-    const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve2(dirname(dotGitPath), rawGitDir);
+    const gitDir = isAbsolute2(rawGitDir) ? rawGitDir : resolve2(dirname2(dotGitPath), rawGitDir);
     if (!existsSync4(join3(gitDir, "commondir"))) {
       return false;
     }
     if (!worktreeGitdirBacklinkMatches(gitDir, dotGitPath)) {
       return false;
     }
-    return worktreeConfigMatchesRoot(gitDir, dirname(dotGitPath));
+    return worktreeConfigMatchesRoot(gitDir, dirname2(dotGitPath));
   } catch {
     return false;
   }
@@ -1709,7 +1746,7 @@ function worktreeGitdirBacklinkMatches(gitDir, dotGitPath) {
   if (rawBacklink === "") {
     return false;
   }
-  const linkedDotGitPath = isAbsolute(rawBacklink) ? rawBacklink : resolve2(gitDir, rawBacklink);
+  const linkedDotGitPath = isAbsolute2(rawBacklink) ? rawBacklink : resolve2(gitDir, rawBacklink);
   try {
     return sameFilesystemPath(linkedDotGitPath, dotGitPath);
   } catch {
@@ -1725,7 +1762,7 @@ function worktreeConfigMatchesRoot(gitDir, worktreeRoot) {
   if (configuredWorktree === null) {
     return true;
   }
-  const resolvedConfiguredWorktree = isAbsolute(configuredWorktree) ? configuredWorktree : resolve2(gitDir, configuredWorktree);
+  const resolvedConfiguredWorktree = isAbsolute2(configuredWorktree) ? configuredWorktree : resolve2(gitDir, configuredWorktree);
   try {
     return sameFilesystemPath(resolvedConfiguredWorktree, worktreeRoot);
   } catch {
@@ -1743,7 +1780,7 @@ function sameFilesystemPath(left, right) {
   return getCanonicalPathForComparison(left) === getCanonicalPathForComparison(right);
 }
 function getCanonicalPathForComparison(path) {
-  return normalizePathForComparison(realpathSync.native(path));
+  return normalizePathForComparison(realpathSync2.native(path));
 }
 function normalizePathForComparison(path) {
   let normalized = path.replace(/^\\\\\?\\UNC\\/i, "//").replace(/^\\\\\?\\/i, "");
@@ -1771,17 +1808,53 @@ function readCoreWorktree(configPath) {
     }
     const match = trimmed.match(/^worktree\s*=\s*(.*)$/i);
     if (match) {
-      configuredWorktree = unquoteGitConfigValue(match[1] ?? "");
+      configuredWorktree = parseGitConfigValue(match[1] ?? "");
     }
   }
   return configuredWorktree;
 }
-function unquoteGitConfigValue(value) {
+function parseGitConfigValue(value) {
   const trimmed = value.trim();
-  if (trimmed.startsWith('"') && trimmed.endsWith('"') || trimmed.startsWith("'") && trimmed.endsWith("'")) {
-    return trimmed.slice(1, -1);
+  if (!trimmed.startsWith('"') || !trimmed.endsWith('"')) {
+    return trimmed;
   }
-  return trimmed;
+  return unescapeDoubleQuotedGitConfigValue(trimmed.slice(1, -1));
+}
+function unescapeDoubleQuotedGitConfigValue(value) {
+  let result = "";
+  for (let i = 0;i < value.length; i++) {
+    const char = value[i];
+    if (char !== "\\") {
+      result += char;
+      continue;
+    }
+    const next = value[i + 1];
+    if (next === undefined) {
+      result += char;
+      continue;
+    }
+    switch (next) {
+      case "\\":
+      case '"':
+        result += next;
+        break;
+      case "n":
+        result += `
+`;
+        break;
+      case "t":
+        result += "\t";
+        break;
+      case "b":
+        result += "\b";
+        break;
+      default:
+        result += `\\${next}`;
+        break;
+    }
+    i++;
+  }
+  return result;
 }
 function resolveGitCwd(baseCwd, target) {
   try {
@@ -1790,32 +1863,6 @@ function resolveGitCwd(baseCwd, target) {
   } catch {
     return null;
   }
-}
-function resolveChdirTarget(baseCwd, target) {
-  const root = isAbsolute(target) ? getPathRoot(target) : "";
-  let current = root || baseCwd;
-  for (const component of getPathComponents(root ? target.slice(root.length) : target)) {
-    if (component === "" || component === ".") {
-      continue;
-    }
-    if (component === "..") {
-      current = dirname(current);
-      continue;
-    }
-    const candidate = appendPathWithoutNormalizing(current, component);
-    current = lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
-  }
-  return current;
-}
-function appendPathWithoutNormalizing(base, target) {
-  return base.endsWith("/") || base.endsWith("\\") ? `${base}${target}` : `${base}${sep}${target}`;
-}
-function getPathRoot(target) {
-  return parsePath(target).root;
-}
-function getPathComponents(target) {
-  const separator = process.platform === "win32" ? /[\\/]+/ : /\/+/;
-  return target.split(separator);
 }
 function isDirectory(path) {
   try {
@@ -1827,7 +1874,7 @@ function isDirectory(path) {
 function findDotGit(cwd) {
   let current;
   try {
-    current = realpathSync(cwd);
+    current = realpathSync2(cwd);
   } catch {
     return null;
   }
@@ -1836,7 +1883,7 @@ function findDotGit(cwd) {
     if (existsSync4(dotGitPath)) {
       return dotGitPath;
     }
-    const parent = dirname(current);
+    const parent = dirname2(current);
     if (parent === current) {
       return null;
     }
@@ -2323,13 +2370,6 @@ function _stripAttachedIoNumbers(command) {
 var ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
 var ENV_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES = new Set(GIT_CONTEXT_ENV_OVERRIDES);
-var GIT_CONFIG_AFFECTING_ENV_NAMES = new Set([
-  "GIT_CONFIG_GLOBAL",
-  "GIT_CONFIG_NOSYSTEM",
-  "GIT_CONFIG_SYSTEM",
-  "HOME",
-  "XDG_CONFIG_HOME"
-]);
 function parseEnvAssignment(token) {
   if (!ENV_ASSIGNMENT_RE.test(token)) {
     return null;
@@ -2594,40 +2634,17 @@ function resolveWrapperCwd(cwd, target) {
     return null;
   }
   try {
-    if (!cwd && !isAbsolute2(target)) {
+    if (!cwd && !isAbsolute3(target)) {
       return null;
     }
-    const baseCwd = isAbsolute2(target) ? getPathRoot2(target) : realpathSync2(cwd ?? "/");
-    return resolveChdirTarget2(baseCwd, target);
+    const baseCwd = isAbsolute3(target) ? getPathRoot2(target) : realpathSync3(cwd ?? "/");
+    return resolveChdirTarget(baseCwd, target);
   } catch {
     return null;
   }
 }
-function resolveChdirTarget2(baseCwd, target) {
-  const root = isAbsolute2(target) ? getPathRoot2(target) : "";
-  let current = root || baseCwd;
-  for (const component of getPathComponents2(root ? target.slice(root.length) : target)) {
-    if (component === "" || component === ".") {
-      continue;
-    }
-    if (component === "..") {
-      current = dirname2(current);
-      continue;
-    }
-    const candidate = appendPathWithoutNormalizing2(current, component);
-    current = lstatSync2(candidate).isSymbolicLink() ? realpathSync2(candidate) : candidate;
-  }
-  return current;
-}
-function appendPathWithoutNormalizing2(base, target) {
-  return base.endsWith("/") || base.endsWith("\\") ? `${base}${target}` : `${base}${sep2}${target}`;
-}
 function getPathRoot2(target) {
   return parsePath2(target).root;
-}
-function getPathComponents2(target) {
-  const separator = process.platform === "win32" ? /[\\/]+/ : /\/+/;
-  return target.split(separator);
 }
 function stripCommand(tokens) {
   let i = 1;
@@ -2982,7 +2999,7 @@ function extractDashCArg(tokens) {
 // src/core/rules-git.ts
 import { execFileSync } from "node:child_process";
 import { existsSync as existsSync5, readFileSync as readFileSync5 } from "node:fs";
-import { dirname as dirname3, isAbsolute as isAbsolute3, join as join4, resolve as resolve3 } from "node:path";
+import { dirname as dirname3, isAbsolute as isAbsolute4, join as join4, resolve as resolve3 } from "node:path";
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
 var REASON_CHECKOUT_REF_PATH = "git checkout <ref> -- <path> overwrites working tree with ref version. Use 'git stash' first.";
@@ -3012,14 +3029,11 @@ var CHECKOUT_OPTS_WITH_VALUE = new Set([
 var CHECKOUT_OPTS_WITH_OPTIONAL_VALUE = new Set(["--recurse-submodules", "--track", "-t"]);
 var CHECKOUT_SHORT_OPTS_WITH_VALUE = new Set(["-b", "-B", "-U"]);
 var SWITCH_SHORT_OPTS_WITH_VALUE = new Set(["-c", "-C"]);
-var GIT_CONFIG_AFFECTING_ENV_NAMES2 = new Set([
-  "GIT_CONFIG_GLOBAL",
-  "GIT_CONFIG_NOSYSTEM",
-  "GIT_CONFIG_SYSTEM",
-  "HOME",
-  "XDG_CONFIG_HOME"
-]);
-var TRUSTED_GIT_BINARIES = ["/usr/bin/git"];
+var TRUSTED_GIT_BINARIES = [
+  "/usr/bin/git",
+  "/usr/local/bin/git",
+  "/opt/homebrew/bin/git"
+];
 var CHECKOUT_KNOWN_OPTS_NO_VALUE = new Set([
   "-q",
   "--quiet",
@@ -3416,7 +3430,7 @@ function hasConfigAffectingEnvAssignment(envAssignments) {
     return false;
   }
   for (const key of envAssignments.keys()) {
-    if (GIT_CONFIG_AFFECTING_ENV_NAMES2.has(key)) {
+    if (GIT_CONFIG_AFFECTING_ENV_NAMES.has(key)) {
       return true;
     }
   }
@@ -3522,7 +3536,7 @@ function resolveGitDirFromDotGit(dotGitPath) {
     if (rawGitDir === "") {
       return null;
     }
-    return isAbsolute3(rawGitDir) ? rawGitDir : resolve3(dirname3(dotGitPath), rawGitDir);
+    return isAbsolute4(rawGitDir) ? rawGitDir : resolve3(dirname3(dotGitPath), rawGitDir);
   } catch {
     return null;
   }
@@ -3537,7 +3551,7 @@ function resolveCommonGitDir(gitDir) {
     if (rawCommonDir === "") {
       return null;
     }
-    return isAbsolute3(rawCommonDir) ? rawCommonDir : resolve3(gitDir, rawCommonDir);
+    return isAbsolute4(rawCommonDir) ? rawCommonDir : resolve3(gitDir, rawCommonDir);
   } catch {
     return null;
   }
@@ -3704,9 +3718,9 @@ function analyzeGitWorktree(tokens) {
 }
 
 // src/core/rules-rm.ts
-import { realpathSync as realpathSync3 } from "node:fs";
+import { realpathSync as realpathSync4 } from "node:fs";
 import { homedir as homedir3, tmpdir } from "node:os";
-import { normalize, resolve as resolve4, sep as sep3 } from "node:path";
+import { normalize, resolve as resolve4, sep as sep2 } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison2(p) {
   let normalized = normalize(p);
@@ -3850,7 +3864,7 @@ function isTempTarget(path, allowTmpdirVar) {
   const systemTmpdir = tmpdir();
   const normalizedTmpdir = normalizePathForComparison2(systemTmpdir);
   const pathToCompare = normalizePathForComparison2(normalized);
-  if (pathToCompare.startsWith(`${normalizedTmpdir}${sep3}`) || pathToCompare === normalizedTmpdir) {
+  if (pathToCompare.startsWith(`${normalizedTmpdir}${sep2}`) || pathToCompare === normalizedTmpdir) {
     return true;
   }
   if (allowTmpdirVar) {
@@ -3879,8 +3893,8 @@ function isCwdSelfTarget(target, cwd) {
   }
   try {
     const resolved = resolve4(cwd, target);
-    const realCwd = realpathSync3(cwd);
-    const realResolved = realpathSync3(resolved);
+    const realCwd = realpathSync4(cwd);
+    const realResolved = realpathSync4(resolved);
     return normalizePathForComparison2(realResolved) === normalizePathForComparison2(realCwd);
   } catch {
     try {
@@ -3902,7 +3916,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   if (target.startsWith("/") || /^[A-Za-z]:[\\/]/.test(target)) {
     try {
       const normalizedTarget = normalizePathForComparison2(target);
-      const normalizedCwd = `${normalizePathForComparison2(originalCwd)}${sep3}`;
+      const normalizedCwd = `${normalizePathForComparison2(originalCwd)}${sep2}`;
       return normalizedTarget.startsWith(normalizedCwd);
     } catch {
       return false;
@@ -3913,7 +3927,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
       const resolved = resolve4(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison2(resolved);
       const normalizedOriginalCwd = normalizePathForComparison2(originalCwd);
-      return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep3}`) || normalizedResolved === normalizedOriginalCwd;
+      return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep2}`) || normalizedResolved === normalizedOriginalCwd;
     } catch {
       return false;
     }
@@ -3925,7 +3939,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     const resolved = resolve4(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison2(resolved);
     const normalizedCwd = normalizePathForComparison2(originalCwd);
-    return normalizedResolved.startsWith(`${normalizedCwd}${sep3}`) || normalizedResolved === normalizedCwd;
+    return normalizedResolved.startsWith(`${normalizedCwd}${sep2}`) || normalizedResolved === normalizedCwd;
   } catch {
     return false;
   }
@@ -4202,7 +4216,7 @@ function parseParallelCommand(tokens) {
 
 // src/core/analyze/tmpdir.ts
 import { tmpdir as tmpdir2 } from "node:os";
-import { normalize as normalize2, sep as sep4 } from "node:path";
+import { normalize as normalize2, sep as sep3 } from "node:path";
 function isTmpdirOverriddenToNonTemp(envAssignments) {
   if (!envAssignments.has("TMPDIR")) {
     return false;
@@ -4222,7 +4236,7 @@ function isPathOrSubpath(path, basePath) {
   if (path === basePath) {
     return true;
   }
-  const baseWithSlash = basePath.endsWith(sep4) ? basePath : `${basePath}${sep4}`;
+  const baseWithSlash = basePath.endsWith(sep3) ? basePath : `${basePath}${sep3}`;
   return path.startsWith(baseWithSlash);
 }
 
@@ -4648,13 +4662,6 @@ function stripLeadingGrouping(tokens) {
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES2 = new Set(GIT_CONTEXT_ENV_OVERRIDES);
-var GIT_CONFIG_AFFECTING_ENV_NAMES3 = new Set([
-  "GIT_CONFIG_GLOBAL",
-  "GIT_CONFIG_NOSYSTEM",
-  "GIT_CONFIG_SYSTEM",
-  "HOME",
-  "XDG_CONFIG_HOME"
-]);
 var GIT_CONTEXT_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 function analyzeCommandInternal(command, depth, options) {
   if (depth >= MAX_RECURSION_DEPTH) {
@@ -4860,7 +4867,7 @@ function parseGitContextAppendEnvAssignment2(token) {
   return { name, value: token.slice(eqIdx + 1) };
 }
 function isTrackedGitEnvName2(name) {
-  return GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES3.has(name) || isGitConfigEnvName2(name);
+  return GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES.has(name) || isGitConfigEnvName2(name);
 }
 function isGitConfigEnvName2(name) {
   return name === "GIT_CONFIG_COUNT" || name === "GIT_CONFIG_PARAMETERS" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(name);

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -1380,7 +1380,7 @@ All checks passed.`);
 }
 
 // src/bin/doctor/hooks.ts
-import { existsSync as existsSync5, readdirSync as readdirSync2, readFileSync as readFileSync5 } from "node:fs";
+import { existsSync as existsSync6, readdirSync as readdirSync2, readFileSync as readFileSync5 } from "node:fs";
 import { homedir as homedir4, tmpdir as tmpdir3 } from "node:os";
 import { join as join4 } from "node:path";
 
@@ -1606,7 +1606,12 @@ function getGitExecutionContext(tokens, cwd) {
   if (!cwd) {
     return { gitCwd: null, hasExplicitGitContext: false };
   }
-  let gitCwd = resolve2(cwd);
+  let gitCwd;
+  try {
+    gitCwd = realpathSync(resolve2(cwd));
+  } catch {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
   if (!isDirectory(gitCwd)) {
     return { gitCwd: null, hasExplicitGitContext: false };
   }
@@ -1670,8 +1675,8 @@ function isLinkedWorktree(cwd) {
     return false;
   }
   try {
-    const stat = statSync(dotGitPath);
-    if (!stat.isFile()) {
+    const stat = lstatSync(dotGitPath);
+    if (stat.isSymbolicLink() || !stat.isFile()) {
       return false;
     }
     const content = readFileSync4(dotGitPath, "utf-8");
@@ -1816,6 +1821,7 @@ var ENV_PROXY = new Proxy({}, {
 });
 var ARITHMETIC_SENTINEL = "__CC_SAFETY_NET_ARITH_SENTINEL__";
 var BACKTICK_ATTACHED_SUFFIX_SENTINEL = "__CC_SAFETY_NET_BACKTICK_SUFFIX__";
+var DYNAMIC_SUBSTITUTION_TOKEN = "$__CC_SAFETY_NET_DYNAMIC_SUBSTITUTION__";
 function splitShellCommands(command) {
   if (hasUnclosedQuotes(command)) {
     return [[command]];
@@ -1859,9 +1865,14 @@ function splitShellCommands(command) {
       const { innerSegments, endIndex } = extractCommandSubstitution(tokens, i + 2);
       const attachedSuffix = _getBacktickAttachedSuffix(tokens[endIndex + 1]);
       const shouldKeepCurrent = attachedSuffix !== null && !_isRedirectOp(tokens[i - 1]) && !isOperatorToken(tokens[i - 1]);
-      if (!shouldKeepCurrent && current.length > 0) {
-        segments.push(current);
-        current = [];
+      if (current.length > 0) {
+        if (_containsGitCommandToken(current)) {
+          current.push(DYNAMIC_SUBSTITUTION_TOKEN);
+        }
+        if (!shouldKeepCurrent) {
+          segments.push(current);
+          current = [];
+        }
       }
       for (const seg of innerSegments) {
         segments.push(seg);
@@ -1879,6 +1890,9 @@ function splitShellCommands(command) {
         if (prefix) {
           current.push(prefix);
         }
+      }
+      if (_containsGitCommandToken(current)) {
+        current.push(DYNAMIC_SUBSTITUTION_TOKEN);
       }
       const { innerSegments, endIndex } = extractCommandSubstitution(tokens, i + 2);
       for (const seg of innerSegments) {
@@ -1965,6 +1979,9 @@ function _getCommandTokenText(token) {
     return token.pattern;
   }
   return null;
+}
+function _containsGitCommandToken(tokens) {
+  return tokens.some((token) => (token.split("/").pop() ?? token).toLowerCase() === "git");
 }
 function extractCommandSubstitution(tokens, startIndex) {
   if (tokens[startIndex] === ARITHMETIC_SENTINEL) {
@@ -2538,7 +2555,8 @@ function resolveWrapperCwd(cwd, target) {
     if (!cwd && !isAbsolute2(target)) {
       return null;
     }
-    return resolveChdirTarget2(cwd ?? "/", target);
+    const baseCwd = isAbsolute2(target) ? "/" : realpathSync2(cwd ?? "/");
+    return resolveChdirTarget2(baseCwd, target);
   } catch {
     return null;
   }
@@ -2913,6 +2931,7 @@ function extractDashCArg(tokens) {
 
 // src/core/rules-git.ts
 import { execFileSync } from "node:child_process";
+import { existsSync as existsSync5 } from "node:fs";
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
 var REASON_CHECKOUT_REF_PATH = "git checkout <ref> -- <path> overwrites working tree with ref version. Use 'git stash' first.";
@@ -2942,6 +2961,14 @@ var CHECKOUT_OPTS_WITH_VALUE = new Set([
 var CHECKOUT_OPTS_WITH_OPTIONAL_VALUE = new Set(["--recurse-submodules", "--track", "-t"]);
 var CHECKOUT_SHORT_OPTS_WITH_VALUE = new Set(["-b", "-B", "-U"]);
 var SWITCH_SHORT_OPTS_WITH_VALUE = new Set(["-c", "-C"]);
+var GIT_CONFIG_AFFECTING_ENV_NAMES = new Set([
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_CONFIG_SYSTEM",
+  "HOME",
+  "XDG_CONFIG_HOME"
+]);
+var TRUSTED_GIT_BINARIES = ["/usr/bin/git"];
 var CHECKOUT_KNOWN_OPTS_NO_VALUE = new Set([
   "-q",
   "--quiet",
@@ -3243,7 +3270,7 @@ function isNonRelaxableLocalDiscard(tokens, options, gitCwd) {
   return normalizedSubcommand === "clean" && countCleanForceFlags(rest) > 1;
 }
 function hasDynamicGitArgument(tokens) {
-  return tokens.some((token) => token.includes("$"));
+  return tokens.some((token) => /[$*?[]/.test(token));
 }
 function hasRecursiveSubmoduleConfig(tokens, options, gitCwd) {
   const commandLineConfig = commandLineRecursiveSubmoduleConfig(tokens, options.envAssignments);
@@ -3253,6 +3280,9 @@ function hasRecursiveSubmoduleConfig(tokens, options, gitCwd) {
   const envConfig = envRecursiveSubmoduleConfig(options.envAssignments);
   if (envConfig !== null) {
     return envConfig;
+  }
+  if (hasConfigAffectingEnvAssignment(options.envAssignments)) {
+    return true;
   }
   return effectiveGitConfigEnablesRecursiveSubmodules(gitCwd);
 }
@@ -3308,6 +3338,9 @@ function commandLineRecursiveSubmoduleConfig(tokens, envAssignments) {
   return recursiveSubmoduleConfig;
 }
 function envRecursiveSubmoduleConfig(envAssignments) {
+  if (getEnvConfigValue("GIT_CONFIG_PARAMETERS", envAssignments) !== undefined) {
+    return true;
+  }
   const countValue = getEnvConfigValue("GIT_CONFIG_COUNT", envAssignments);
   if (countValue === undefined) {
     return null;
@@ -3327,12 +3360,27 @@ function envRecursiveSubmoduleConfig(envAssignments) {
   }
   return recursiveSubmoduleConfig;
 }
+function hasConfigAffectingEnvAssignment(envAssignments) {
+  if (!envAssignments) {
+    return false;
+  }
+  for (const key of envAssignments.keys()) {
+    if (GIT_CONFIG_AFFECTING_ENV_NAMES.has(key)) {
+      return true;
+    }
+  }
+  return false;
+}
 function getEnvConfigValue(name, envAssignments) {
   return envAssignments?.get(name) ?? process.env[name];
 }
 function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
+  const gitBinary = getTrustedGitBinary();
+  if (gitBinary === null) {
+    return true;
+  }
   try {
-    const value = execFileSync("git", ["config", "--get", "submodule.recurse"], {
+    const value = execFileSync(gitBinary, ["config", "--get", "submodule.recurse"], {
       cwd,
       encoding: "utf8",
       env: withoutGitConfigEnv(process.env),
@@ -3343,10 +3391,18 @@ function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
     return !isGitConfigUnsetError(error);
   }
 }
+function getTrustedGitBinary() {
+  for (const gitBinary of TRUSTED_GIT_BINARIES) {
+    if (existsSync5(gitBinary)) {
+      return gitBinary;
+    }
+  }
+  return null;
+}
 function withoutGitConfigEnv(env) {
   const nextEnv = { ...env };
   for (const key of Object.keys(nextEnv)) {
-    if (key === "GIT_CONFIG_COUNT" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(key)) {
+    if (key === "GIT_CONFIG_COUNT" || key === "GIT_CONFIG_PARAMETERS" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(key)) {
       delete nextEnv[key];
     }
   }
@@ -3361,6 +3417,9 @@ function recursiveSubmoduleConfigValue(config) {
   }
   const eqIdx = config.indexOf("=");
   const key = (eqIdx === -1 ? config : config.slice(0, eqIdx)).toLowerCase();
+  if (isIncludeConfigKey(key)) {
+    return true;
+  }
   if (key !== "submodule.recurse") {
     return null;
   }
@@ -3376,11 +3435,18 @@ function recursiveSubmoduleConfigEnvValue(configEnv, envAssignments) {
   if (!configEnv || eqIdx === -1) {
     return null;
   }
-  if (configEnv.slice(0, eqIdx).toLowerCase() !== "submodule.recurse") {
+  const key = configEnv.slice(0, eqIdx).toLowerCase();
+  if (isIncludeConfigKey(key)) {
+    return true;
+  }
+  if (key !== "submodule.recurse") {
     return null;
   }
   const value = getEnvConfigValue(configEnv.slice(eqIdx + 1), envAssignments);
   return value === undefined || gitConfigValueEnablesRecursiveSubmodules(value);
+}
+function isIncludeConfigKey(key) {
+  return key === "include.path" || key.startsWith("includeif.") && key.endsWith(".path");
 }
 function isForcedBranchReset(subcommand, rest) {
   if (subcommand === "checkout") {
@@ -3398,13 +3464,17 @@ function isForcedBranchReset(subcommand, rest) {
       shortOptsWithValue: SWITCH_SHORT_OPTS_WITH_VALUE
     });
     const hasForce = before.includes("--force") || before.includes("--discard-changes") || shortOpts.has("-f");
-    const hasForceCreate = before.some((token) => token === "-C" || token.startsWith("-C") || token === "--force-create" || token.startsWith("--force-create=")) || shortOpts.has("-C");
+    const hasForceCreate = before.some((token) => token === "-C" || token.startsWith("-C") || isForceCreateOption(token)) || shortOpts.has("-C");
     return hasForce && hasForceCreate;
   }
   return false;
 }
+function isForceCreateOption(token) {
+  const optionName = token.split("=", 1)[0] ?? token;
+  return optionName === "--force-create" || optionName.length >= "--force-c".length && "--force-create".startsWith(optionName);
+}
 function hasRecurseSubmodulesOption(tokens) {
-  return tokens.some((token) => token === "--recurse-submodules" || token.startsWith("--recurse-submodules="));
+  return tokens.some((token) => token.startsWith("--recurse-sub"));
 }
 function countCleanForceFlags(tokens) {
   let count = 0;
@@ -3699,6 +3769,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
 // src/core/analyze/parallel.ts
 var REASON_PARALLEL_RM = "parallel rm -rf with dynamic input is dangerous. Use explicit file list instead.";
 var REASON_PARALLEL_SHELL = "parallel with shell -c can execute arbitrary commands from dynamic input.";
+var PARALLEL_PLACEHOLDER_RE = /\{[^{}\s]*\}/;
 function analyzeParallel(tokens, context) {
   const parseResult = parseParallelCommand(tokens);
   if (!parseResult) {
@@ -3732,13 +3803,13 @@ function analyzeParallel(tokens, context) {
   if (SHELL_WRAPPERS.has(head)) {
     const dashCArg = extractDashCArg(childTokens);
     if (dashCArg) {
-      if (dashCArg === "{}" || dashCArg === "{1}") {
+      if (isOnlyParallelPlaceholder(dashCArg)) {
         return REASON_PARALLEL_SHELL;
       }
-      if (dashCArg.includes("{}")) {
+      if (hasParallelPlaceholder(dashCArg)) {
         if (args.length > 0) {
           for (const arg of args) {
-            const expandedScript = dashCArg.replace(/{}/g, arg);
+            const expandedScript = replaceParallelPlaceholder(dashCArg, arg);
             const reason3 = context.analyzeNested(expandedScript, nestedOverrides);
             if (reason3) {
               return reason3;
@@ -3808,7 +3879,7 @@ function analyzeParallel(tokens, context) {
   }
   if (head === "git") {
     const gitTokenSets = hasPlaceholder && args.length > 0 ? args.map((arg) => childTokens.map((token) => replaceParallelPlaceholder(token, arg))) : !hasPlaceholder && args.length > 0 ? args.map((arg) => [...childTokens, arg]) : [childTokens];
-    const dynamicGitArgs = usesStdin || hasPlaceholder && args.length === 0;
+    const dynamicGitArgs = usesStdin || hasPlaceholder;
     for (const gitTokens of gitTokenSets) {
       const gitResult = analyzeGit(gitTokens, {
         cwd: childCwd,
@@ -3846,7 +3917,13 @@ function buildCommandsModeOverrides(context, runsRemotely) {
   return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 function replaceParallelPlaceholder(token, arg) {
-  return token.replace(/\{\}/g, arg).replace(/\{1\}/g, arg).replace(/\{\.\}/g, arg);
+  return token.replace(/\{[^{}\s]*\}/g, arg);
+}
+function hasParallelPlaceholder(token) {
+  return PARALLEL_PLACEHOLDER_RE.test(token);
+}
+function isOnlyParallelPlaceholder(token) {
+  return /^\{[^{}\s]*\}$/.test(token);
 }
 function parseParallelCommand(tokens) {
   const parallelOptsWithValue = new Set([
@@ -3945,7 +4022,7 @@ function parseParallelCommand(tokens) {
       }
     }
   }
-  const hasPlaceholder = templateTokens.some((t) => t.includes("{}") || t.includes("{1}") || t.includes("{.}"));
+  const hasPlaceholder = templateTokens.some(hasParallelPlaceholder);
   if (templateTokens.length === 0 && markerIndex === -1) {
     return null;
   }
@@ -4406,6 +4483,13 @@ function stripLeadingGrouping(tokens) {
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES2 = new Set(GIT_CONTEXT_ENV_OVERRIDES);
+var GIT_CONFIG_AFFECTING_ENV_NAMES2 = new Set([
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_CONFIG_SYSTEM",
+  "HOME",
+  "XDG_CONFIG_HOME"
+]);
 var GIT_CONTEXT_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 function analyzeCommandInternal(command, depth, options) {
   if (depth >= MAX_RECURSION_DEPTH) {
@@ -4508,7 +4592,7 @@ function applyShellGitContextEnvSegment(tokens, state) {
     return;
   }
   for (const token of tokens.slice(operandsInfo.operandsStart)) {
-    addTypesetGitContextEnvAssignment(state, token, operandsInfo.exports);
+    addTypesetGitContextEnvAssignment(state, token, operandsInfo.exports, command === "readonly" ? leadingAssignments : undefined);
   }
 }
 function getSegmentGitContextEnvAssignments(tokens, state) {
@@ -4538,7 +4622,7 @@ function getShellCommandInfo(tokens) {
     if (!assignment) {
       break;
     }
-    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
+    if (isTrackedGitEnvName(assignment.name)) {
       leadingAssignments.set(assignment.name, assignment);
     }
     i++;
@@ -4550,6 +4634,9 @@ function getShellCommandInfo(tokens) {
   let command = tokens[commandIndex] ?? null;
   if (command === "builtin") {
     commandIndex++;
+    if (tokens[commandIndex] === "--") {
+      commandIndex++;
+    }
     command = tokens[commandIndex] ?? null;
   }
   if (command === "command") {
@@ -4593,7 +4680,7 @@ function parseShellAssignment(token) {
 }
 function parseGitContextEnvAssignment(token) {
   const assignment = parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment2(token);
-  if (!assignment || !GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
+  if (!assignment || !isTrackedGitEnvName(assignment.name)) {
     return null;
   }
   return assignment;
@@ -4606,6 +4693,12 @@ function parseGitContextAppendEnvAssignment2(token) {
   }
   const eqIdx = token.indexOf("=");
   return { name, value: token.slice(eqIdx + 1) };
+}
+function isTrackedGitEnvName(name) {
+  return GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES2.has(name) || isGitConfigEnvName(name);
+}
+function isGitConfigEnvName(name) {
+  return name === "GIT_CONFIG_COUNT" || name === "GIT_CONFIG_PARAMETERS" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(name);
 }
 function setShellGitContextAssignment(state, assignment) {
   state.shellAssignments.set(assignment.name, assignment.value);
@@ -4626,15 +4719,17 @@ function addExportedGitContextEnvAssignment(state, token) {
     setEffectiveGitContextAssignment(state, assignment);
     return;
   }
-  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
+  if (isTrackedGitEnvName(token)) {
     state.exportedNames.add(token);
     const value = state.shellAssignments.get(token);
     if (value !== undefined) {
       setEffectiveGitContextAssignment(state, { name: token, value });
+    } else {
+      setEffectiveGitContextAssignment(state, { name: token, value: "" });
     }
   }
 }
-function addTypesetGitContextEnvAssignment(state, token, exports) {
+function addTypesetGitContextEnvAssignment(state, token, exports, readonlyLeadingAssignments) {
   const assignment = parseGitContextEnvAssignment(token);
   if (assignment) {
     state.shellAssignments.set(assignment.name, assignment.value);
@@ -4646,11 +4741,19 @@ function addTypesetGitContextEnvAssignment(state, token, exports) {
     }
     return;
   }
-  if (exports && GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
+  const readonlyAssignment = readonlyLeadingAssignments?.get(token);
+  if (readonlyAssignment) {
+    state.exportedNames.add(token);
+    setEffectiveGitContextAssignment(state, readonlyAssignment);
+    return;
+  }
+  if (exports && isTrackedGitEnvName(token)) {
     state.exportedNames.add(token);
     const value = state.shellAssignments.get(token);
     if (value !== undefined) {
       setEffectiveGitContextAssignment(state, { name: token, value });
+    } else {
+      setEffectiveGitContextAssignment(state, { name: token, value: "" });
     }
   }
 }
@@ -4879,7 +4982,7 @@ function detectClaudeCode(homeDir) {
   const errors = [];
   const settingsPath = join4(homeDir, ".claude", "settings.json");
   const pluginKey = "safety-net@cc-marketplace";
-  if (existsSync5(settingsPath)) {
+  if (existsSync6(settingsPath)) {
     try {
       const settings = JSON.parse(readFileSync5(settingsPath, "utf-8"));
       const pluginValue = settings.enabledPlugins?.[pluginKey];
@@ -4916,7 +5019,7 @@ function detectOpenCode(homeDir) {
   const candidates = ["opencode.json", "opencode.jsonc"];
   for (const filename of candidates) {
     const configPath = join4(configDir, filename);
-    if (existsSync5(configPath)) {
+    if (existsSync6(configPath)) {
       try {
         const content = readFileSync5(configPath, "utf-8");
         const json = stripJsonComments(content);
@@ -4950,7 +5053,7 @@ function checkGeminiHooksEnabled(homeDir, cwd, errors) {
     join4(cwd, ".gemini", "settings.json")
   ];
   for (const settingsPath of candidates) {
-    if (existsSync5(settingsPath)) {
+    if (existsSync6(settingsPath)) {
       try {
         const settings = JSON.parse(readFileSync5(settingsPath, "utf-8"));
         if (settings.tools?.enableHooks === true) {
@@ -4966,7 +5069,7 @@ function checkGeminiHooksEnabled(homeDir, cwd, errors) {
 function detectGeminiCLI(homeDir, cwd) {
   const errors = [];
   const extensionPath = join4(homeDir, ".gemini", "extensions", "extension-enablement.json");
-  if (!existsSync5(extensionPath)) {
+  if (!existsSync6(extensionPath)) {
     return { platform: "gemini-cli", status: "n/a" };
   }
   let isInstalled = false;
@@ -5086,7 +5189,7 @@ function _listJsonFiles(dirPath, errors) {
   }
 }
 function _collectSafetyNetCopilotHookFiles(dirPath, errors) {
-  if (!existsSync5(dirPath))
+  if (!existsSync6(dirPath))
     return [];
   const matches = [];
   for (const filename of _listJsonFiles(dirPath, errors)) {
@@ -5099,7 +5202,7 @@ function _collectSafetyNetCopilotHookFiles(dirPath, errors) {
   return matches;
 }
 function _collectCopilotInlineConfig(configPath, errors) {
-  if (!existsSync5(configPath))
+  if (!existsSync6(configPath))
     return;
   const config = _readCopilotConfigFile(configPath, errors);
   if (!config)
@@ -5151,7 +5254,7 @@ function _checkCopilotEnabled(homeDir, cwd, copilotCliVersion, errors) {
   const repoHookPaths = _collectSafetyNetCopilotHookFiles(repoHookDir, errors);
   const userHookSupport = _supportsCopilotUserHookFiles(copilotCliVersion);
   const userHookErrors = userHookSupport === true ? errors : undefined;
-  const userHookFiles = existsSync5(userHookDir) ? _listJsonFiles(userHookDir, userHookErrors) : [];
+  const userHookFiles = existsSync6(userHookDir) ? _listJsonFiles(userHookDir, userHookErrors) : [];
   const userHookPaths = [];
   for (const filename of userHookFiles) {
     const configPath = join4(userHookDir, filename);
@@ -5441,7 +5544,7 @@ function printReport(report) {
 }
 
 // src/bin/explain/config.ts
-import { existsSync as existsSync6 } from "node:fs";
+import { existsSync as existsSync7 } from "node:fs";
 import { resolve as resolve4 } from "node:path";
 
 // src/core/env.ts
@@ -5454,7 +5557,7 @@ function envTruthy(name) {
 function getConfigSource(options) {
   const projectPath = getProjectConfigPath(options?.cwd);
   let invalidProjectPath = null;
-  if (existsSync6(projectPath)) {
+  if (existsSync7(projectPath)) {
     const validation = validateConfigFile(projectPath);
     if (validation.errors.length === 0) {
       return { configSource: projectPath, configValid: true };
@@ -5462,7 +5565,7 @@ function getConfigSource(options) {
     invalidProjectPath = projectPath;
   }
   const userPath = options?.userConfigPath ?? getUserConfigPath();
-  if (existsSync6(userPath)) {
+  if (existsSync7(userPath)) {
     const validation = validateConfigFile(userPath);
     return { configSource: userPath, configValid: validation.errors.length === 0 };
   }
@@ -5561,7 +5664,7 @@ function explainInnerSegments(innerCmd, depth, options, steps) {
     const result = explainSegment(segment, depth + 1, {
       ...options,
       effectiveCwd,
-      envAssignments: shellGitContextState.effectiveEnvAssignments
+      envAssignments: getSegmentGitContextEnvAssignments(segment, shellGitContextState)
     }, steps);
     if (result)
       return result;
@@ -5983,7 +6086,7 @@ function explainCommand2(command, options) {
     const result = explainSegment(segment, 0, {
       ...analyzeOpts,
       effectiveCwd,
-      envAssignments: shellGitContextState.effectiveEnvAssignments
+      envAssignments: getSegmentGitContextEnvAssignments(segment, shellGitContextState)
     }, segmentSteps);
     if (result) {
       blocked = true;
@@ -6464,7 +6567,7 @@ function showCommandHelp(commandName) {
 }
 
 // src/core/audit.ts
-import { appendFileSync, existsSync as existsSync7, mkdirSync } from "node:fs";
+import { appendFileSync, existsSync as existsSync8, mkdirSync } from "node:fs";
 import { homedir as homedir5 } from "node:os";
 import { join as join5 } from "node:path";
 function sanitizeSessionIdForFilename(sessionId) {
@@ -6487,7 +6590,7 @@ function writeAuditLog(sessionId, command, segment, reason, cwd, options = {}) {
   const home = options.homeDir ?? homedir5();
   const logsDir = join5(home, ".cc-safety-net", "logs");
   try {
-    if (!existsSync7(logsDir)) {
+    if (!existsSync8(logsDir)) {
       mkdirSync(logsDir, { recursive: true });
     }
     const logFile = join5(logsDir, `${safeSessionId}.jsonl`);
@@ -6745,7 +6848,7 @@ async function runGeminiCLIHook() {
 }
 
 // src/bin/statusline.ts
-import { existsSync as existsSync8, readFileSync as readFileSync6 } from "node:fs";
+import { existsSync as existsSync9, readFileSync as readFileSync6 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
 import { join as join6 } from "node:path";
 async function readStdinAsync() {
@@ -6775,7 +6878,7 @@ function getSettingsPath() {
 }
 function isPluginEnabled() {
   const settingsPath = getSettingsPath();
-  if (!existsSync8(settingsPath)) {
+  if (!existsSync9(settingsPath)) {
     return false;
   }
   try {
@@ -6830,7 +6933,7 @@ async function printStatusline() {
 }
 
 // src/bin/verify-config.ts
-import { existsSync as existsSync9, readFileSync as readFileSync7, writeFileSync } from "node:fs";
+import { existsSync as existsSync10, readFileSync as readFileSync7, writeFileSync } from "node:fs";
 import { resolve as resolve5 } from "node:path";
 var HEADER = "Safety Net Config";
 var SEPARATOR = "═".repeat(HEADER.length);
@@ -6885,14 +6988,14 @@ function verifyConfig(options = {}) {
   let hasErrors = false;
   const configsChecked = [];
   printHeader();
-  if (existsSync9(userConfig)) {
+  if (existsSync10(userConfig)) {
     const result = validateConfigFile(userConfig);
     configsChecked.push({ scope: "User", path: userConfig, result });
     if (result.errors.length > 0) {
       hasErrors = true;
     }
   }
-  if (existsSync9(projectConfig)) {
+  if (existsSync10(projectConfig)) {
     const result = validateConfigFile(projectConfig);
     configsChecked.push({
       scope: "Project",

--- a/dist/core/analyze/analyze-command.d.ts
+++ b/dist/core/analyze/analyze-command.d.ts
@@ -4,3 +4,5 @@ export type InternalOptions = AnalyzeOptions & {
     config: Config;
 };
 export declare function analyzeCommandInternal(command: string, depth: number, options: InternalOptions): AnalyzeResult | null;
+export declare function getShellGitContextEnvAssignments(tokens: readonly string[]): Map<string, string>;
+export declare function getExportedGitContextEnvAssignments(tokens: readonly string[], shellGitContextAssignments: ReadonlyMap<string, string>): Map<string, string>;

--- a/dist/core/analyze/analyze-command.d.ts
+++ b/dist/core/analyze/analyze-command.d.ts
@@ -9,6 +9,7 @@ export interface ShellGitContextEnvState {
     shellAssignments: Map<string, string>;
     exportedNames: Set<string>;
     allexport: boolean;
+    keywordExport: boolean;
 }
 export declare function createShellGitContextEnvState(effectiveEnvAssignments?: ReadonlyMap<string, string>): ShellGitContextEnvState;
 export declare function applyShellGitContextEnvSegment(tokens: readonly string[], state: ShellGitContextEnvState): void;

--- a/dist/core/analyze/analyze-command.d.ts
+++ b/dist/core/analyze/analyze-command.d.ts
@@ -4,5 +4,11 @@ export type InternalOptions = AnalyzeOptions & {
     config: Config;
 };
 export declare function analyzeCommandInternal(command: string, depth: number, options: InternalOptions): AnalyzeResult | null;
-export declare function getShellGitContextEnvAssignments(tokens: readonly string[]): Map<string, string>;
-export declare function getExportedGitContextEnvAssignments(tokens: readonly string[], shellGitContextAssignments: ReadonlyMap<string, string>): Map<string, string>;
+export interface ShellGitContextEnvState {
+    effectiveEnvAssignments?: ReadonlyMap<string, string>;
+    shellAssignments: Map<string, string>;
+    exportedNames: Set<string>;
+    allexport: boolean;
+}
+export declare function createShellGitContextEnvState(effectiveEnvAssignments?: ReadonlyMap<string, string>): ShellGitContextEnvState;
+export declare function applyShellGitContextEnvSegment(tokens: readonly string[], state: ShellGitContextEnvState): void;

--- a/dist/core/analyze/analyze-command.d.ts
+++ b/dist/core/analyze/analyze-command.d.ts
@@ -13,3 +13,4 @@ export interface ShellGitContextEnvState {
 }
 export declare function createShellGitContextEnvState(effectiveEnvAssignments?: ReadonlyMap<string, string>): ShellGitContextEnvState;
 export declare function applyShellGitContextEnvSegment(tokens: readonly string[], state: ShellGitContextEnvState): void;
+export declare function getSegmentGitContextEnvAssignments(tokens: readonly string[], state: ShellGitContextEnvState): ReadonlyMap<string, string> | undefined;

--- a/dist/core/analyze/parallel.d.ts
+++ b/dist/core/analyze/parallel.d.ts
@@ -1,3 +1,4 @@
+import { type AnalyzeNestedOverrides } from '@/types';
 export interface ParallelAnalyzeContext {
     cwd: string | undefined;
     originalCwd: string | undefined;
@@ -5,7 +6,7 @@ export interface ParallelAnalyzeContext {
     allowTmpdirVar: boolean;
     envAssignments?: ReadonlyMap<string, string>;
     worktreeMode?: boolean;
-    analyzeNested: (command: string) => string | null;
+    analyzeNested: (command: string, overrides?: AnalyzeNestedOverrides) => string | null;
 }
 export declare function analyzeParallel(tokens: readonly string[], context: ParallelAnalyzeContext): string | null;
 export declare function extractParallelChildCommand(tokens: readonly string[]): string[];

--- a/dist/core/analyze/parallel.d.ts
+++ b/dist/core/analyze/parallel.d.ts
@@ -3,6 +3,8 @@ export interface ParallelAnalyzeContext {
     originalCwd: string | undefined;
     paranoidRm: boolean | undefined;
     allowTmpdirVar: boolean;
+    envAssignments?: ReadonlyMap<string, string>;
+    worktreeMode?: boolean;
     analyzeNested: (command: string) => string | null;
 }
 export declare function analyzeParallel(tokens: readonly string[], context: ParallelAnalyzeContext): string | null;

--- a/dist/core/analyze/segment.d.ts
+++ b/dist/core/analyze/segment.d.ts
@@ -1,10 +1,10 @@
-import { type AnalyzeOptions, type Config } from '@/types';
+import { type AnalyzeNestedOverrides, type AnalyzeOptions, type Config } from '@/types';
 export declare const REASON_INTERPRETER_DANGEROUS = "Detected potentially dangerous command in interpreter code.";
 export declare const REASON_INTERPRETER_BLOCKED = "Interpreter one-liners are blocked in paranoid mode.";
 export type InternalOptions = AnalyzeOptions & {
     config: Config;
     effectiveCwd: string | null | undefined;
-    analyzeNested: (command: string) => string | null;
+    analyzeNested: (command: string, overrides?: AnalyzeNestedOverrides) => string | null;
 };
 export declare function analyzeSegment(tokens: string[], depth: number, options: InternalOptions): string | null;
 export declare function segmentChangesCwd(segment: readonly string[]): boolean;

--- a/dist/core/analyze/xargs.d.ts
+++ b/dist/core/analyze/xargs.d.ts
@@ -3,6 +3,8 @@ export interface XargsAnalyzeContext {
     originalCwd: string | undefined;
     paranoidRm: boolean | undefined;
     allowTmpdirVar: boolean;
+    envAssignments?: ReadonlyMap<string, string>;
+    worktreeMode?: boolean;
 }
 export declare function analyzeXargs(tokens: readonly string[], context: XargsAnalyzeContext): string | null;
 interface XargsParseResult {

--- a/dist/core/path.d.ts
+++ b/dist/core/path.d.ts
@@ -1,0 +1,1 @@
+export declare function resolveChdirTarget(baseCwd: string, target: string): string;

--- a/dist/core/rules-git.d.ts
+++ b/dist/core/rules-git.d.ts
@@ -1,4 +1,4 @@
-declare const TRUSTED_GIT_BINARIES: readonly ["/usr/bin/git", "/usr/local/bin/git", "/opt/homebrew/bin/git"];
+declare const TRUSTED_GIT_BINARIES: readonly ["/usr/bin/git", "/usr/local/bin/git", "/opt/homebrew/bin/git", "C:\\Program Files\\Git\\cmd\\git.exe", "C:\\Program Files\\Git\\bin\\git.exe"];
 export interface GitAnalyzeOptions {
     cwd?: string;
     envAssignments?: ReadonlyMap<string, string>;
@@ -15,5 +15,6 @@ declare function extractGitSubcommandAndRest(tokens: readonly string[]): {
     rest: string[];
 };
 declare function getCheckoutPositionalArgs(tokens: readonly string[]): string[];
+declare function effectiveGitConfigEnablesRecursiveSubmodules(cwd: string, gitBinary?: string | null): boolean;
 /** @internal Exported for testing */
-export { extractGitSubcommandAndRest as _extractGitSubcommandAndRest, getCheckoutPositionalArgs as _getCheckoutPositionalArgs, TRUSTED_GIT_BINARIES as _TRUSTED_GIT_BINARIES, };
+export { effectiveGitConfigEnablesRecursiveSubmodules as _effectiveGitConfigEnablesRecursiveSubmodules, extractGitSubcommandAndRest as _extractGitSubcommandAndRest, getCheckoutPositionalArgs as _getCheckoutPositionalArgs, TRUSTED_GIT_BINARIES as _TRUSTED_GIT_BINARIES, };

--- a/dist/core/rules-git.d.ts
+++ b/dist/core/rules-git.d.ts
@@ -1,4 +1,14 @@
-export declare function analyzeGit(tokens: readonly string[]): string | null;
+export interface GitAnalyzeOptions {
+    cwd?: string;
+    envAssignments?: ReadonlyMap<string, string>;
+    worktreeMode?: boolean;
+}
+export interface GitWorktreeRelaxation {
+    originalReason: string;
+    gitCwd: string;
+}
+export declare function analyzeGit(tokens: readonly string[], options?: GitAnalyzeOptions): string | null;
+export declare function getGitWorktreeRelaxation(tokens: readonly string[], options?: GitAnalyzeOptions): GitWorktreeRelaxation | null;
 declare function extractGitSubcommandAndRest(tokens: readonly string[]): {
     subcommand: string | null;
     rest: string[];

--- a/dist/core/rules-git.d.ts
+++ b/dist/core/rules-git.d.ts
@@ -1,3 +1,4 @@
+declare const TRUSTED_GIT_BINARIES: readonly ["/usr/bin/git", "/usr/local/bin/git", "/opt/homebrew/bin/git"];
 export interface GitAnalyzeOptions {
     cwd?: string;
     envAssignments?: ReadonlyMap<string, string>;
@@ -15,4 +16,4 @@ declare function extractGitSubcommandAndRest(tokens: readonly string[]): {
 };
 declare function getCheckoutPositionalArgs(tokens: readonly string[]): string[];
 /** @internal Exported for testing */
-export { extractGitSubcommandAndRest as _extractGitSubcommandAndRest, getCheckoutPositionalArgs as _getCheckoutPositionalArgs, };
+export { extractGitSubcommandAndRest as _extractGitSubcommandAndRest, getCheckoutPositionalArgs as _getCheckoutPositionalArgs, TRUSTED_GIT_BINARIES as _TRUSTED_GIT_BINARIES, };

--- a/dist/core/shell.d.ts
+++ b/dist/core/shell.d.ts
@@ -1,4 +1,8 @@
 export declare function splitShellCommands(command: string): string[][];
+export declare function parseEnvAssignment(token: string): {
+    name: string;
+    value: string;
+} | null;
 export interface EnvStrippingResult {
     tokens: string[];
     envAssignments: Map<string, string>;

--- a/dist/core/shell.d.ts
+++ b/dist/core/shell.d.ts
@@ -2,14 +2,16 @@ export declare function splitShellCommands(command: string): string[][];
 export interface EnvStrippingResult {
     tokens: string[];
     envAssignments: Map<string, string>;
+    cwd?: string | null;
 }
 export declare function stripEnvAssignmentsWithInfo(tokens: string[]): EnvStrippingResult;
 export interface WrapperStrippingResult {
     tokens: string[];
     envAssignments: Map<string, string>;
+    cwd?: string | null;
 }
-export declare function stripWrappers(tokens: string[]): string[];
-export declare function stripWrappersWithInfo(tokens: string[]): WrapperStrippingResult;
+export declare function stripWrappers(tokens: string[], cwd?: string | null): string[];
+export declare function stripWrappersWithInfo(tokens: string[], cwd?: string | null): WrapperStrippingResult;
 export declare function extractShortOpts(tokens: readonly string[], options?: {
     readonly shortOptsWithValue?: ReadonlySet<string>;
 }): Set<string>;

--- a/dist/core/worktree.d.ts
+++ b/dist/core/worktree.d.ts
@@ -1,4 +1,5 @@
 export declare const GIT_GLOBAL_OPTS_WITH_VALUE: ReadonlySet<string>;
+export declare const GIT_CONTEXT_ENV_OVERRIDES: readonly ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"];
 export interface GitExecutionContext {
     gitCwd: string | null;
     hasExplicitGitContext: boolean;

--- a/dist/core/worktree.d.ts
+++ b/dist/core/worktree.d.ts
@@ -7,3 +7,5 @@ export interface GitExecutionContext {
 export declare function hasGitContextEnvOverride(envAssignments?: ReadonlyMap<string, string>): boolean;
 export declare function getGitExecutionContext(tokens: readonly string[], cwd: string | undefined): GitExecutionContext;
 export declare function isLinkedWorktree(cwd: string): boolean;
+/** @internal Exported for testing */
+export declare function normalizePathForComparison(path: string): string;

--- a/dist/core/worktree.d.ts
+++ b/dist/core/worktree.d.ts
@@ -1,0 +1,8 @@
+export declare const GIT_GLOBAL_OPTS_WITH_VALUE: ReadonlySet<string>;
+export interface GitExecutionContext {
+    gitCwd: string | null;
+    hasExplicitGitContext: boolean;
+}
+export declare function hasGitContextEnvOverride(envAssignments?: ReadonlyMap<string, string>): boolean;
+export declare function getGitExecutionContext(tokens: readonly string[], cwd: string | undefined): GitExecutionContext;
+export declare function isLinkedWorktree(cwd: string): boolean;

--- a/dist/core/worktree.d.ts
+++ b/dist/core/worktree.d.ts
@@ -1,5 +1,5 @@
 export declare const GIT_GLOBAL_OPTS_WITH_VALUE: ReadonlySet<string>;
-export declare const GIT_CONTEXT_ENV_OVERRIDES: readonly ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"];
+export declare const GIT_CONTEXT_ENV_OVERRIDES: readonly ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"];
 export interface GitExecutionContext {
     gitCwd: string | null;
     hasExplicitGitContext: boolean;

--- a/dist/core/worktree.d.ts
+++ b/dist/core/worktree.d.ts
@@ -1,5 +1,6 @@
 export declare const GIT_GLOBAL_OPTS_WITH_VALUE: ReadonlySet<string>;
 export declare const GIT_CONTEXT_ENV_OVERRIDES: readonly ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"];
+export declare const GIT_CONFIG_AFFECTING_ENV_NAMES: ReadonlySet<string>;
 export interface GitExecutionContext {
     gitCwd: string | null;
     hasExplicitGitContext: boolean;
@@ -9,3 +10,6 @@ export declare function getGitExecutionContext(tokens: readonly string[], cwd: s
 export declare function isLinkedWorktree(cwd: string): boolean;
 /** @internal Exported for testing */
 export declare function normalizePathForComparison(path: string): string;
+declare function parseGitConfigValue(value: string): string;
+/** @internal Exported for testing */
+export { parseGitConfigValue as _parseGitConfigValue };

--- a/dist/index.js
+++ b/dist/index.js
@@ -565,7 +565,7 @@ function worktreeGitdirBacklinkMatches(gitDir, dotGitPath) {
   }
   const linkedDotGitPath = isAbsolute(rawBacklink) ? rawBacklink : resolve(gitDir, rawBacklink);
   try {
-    return realpathSync(linkedDotGitPath) === realpathSync(dotGitPath);
+    return sameFilesystemPath(linkedDotGitPath, dotGitPath);
   } catch {
     return false;
   }
@@ -581,10 +581,27 @@ function worktreeConfigMatchesRoot(gitDir, worktreeRoot) {
   }
   const resolvedConfiguredWorktree = isAbsolute(configuredWorktree) ? configuredWorktree : resolve(gitDir, configuredWorktree);
   try {
-    return realpathSync(resolvedConfiguredWorktree) === realpathSync(worktreeRoot);
+    return sameFilesystemPath(resolvedConfiguredWorktree, worktreeRoot);
   } catch {
     return false;
   }
+}
+function sameFilesystemPath(left, right) {
+  try {
+    const leftStat = statSync(left);
+    const rightStat = statSync(right);
+    if (leftStat.ino !== 0 && rightStat.ino !== 0 && leftStat.dev === rightStat.dev && leftStat.ino === rightStat.ino) {
+      return true;
+    }
+  } catch {}
+  return normalizePathForComparison(realpathSync(left)) === normalizePathForComparison(realpathSync(right));
+}
+function normalizePathForComparison(path) {
+  let normalized = path.replace(/\\/g, "/");
+  if (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 function readCoreWorktree(configPath) {
   const content = readFileSync(configPath, "utf-8");
@@ -2426,7 +2443,7 @@ import { realpathSync as realpathSync3 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { normalize, resolve as resolve2, sep as sep3 } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
-function normalizePathForComparison(p) {
+function normalizePathForComparison2(p) {
   let normalized = normalize(p);
   if (IS_WINDOWS) {
     normalized = normalized.replace(/\//g, "\\");
@@ -2566,8 +2583,8 @@ function isTempTarget(path, allowTmpdirVar) {
     return true;
   }
   const systemTmpdir = tmpdir();
-  const normalizedTmpdir = normalizePathForComparison(systemTmpdir);
-  const pathToCompare = normalizePathForComparison(normalized);
+  const normalizedTmpdir = normalizePathForComparison2(systemTmpdir);
+  const pathToCompare = normalizePathForComparison2(normalized);
   if (pathToCompare.startsWith(`${normalizedTmpdir}${sep3}`) || pathToCompare === normalizedTmpdir) {
     return true;
   }
@@ -2586,7 +2603,7 @@ function getHomeDirForRmPolicy() {
 }
 function isCwdHomeForRmPolicy(cwd, homeDir) {
   try {
-    return normalizePathForComparison(cwd) === normalizePathForComparison(homeDir);
+    return normalizePathForComparison2(cwd) === normalizePathForComparison2(homeDir);
   } catch {
     return false;
   }
@@ -2599,11 +2616,11 @@ function isCwdSelfTarget(target, cwd) {
     const resolved = resolve2(cwd, target);
     const realCwd = realpathSync3(cwd);
     const realResolved = realpathSync3(resolved);
-    return normalizePathForComparison(realResolved) === normalizePathForComparison(realCwd);
+    return normalizePathForComparison2(realResolved) === normalizePathForComparison2(realCwd);
   } catch {
     try {
       const resolved = resolve2(cwd, target);
-      return normalizePathForComparison(resolved) === normalizePathForComparison(cwd);
+      return normalizePathForComparison2(resolved) === normalizePathForComparison2(cwd);
     } catch {
       return false;
     }
@@ -2619,8 +2636,8 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   if (target.startsWith("/") || /^[A-Za-z]:[\\/]/.test(target)) {
     try {
-      const normalizedTarget = normalizePathForComparison(target);
-      const normalizedCwd = `${normalizePathForComparison(originalCwd)}${sep3}`;
+      const normalizedTarget = normalizePathForComparison2(target);
+      const normalizedCwd = `${normalizePathForComparison2(originalCwd)}${sep3}`;
       return normalizedTarget.startsWith(normalizedCwd);
     } catch {
       return false;
@@ -2629,8 +2646,8 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   if (target.startsWith("./") || target.startsWith(".\\") || !target.includes("/") && !target.includes("\\")) {
     try {
       const resolved = resolve2(resolveCwd, target);
-      const normalizedResolved = normalizePathForComparison(resolved);
-      const normalizedOriginalCwd = normalizePathForComparison(originalCwd);
+      const normalizedResolved = normalizePathForComparison2(resolved);
+      const normalizedOriginalCwd = normalizePathForComparison2(originalCwd);
       return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep3}`) || normalizedResolved === normalizedOriginalCwd;
     } catch {
       return false;
@@ -2641,8 +2658,8 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   try {
     const resolved = resolve2(resolveCwd, target);
-    const normalizedResolved = normalizePathForComparison(resolved);
-    const normalizedCwd = normalizePathForComparison(originalCwd);
+    const normalizedResolved = normalizePathForComparison2(resolved);
+    const normalizedCwd = normalizePathForComparison2(originalCwd);
     return normalizedResolved.startsWith(`${normalizedCwd}${sep3}`) || normalizedResolved === normalizedCwd;
   } catch {
     return false;

--- a/dist/index.js
+++ b/dist/index.js
@@ -944,7 +944,11 @@ function stripWrappersWithInfo(tokens, cwd) {
       break;
     }
     if (head === "sudo") {
-      result = stripSudo(result);
+      const sudoResult = stripSudoWithInfo(result, currentCwd);
+      result = sudoResult.tokens;
+      if (sudoResult.cwd !== undefined) {
+        currentCwd = sudoResult.cwd;
+      }
     }
     if (head === "env") {
       const envResult = stripEnvWithInfo(result, currentCwd);
@@ -969,17 +973,24 @@ function stripWrappersWithInfo(tokens, cwd) {
   return { tokens: finalTokens, envAssignments: allEnvAssignments, cwd: currentCwd };
 }
 var SUDO_OPTS_WITH_VALUE = new Set(["-u", "-g", "-C", "-D", "-h", "-p", "-r", "-t", "-T", "-U"]);
-function stripSudo(tokens) {
+function stripSudoWithInfo(tokens, cwd) {
   let i = 1;
+  let currentCwd = cwd;
   while (i < tokens.length) {
     const token = tokens[i];
     if (!token)
       break;
     if (token === "--") {
-      return tokens.slice(i + 1);
+      return { tokens: tokens.slice(i + 1), cwd: currentCwd };
     }
     if (!token.startsWith("-")) {
       break;
+    }
+    if (token === "-D") {
+      const target = tokens[i + 1];
+      currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
+      i += 2;
+      continue;
     }
     if (SUDO_OPTS_WITH_VALUE.has(token)) {
       i += 2;
@@ -987,7 +998,7 @@ function stripSudo(tokens) {
     }
     i++;
   }
-  return tokens.slice(i);
+  return { tokens: tokens.slice(i), cwd: currentCwd };
 }
 var ENV_OPTS_NO_VALUE = new Set(["-i", "-0", "--null"]);
 var ENV_OPTS_WITH_VALUE = new Set([
@@ -1002,21 +1013,65 @@ var ENV_OPTS_WITH_VALUE = new Set([
 function stripEnvWithInfo(tokens, cwd) {
   const envAssignments = new Map;
   let currentCwd = cwd;
+  let expandedTokens = tokens;
   let i = 1;
-  while (i < tokens.length) {
-    const token = tokens[i];
+  while (i < expandedTokens.length) {
+    const token = expandedTokens[i];
     if (!token)
       break;
     if (token === "--") {
-      return { tokens: tokens.slice(i + 1), envAssignments };
+      return { tokens: expandedTokens.slice(i + 1), envAssignments, cwd: currentCwd };
     }
     if (ENV_OPTS_NO_VALUE.has(token)) {
       i++;
       continue;
     }
+    if (token === "-S" || token === "--split-string") {
+      const splitValue = expandedTokens[i + 1];
+      const splitTokens = splitValue !== undefined ? parseEnvSplitString(splitValue) : null;
+      if (!splitTokens) {
+        currentCwd = null;
+        i += 2;
+        continue;
+      }
+      expandedTokens = [
+        ...expandedTokens.slice(0, i),
+        ...splitTokens,
+        ...expandedTokens.slice(i + 2)
+      ];
+      continue;
+    }
+    if (token.startsWith("-S") && token.length > 2) {
+      const splitTokens = parseEnvSplitString(token.slice("-S".length));
+      if (!splitTokens) {
+        currentCwd = null;
+        i++;
+        continue;
+      }
+      expandedTokens = [
+        ...expandedTokens.slice(0, i),
+        ...splitTokens,
+        ...expandedTokens.slice(i + 1)
+      ];
+      continue;
+    }
+    if (token.startsWith("--split-string=")) {
+      const splitTokens = parseEnvSplitString(token.slice("--split-string=".length));
+      if (!splitTokens) {
+        currentCwd = null;
+        i++;
+        continue;
+      }
+      expandedTokens = [
+        ...expandedTokens.slice(0, i),
+        ...splitTokens,
+        ...expandedTokens.slice(i + 1)
+      ];
+      continue;
+    }
     if (ENV_OPTS_WITH_VALUE.has(token)) {
       if (token === "-C" || token === "--chdir") {
-        const target = tokens[i + 1];
+        const target = expandedTokens[i + 1];
         currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
       }
       i += 2;
@@ -1026,8 +1081,8 @@ function stripEnvWithInfo(tokens, cwd) {
       i++;
       continue;
     }
-    if (token.startsWith("-C=") || token.startsWith("--chdir=")) {
-      const target = token.startsWith("-C=") ? token.slice("-C=".length) : token.slice("--chdir=".length);
+    if (token.startsWith("-C") && token.length > 2 || token.startsWith("--chdir=")) {
+      const target = token.startsWith("--chdir=") ? token.slice("--chdir=".length) : token.startsWith("-C=") ? token.slice("-C=".length) : token.slice("-C".length);
       currentCwd = resolveWrapperCwd(currentCwd, target);
       i++;
       continue;
@@ -1047,7 +1102,22 @@ function stripEnvWithInfo(tokens, cwd) {
     envAssignments.set(assignment.name, assignment.value);
     i++;
   }
-  return { tokens: tokens.slice(i), envAssignments, cwd: currentCwd };
+  return { tokens: expandedTokens.slice(i), envAssignments, cwd: currentCwd };
+}
+function parseEnvSplitString(value) {
+  if (hasUnclosedQuotes(value)) {
+    return null;
+  }
+  const parsed = $parse(value, ENV_PROXY);
+  const result = [];
+  for (const entry of parsed) {
+    const token = _getCommandTokenText(entry);
+    if (token === null) {
+      return null;
+    }
+    result.push(token);
+  }
+  return result;
 }
 function resolveWrapperCwd(cwd, target) {
   if (target === "") {
@@ -2152,7 +2222,7 @@ function analyzeParallel(tokens, context) {
   }
   const { template, args, hasPlaceholder, runsRemotely } = parseResult;
   if (template.length === 0) {
-    const nestedOverrides2 = runsRemotely ? { worktreeMode: false } : undefined;
+    const nestedOverrides2 = buildCommandsModeOverrides(context, runsRemotely);
     for (const arg of args) {
       const reason = context.analyzeNested(arg, nestedOverrides2);
       if (reason) {
@@ -2252,13 +2322,16 @@ function analyzeParallel(tokens, context) {
     }
   }
   if (head === "git") {
-    const gitResult = analyzeGit(childTokens, {
-      cwd: childCwd,
-      envAssignments: childEnvAssignments,
-      worktreeMode: runsRemotely ? false : context.worktreeMode
-    });
-    if (gitResult) {
-      return gitResult;
+    const gitTokenSets = !hasPlaceholder && args.length > 0 ? args.map((arg) => [...childTokens, arg]) : [childTokens];
+    for (const gitTokens of gitTokenSets) {
+      const gitResult = analyzeGit(gitTokens, {
+        cwd: childCwd,
+        envAssignments: childEnvAssignments,
+        worktreeMode: runsRemotely ? false : context.worktreeMode
+      });
+      if (gitResult) {
+        return gitResult;
+      }
     }
   }
   return null;
@@ -2272,6 +2345,19 @@ function buildNestedOverrides(envAssignments, cwd, runsRemotely) {
     overrides.worktreeMode = false;
   }
   return overrides;
+}
+function buildCommandsModeOverrides(context, runsRemotely) {
+  const overrides = {};
+  if (context.envAssignments) {
+    overrides.envAssignments = context.envAssignments;
+  }
+  if (context.cwd !== undefined) {
+    overrides.effectiveCwd = context.cwd;
+  }
+  if (runsRemotely) {
+    overrides.worktreeMode = false;
+  }
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 function parseParallelCommand(tokens) {
   const parallelOptsWithValue = new Set([
@@ -2406,8 +2492,9 @@ function isPathOrSubpath(path, basePath) {
 // src/core/analyze/xargs.ts
 var REASON_XARGS_RM = "xargs rm -rf with dynamic input is dangerous. Use explicit file list instead.";
 var REASON_XARGS_SHELL = "xargs with shell -c can execute arbitrary commands from dynamic input.";
+var XARGS_APPENDED_INPUT = "__CC_SAFETY_NET_XARGS_INPUT__";
 function analyzeXargs(tokens, context) {
-  const { childTokens: rawChildTokens } = extractXargsChildCommandWithInfo(tokens);
+  const { childTokens: rawChildTokens, replacementToken } = extractXargsChildCommandWithInfo(tokens);
   const childWrapperInfo = stripWrappersWithInfo(rawChildTokens, context.cwd);
   let childTokens = childWrapperInfo.tokens;
   const childEnvAssignments = new Map(context.envAssignments ?? []);
@@ -2445,7 +2532,8 @@ function analyzeXargs(tokens, context) {
     }
   }
   if (head === "git") {
-    const gitResult = analyzeGit(childTokens, {
+    const gitTokens = replacementToken === null ? [...childTokens, XARGS_APPENDED_INPUT] : childTokens;
+    const gitResult = analyzeGit(gitTokens, {
       cwd: childCwd,
       envAssignments: childEnvAssignments,
       worktreeMode: context.worktreeMode
@@ -2660,7 +2748,10 @@ function analyzeSegment(tokens, depth, options) {
       if (options.paranoidInterpreters) {
         return REASON_INTERPRETER_BLOCKED + PARANOID_INTERPRETERS_SUFFIX;
       }
-      const innerReason = options.analyzeNested(codeArg);
+      const innerReason = options.analyzeNested(codeArg, {
+        effectiveCwd: nestedEffectiveCwd,
+        envAssignments
+      });
       if (innerReason) {
         return innerReason;
       }
@@ -2670,7 +2761,11 @@ function analyzeSegment(tokens, depth, options) {
     }
   }
   if (normalizedHead === "busybox" && stripped.length > 1) {
-    return analyzeSegment(stripped.slice(1), depth, options);
+    return analyzeSegment(stripped.slice(1), depth, {
+      ...options,
+      effectiveCwd: nestedEffectiveCwd,
+      envAssignments
+    });
   }
   const isGit = basename.toLowerCase() === "git";
   const isRm = basename === "rm";
@@ -2814,6 +2909,7 @@ function stripLeadingGrouping(tokens) {
 // src/core/analyze/analyze-command.ts
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
+var GIT_CONTEXT_ENV_OVERRIDE_NAMES = new Set(GIT_CONTEXT_ENV_OVERRIDES);
 function analyzeCommandInternal(command, depth, options) {
   if (depth >= MAX_RECURSION_DEPTH) {
     return { reason: REASON_RECURSION_LIMIT, segment: command };
@@ -2824,8 +2920,10 @@ function analyzeCommandInternal(command, depth, options) {
   }
   const originalCwd = options.cwd;
   let effectiveCwd = options.effectiveCwd !== undefined ? options.effectiveCwd : options.cwd;
+  let effectiveEnvAssignments = options.envAssignments;
   for (const segment of segments) {
     const segmentStr = segment.join(" ");
+    const segmentEnvAssignments = effectiveEnvAssignments;
     if (segment.length === 1 && segment[0]?.includes(" ")) {
       const textReason = dangerousInText(segment[0]);
       if (textReason) {
@@ -2840,12 +2938,13 @@ function analyzeCommandInternal(command, depth, options) {
       ...options,
       cwd: originalCwd,
       effectiveCwd,
+      envAssignments: segmentEnvAssignments,
       analyzeNested: (nestedCommand, overrides) => {
         const nestedEffectiveCwd = overrides && Object.hasOwn(overrides, "effectiveCwd") ? overrides.effectiveCwd : effectiveCwd;
         return analyzeCommandInternal(nestedCommand, depth + 1, {
           ...options,
           effectiveCwd: nestedEffectiveCwd,
-          envAssignments: overrides?.envAssignments ?? options.envAssignments,
+          envAssignments: overrides?.envAssignments ?? segmentEnvAssignments,
           worktreeMode: overrides?.worktreeMode ?? options.worktreeMode
         })?.reason ?? null;
       }
@@ -2856,8 +2955,32 @@ function analyzeCommandInternal(command, depth, options) {
     if (segmentChangesCwd(segment)) {
       effectiveCwd = null;
     }
+    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment);
+    if (exportedEnvAssignments.size > 0) {
+      const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
+      for (const [k, v] of exportedEnvAssignments) {
+        nextEnvAssignments.set(k, v);
+      }
+      effectiveEnvAssignments = nextEnvAssignments;
+    }
   }
   return null;
+}
+function getExportedGitContextEnvAssignments(tokens) {
+  const result = new Map;
+  if (tokens[0] !== "export") {
+    return result;
+  }
+  for (const token of tokens.slice(1)) {
+    if (token.startsWith("-")) {
+      return new Map;
+    }
+    const assignment = parseEnvAssignment(token);
+    if (assignment && GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
+      result.set(assignment.name, assignment.value);
+    }
+  }
+  return result;
 }
 
 // src/core/config.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -400,7 +400,7 @@ function hasRecursiveForceFlags(tokens) {
 
 // src/core/shell.ts
 import { lstatSync as lstatSync2, realpathSync as realpathSync2 } from "node:fs";
-import { dirname as dirname2, isAbsolute as isAbsolute2 } from "node:path";
+import { dirname as dirname2, isAbsolute as isAbsolute2, parse as parsePath2, sep as sep2 } from "node:path";
 
 // node_modules/shell-quote/index.js
 var $quote = require_quote();
@@ -432,7 +432,7 @@ var PARANOID_INTERPRETERS_SUFFIX = `
 
 // src/core/worktree.ts
 import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, parse as parsePath, resolve, sep } from "node:path";
 var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
   "-c",
   "-C",
@@ -625,8 +625,9 @@ function resolveGitCwd(baseCwd, target) {
   }
 }
 function resolveChdirTarget(baseCwd, target) {
-  let current = isAbsolute(target) ? "/" : baseCwd;
-  for (const component of target.split("/")) {
+  const root = isAbsolute(target) ? getPathRoot(target) : "";
+  let current = root || baseCwd;
+  for (const component of getPathComponents(root ? target.slice(root.length) : target)) {
     if (component === "" || component === ".") {
       continue;
     }
@@ -640,7 +641,14 @@ function resolveChdirTarget(baseCwd, target) {
   return current;
 }
 function appendPathWithoutNormalizing(base, target) {
-  return base.endsWith("/") ? `${base}${target}` : `${base}/${target}`;
+  return base.endsWith("/") || base.endsWith("\\") ? `${base}${target}` : `${base}${sep}${target}`;
+}
+function getPathRoot(target) {
+  return parsePath(target).root;
+}
+function getPathComponents(target) {
+  const separator = process.platform === "win32" ? /[\\/]+/ : /\/+/;
+  return target.split(separator);
 }
 function isDirectory(path) {
   try {
@@ -1148,6 +1156,13 @@ function _stripAttachedIoNumbers(command) {
 var ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
 var ENV_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES = new Set(GIT_CONTEXT_ENV_OVERRIDES);
+var GIT_CONFIG_AFFECTING_ENV_NAMES = new Set([
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_CONFIG_SYSTEM",
+  "HOME",
+  "XDG_CONFIG_HOME"
+]);
 function parseEnvAssignment(token) {
   if (!ENV_ASSIGNMENT_RE.test(token)) {
     return null;
@@ -1158,11 +1173,17 @@ function parseEnvAssignment(token) {
 function parseGitContextAppendEnvAssignment(token) {
   const match = token.match(ENV_APPEND_ASSIGNMENT_RE);
   const name = match?.[1];
-  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name)) {
+  if (!name || !isTrackedGitEnvName(name)) {
     return null;
   }
   const eqIdx = token.indexOf("=");
   return { name, value: token.slice(eqIdx + 1) };
+}
+function isTrackedGitEnvName(name) {
+  return GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES.has(name) || isGitConfigEnvName(name);
+}
+function isGitConfigEnvName(name) {
+  return name === "GIT_CONFIG_COUNT" || name === "GIT_CONFIG_PARAMETERS" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(name);
 }
 function stripEnvAssignmentsWithInfo(tokens) {
   const envAssignments = new Map;
@@ -1409,15 +1430,16 @@ function resolveWrapperCwd(cwd, target) {
     if (!cwd && !isAbsolute2(target)) {
       return null;
     }
-    const baseCwd = isAbsolute2(target) ? "/" : realpathSync2(cwd ?? "/");
+    const baseCwd = isAbsolute2(target) ? getPathRoot2(target) : realpathSync2(cwd ?? "/");
     return resolveChdirTarget2(baseCwd, target);
   } catch {
     return null;
   }
 }
 function resolveChdirTarget2(baseCwd, target) {
-  let current = isAbsolute2(target) ? "/" : baseCwd;
-  for (const component of target.split("/")) {
+  const root = isAbsolute2(target) ? getPathRoot2(target) : "";
+  let current = root || baseCwd;
+  for (const component of getPathComponents2(root ? target.slice(root.length) : target)) {
     if (component === "" || component === ".") {
       continue;
     }
@@ -1431,7 +1453,14 @@ function resolveChdirTarget2(baseCwd, target) {
   return current;
 }
 function appendPathWithoutNormalizing2(base, target) {
-  return base.endsWith("/") ? `${base}${target}` : `${base}/${target}`;
+  return base.endsWith("/") || base.endsWith("\\") ? `${base}${target}` : `${base}${sep2}${target}`;
+}
+function getPathRoot2(target) {
+  return parsePath2(target).root;
+}
+function getPathComponents2(target) {
+  const separator = process.platform === "win32" ? /[\\/]+/ : /\/+/;
+  return target.split(separator);
 }
 function stripCommand(tokens) {
   let i = 1;
@@ -1815,7 +1844,7 @@ var CHECKOUT_OPTS_WITH_VALUE = new Set([
 var CHECKOUT_OPTS_WITH_OPTIONAL_VALUE = new Set(["--recurse-submodules", "--track", "-t"]);
 var CHECKOUT_SHORT_OPTS_WITH_VALUE = new Set(["-b", "-B", "-U"]);
 var SWITCH_SHORT_OPTS_WITH_VALUE = new Set(["-c", "-C"]);
-var GIT_CONFIG_AFFECTING_ENV_NAMES = new Set([
+var GIT_CONFIG_AFFECTING_ENV_NAMES2 = new Set([
   "GIT_CONFIG_GLOBAL",
   "GIT_CONFIG_NOSYSTEM",
   "GIT_CONFIG_SYSTEM",
@@ -2219,7 +2248,7 @@ function hasConfigAffectingEnvAssignment(envAssignments) {
     return false;
   }
   for (const key of envAssignments.keys()) {
-    if (GIT_CONFIG_AFFECTING_ENV_NAMES.has(key)) {
+    if (GIT_CONFIG_AFFECTING_ENV_NAMES2.has(key)) {
       return true;
     }
   }
@@ -2395,7 +2424,7 @@ function analyzeGitWorktree(tokens) {
 // src/core/rules-rm.ts
 import { realpathSync as realpathSync3 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { normalize, resolve as resolve2, sep } from "node:path";
+import { normalize, resolve as resolve2, sep as sep3 } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison(p) {
   let normalized = normalize(p);
@@ -2539,7 +2568,7 @@ function isTempTarget(path, allowTmpdirVar) {
   const systemTmpdir = tmpdir();
   const normalizedTmpdir = normalizePathForComparison(systemTmpdir);
   const pathToCompare = normalizePathForComparison(normalized);
-  if (pathToCompare.startsWith(`${normalizedTmpdir}${sep}`) || pathToCompare === normalizedTmpdir) {
+  if (pathToCompare.startsWith(`${normalizedTmpdir}${sep3}`) || pathToCompare === normalizedTmpdir) {
     return true;
   }
   if (allowTmpdirVar) {
@@ -2591,7 +2620,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   if (target.startsWith("/") || /^[A-Za-z]:[\\/]/.test(target)) {
     try {
       const normalizedTarget = normalizePathForComparison(target);
-      const normalizedCwd = `${normalizePathForComparison(originalCwd)}${sep}`;
+      const normalizedCwd = `${normalizePathForComparison(originalCwd)}${sep3}`;
       return normalizedTarget.startsWith(normalizedCwd);
     } catch {
       return false;
@@ -2602,7 +2631,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
       const resolved = resolve2(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison(resolved);
       const normalizedOriginalCwd = normalizePathForComparison(originalCwd);
-      return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep}`) || normalizedResolved === normalizedOriginalCwd;
+      return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep3}`) || normalizedResolved === normalizedOriginalCwd;
     } catch {
       return false;
     }
@@ -2614,7 +2643,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     const resolved = resolve2(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison(resolved);
     const normalizedCwd = normalizePathForComparison(originalCwd);
-    return normalizedResolved.startsWith(`${normalizedCwd}${sep}`) || normalizedResolved === normalizedCwd;
+    return normalizedResolved.startsWith(`${normalizedCwd}${sep3}`) || normalizedResolved === normalizedCwd;
   } catch {
     return false;
   }
@@ -2699,7 +2728,7 @@ function analyzeParallel(tokens, context) {
       for (const arg of args) {
         const expandedTokens = childTokens.map((t) => t.replace(/{}/g, arg));
         const rmResult = analyzeRm(expandedTokens, {
-          cwd: context.cwd,
+          cwd: childCwd,
           originalCwd: context.originalCwd,
           paranoid: context.paranoidRm,
           allowTmpdirVar: context.allowTmpdirVar
@@ -2713,7 +2742,7 @@ function analyzeParallel(tokens, context) {
     if (args.length > 0) {
       const expandedTokens = [...childTokens, args[0] ?? ""];
       const rmResult = analyzeRm(expandedTokens, {
-        cwd: context.cwd,
+        cwd: childCwd,
         originalCwd: context.originalCwd,
         paranoid: context.paranoidRm,
         allowTmpdirVar: context.allowTmpdirVar
@@ -2891,7 +2920,7 @@ function parseParallelCommand(tokens) {
 
 // src/core/analyze/tmpdir.ts
 import { tmpdir as tmpdir2 } from "node:os";
-import { normalize as normalize2, sep as sep2 } from "node:path";
+import { normalize as normalize2, sep as sep4 } from "node:path";
 function isTmpdirOverriddenToNonTemp(envAssignments) {
   if (!envAssignments.has("TMPDIR")) {
     return false;
@@ -2911,7 +2940,7 @@ function isPathOrSubpath(path, basePath) {
   if (path === basePath) {
     return true;
   }
-  const baseWithSlash = basePath.endsWith(sep2) ? basePath : `${basePath}${sep2}`;
+  const baseWithSlash = basePath.endsWith(sep4) ? basePath : `${basePath}${sep4}`;
   return path.startsWith(baseWithSlash);
 }
 
@@ -2941,7 +2970,7 @@ function analyzeXargs(tokens, context) {
   }
   if (head === "rm" && hasRecursiveForceFlags(childTokens)) {
     const rmResult = analyzeRm(childTokens, {
-      cwd: context.cwd,
+      cwd: childCwd,
       originalCwd: context.originalCwd,
       paranoid: context.paranoidRm,
       allowTmpdirVar: context.allowTmpdirVar
@@ -3337,7 +3366,7 @@ function stripLeadingGrouping(tokens) {
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES2 = new Set(GIT_CONTEXT_ENV_OVERRIDES);
-var GIT_CONFIG_AFFECTING_ENV_NAMES2 = new Set([
+var GIT_CONFIG_AFFECTING_ENV_NAMES3 = new Set([
   "GIT_CONFIG_GLOBAL",
   "GIT_CONFIG_NOSYSTEM",
   "GIT_CONFIG_SYSTEM",
@@ -3398,7 +3427,7 @@ function createShellGitContextEnvState(effectiveEnvAssignments) {
   return {
     effectiveEnvAssignments,
     shellAssignments: new Map,
-    exportedNames: new Set,
+    exportedNames: getInitiallyExportedGitContextNames(effectiveEnvAssignments),
     allexport: false,
     keywordExport: false
   };
@@ -3476,7 +3505,7 @@ function getShellCommandInfo(tokens) {
     if (!assignment) {
       break;
     }
-    if (isTrackedGitEnvName(assignment.name)) {
+    if (isTrackedGitEnvName2(assignment.name)) {
       leadingAssignments.set(assignment.name, assignment);
     }
     i++;
@@ -3534,7 +3563,7 @@ function parseShellAssignment(token) {
 }
 function parseGitContextEnvAssignment(token) {
   const assignment = parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment2(token);
-  if (!assignment || !isTrackedGitEnvName(assignment.name)) {
+  if (!assignment || !isTrackedGitEnvName2(assignment.name)) {
     return null;
   }
   return assignment;
@@ -3542,17 +3571,31 @@ function parseGitContextEnvAssignment(token) {
 function parseGitContextAppendEnvAssignment2(token) {
   const match = token.match(GIT_CONTEXT_APPEND_ASSIGNMENT_RE);
   const name = match?.[1];
-  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name)) {
+  if (!name || !isTrackedGitEnvName2(name)) {
     return null;
   }
   const eqIdx = token.indexOf("=");
   return { name, value: token.slice(eqIdx + 1) };
 }
-function isTrackedGitEnvName(name) {
-  return GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES2.has(name) || isGitConfigEnvName(name);
+function isTrackedGitEnvName2(name) {
+  return GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES3.has(name) || isGitConfigEnvName2(name);
 }
-function isGitConfigEnvName(name) {
+function isGitConfigEnvName2(name) {
   return name === "GIT_CONFIG_COUNT" || name === "GIT_CONFIG_PARAMETERS" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(name);
+}
+function getInitiallyExportedGitContextNames(effectiveEnvAssignments) {
+  const exportedNames = new Set;
+  for (const name of Object.keys(process.env)) {
+    if (isTrackedGitEnvName2(name)) {
+      exportedNames.add(name);
+    }
+  }
+  for (const name of effectiveEnvAssignments?.keys() ?? []) {
+    if (isTrackedGitEnvName2(name)) {
+      exportedNames.add(name);
+    }
+  }
+  return exportedNames;
 }
 function setShellGitContextAssignment(state, assignment) {
   state.shellAssignments.set(assignment.name, assignment.value);
@@ -3573,7 +3616,7 @@ function addExportedGitContextEnvAssignment(state, token) {
     setEffectiveGitContextAssignment(state, assignment);
     return;
   }
-  if (isTrackedGitEnvName(token)) {
+  if (isTrackedGitEnvName2(token)) {
     state.exportedNames.add(token);
     const value = state.shellAssignments.get(token);
     if (value !== undefined) {
@@ -3601,7 +3644,7 @@ function addTypesetGitContextEnvAssignment(state, token, exports, readonlyLeadin
     setEffectiveGitContextAssignment(state, readonlyAssignment);
     return;
   }
-  if (exports && isTrackedGitEnvName(token)) {
+  if (exports && isTrackedGitEnvName2(token)) {
     state.exportedNames.add(token);
     const value = state.shellAssignments.get(token);
     if (value !== undefined) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1835,7 +1835,8 @@ function extractDashCArg(tokens) {
 
 // src/core/rules-git.ts
 import { execFileSync } from "node:child_process";
-import { existsSync as existsSync2 } from "node:fs";
+import { existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
+import { dirname as dirname3, isAbsolute as isAbsolute3, join as join2, resolve as resolve2 } from "node:path";
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
 var REASON_CHECKOUT_REF_PATH = "git checkout <ref> -- <path> overwrites working tree with ref version. Use 'git stash' first.";
@@ -2279,9 +2280,13 @@ function getEnvConfigValue(name, envAssignments) {
   return envAssignments?.get(name) ?? process.env[name];
 }
 function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
+  const localConfigResult = localGitConfigEnablesRecursiveSubmodules(cwd);
+  if (localConfigResult === null || localConfigResult) {
+    return true;
+  }
   const gitBinary = getTrustedGitBinary();
   if (gitBinary === null) {
-    return true;
+    return false;
   }
   try {
     const value = execFileSync(gitBinary, ["config", "--get", "submodule.recurse"], {
@@ -2294,6 +2299,22 @@ function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
   } catch (error) {
     return !isGitConfigUnsetError(error);
   }
+}
+function localGitConfigEnablesRecursiveSubmodules(cwd) {
+  const configPaths = getLocalGitConfigPaths(cwd);
+  if (configPaths === null) {
+    return null;
+  }
+  for (const configPath of configPaths) {
+    if (!existsSync2(configPath)) {
+      continue;
+    }
+    const result = gitConfigFileEnablesRecursiveSubmodules(configPath);
+    if (result) {
+      return true;
+    }
+  }
+  return false;
 }
 function getTrustedGitBinary() {
   for (const gitBinary of TRUSTED_GIT_BINARIES) {
@@ -2314,6 +2335,100 @@ function withoutGitConfigEnv(env) {
 }
 function isGitConfigUnsetError(error) {
   return typeof error === "object" && error !== null && "status" in error && error.status === 1;
+}
+function getLocalGitConfigPaths(cwd) {
+  const dotGitPath = findDotGitPath(cwd);
+  if (dotGitPath === null) {
+    return null;
+  }
+  const gitDir = resolveGitDirFromDotGit(dotGitPath);
+  if (gitDir === null) {
+    return null;
+  }
+  const commonDir = resolveCommonGitDir(gitDir);
+  if (commonDir === null) {
+    return null;
+  }
+  return [join2(commonDir, "config"), join2(gitDir, "config.worktree")];
+}
+function findDotGitPath(cwd) {
+  let current = cwd;
+  while (true) {
+    const dotGitPath = join2(current, ".git");
+    if (existsSync2(dotGitPath)) {
+      return dotGitPath;
+    }
+    const parent = dirname3(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+function resolveGitDirFromDotGit(dotGitPath) {
+  try {
+    const content = readFileSync2(dotGitPath, "utf-8");
+    const firstLine = content.split(/\r?\n/, 1)[0]?.trim() ?? "";
+    if (!firstLine.startsWith("gitdir:")) {
+      return dotGitPath;
+    }
+    const rawGitDir = firstLine.slice("gitdir:".length).trim();
+    if (rawGitDir === "") {
+      return null;
+    }
+    return isAbsolute3(rawGitDir) ? rawGitDir : resolve2(dirname3(dotGitPath), rawGitDir);
+  } catch {
+    return null;
+  }
+}
+function resolveCommonGitDir(gitDir) {
+  const commonDirPath = join2(gitDir, "commondir");
+  if (!existsSync2(commonDirPath)) {
+    return gitDir;
+  }
+  try {
+    const rawCommonDir = readFileSync2(commonDirPath, "utf-8").split(/\r?\n/, 1)[0]?.trim() ?? "";
+    if (rawCommonDir === "") {
+      return null;
+    }
+    return isAbsolute3(rawCommonDir) ? rawCommonDir : resolve2(gitDir, rawCommonDir);
+  } catch {
+    return null;
+  }
+}
+function gitConfigFileEnablesRecursiveSubmodules(configPath) {
+  let content;
+  try {
+    content = readFileSync2(configPath, "utf-8");
+  } catch {
+    return true;
+  }
+  let section = "";
+  let recursiveSubmoduleConfig = false;
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith(";")) {
+      continue;
+    }
+    const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+    if (sectionMatch) {
+      section = sectionMatch[1]?.trim().toLowerCase() ?? "";
+      continue;
+    }
+    const eqIdx = trimmed.indexOf("=");
+    const key = (eqIdx === -1 ? trimmed : trimmed.slice(0, eqIdx)).trim().toLowerCase();
+    const value = eqIdx === -1 ? "true" : trimmed.slice(eqIdx + 1).trim();
+    if (isIncludeConfigSection(section) && key === "path") {
+      return true;
+    }
+    if (section === "submodule" && key === "recurse") {
+      recursiveSubmoduleConfig = gitConfigValueEnablesRecursiveSubmodules(value);
+    }
+  }
+  return recursiveSubmoduleConfig;
+}
+function isIncludeConfigSection(section) {
+  return section === "include" || section.startsWith("includeif ");
 }
 function recursiveSubmoduleConfigValue(config) {
   if (!config) {
@@ -2445,7 +2560,7 @@ function analyzeGitWorktree(tokens) {
 // src/core/rules-rm.ts
 import { realpathSync as realpathSync3 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { normalize, resolve as resolve2, sep as sep3 } from "node:path";
+import { normalize, resolve as resolve3, sep as sep3 } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison2(p) {
   let normalized = normalize(p);
@@ -2617,13 +2732,13 @@ function isCwdSelfTarget(target, cwd) {
     return true;
   }
   try {
-    const resolved = resolve2(cwd, target);
+    const resolved = resolve3(cwd, target);
     const realCwd = realpathSync3(cwd);
     const realResolved = realpathSync3(resolved);
     return normalizePathForComparison2(realResolved) === normalizePathForComparison2(realCwd);
   } catch {
     try {
-      const resolved = resolve2(cwd, target);
+      const resolved = resolve3(cwd, target);
       return normalizePathForComparison2(resolved) === normalizePathForComparison2(cwd);
     } catch {
       return false;
@@ -2649,7 +2764,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   if (target.startsWith("./") || target.startsWith(".\\") || !target.includes("/") && !target.includes("\\")) {
     try {
-      const resolved = resolve2(resolveCwd, target);
+      const resolved = resolve3(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison2(resolved);
       const normalizedOriginalCwd = normalizePathForComparison2(originalCwd);
       return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep3}`) || normalizedResolved === normalizedOriginalCwd;
@@ -2661,7 +2776,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     return false;
   }
   try {
-    const resolved = resolve2(resolveCwd, target);
+    const resolved = resolve3(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison2(resolved);
     const normalizedCwd = normalizePathForComparison2(originalCwd);
     return normalizedResolved.startsWith(`${normalizedCwd}${sep3}`) || normalizedResolved === normalizedCwd;
@@ -3774,18 +3889,18 @@ function getSetOptionChanges(tokens, commandIndex) {
 }
 
 // src/core/config.ts
-import { existsSync as existsSync3, readFileSync as readFileSync2 } from "node:fs";
+import { existsSync as existsSync3, readFileSync as readFileSync3 } from "node:fs";
 import { homedir as homedir2 } from "node:os";
-import { join as join2, resolve as resolve3 } from "node:path";
+import { join as join3, resolve as resolve4 } from "node:path";
 var DEFAULT_CONFIG = {
   version: 1,
   rules: []
 };
 function loadConfig(cwd, options) {
   const safeCwd = typeof cwd === "string" ? cwd : process.cwd();
-  const userConfigDir = options?.userConfigDir ?? join2(homedir2(), ".cc-safety-net");
-  const userConfigPath = join2(userConfigDir, "config.json");
-  const projectConfigPath = join2(safeCwd, ".safety-net.json");
+  const userConfigDir = options?.userConfigDir ?? join3(homedir2(), ".cc-safety-net");
+  const userConfigPath = join3(userConfigDir, "config.json");
+  const projectConfigPath = join3(safeCwd, ".safety-net.json");
   const userConfig = loadSingleConfig(userConfigPath);
   const projectConfig = loadSingleConfig(projectConfigPath);
   return mergeConfigs(userConfig, projectConfig);
@@ -3795,7 +3910,7 @@ function loadSingleConfig(path) {
     return null;
   }
   try {
-    const content = readFileSync2(path, "utf-8");
+    const content = readFileSync3(path, "utf-8");
     if (!content.trim()) {
       return null;
     }
@@ -3922,7 +4037,7 @@ function validateConfigFile(path) {
     return { errors, ruleNames };
   }
   try {
-    const content = readFileSync2(path, "utf-8");
+    const content = readFileSync3(path, "utf-8");
     if (!content.trim()) {
       errors.push("Config file is empty");
       return { errors, ruleNames };
@@ -3935,10 +4050,10 @@ function validateConfigFile(path) {
   }
 }
 function getUserConfigPath() {
-  return join2(homedir2(), ".cc-safety-net", "config.json");
+  return join3(homedir2(), ".cc-safety-net", "config.json");
 }
 function getProjectConfigPath(cwd) {
-  return resolve3(cwd ?? process.cwd(), ".safety-net.json");
+  return resolve4(cwd ?? process.cwd(), ".safety-net.json");
 }
 
 // src/core/analyze.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -1886,7 +1886,9 @@ var SWITCH_SHORT_OPTS_WITH_VALUE = new Set(["-c", "-C"]);
 var TRUSTED_GIT_BINARIES = [
   "/usr/bin/git",
   "/usr/local/bin/git",
-  "/opt/homebrew/bin/git"
+  "/opt/homebrew/bin/git",
+  "C:\\Program Files\\Git\\cmd\\git.exe",
+  "C:\\Program Files\\Git\\bin\\git.exe"
 ];
 var CHECKOUT_KNOWN_OPTS_NO_VALUE = new Set([
   "-q",
@@ -2293,14 +2295,13 @@ function hasConfigAffectingEnvAssignment(envAssignments) {
 function getEnvConfigValue(name, envAssignments) {
   return envAssignments?.get(name) ?? process.env[name];
 }
-function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
+function effectiveGitConfigEnablesRecursiveSubmodules(cwd, gitBinary = getTrustedGitBinary()) {
   const localConfigResult = localGitConfigEnablesRecursiveSubmodules(cwd);
   if (localConfigResult === null || localConfigResult) {
     return true;
   }
-  const gitBinary = getTrustedGitBinary();
   if (gitBinary === null) {
-    return false;
+    return true;
   }
   try {
     const value = execFileSync(gitBinary, ["config", "--get", "submodule.recurse"], {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1385,6 +1385,145 @@ function extractDashCArg(tokens) {
   return null;
 }
 
+// src/core/worktree.ts
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
+  "-c",
+  "-C",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--super-prefix",
+  "--config-env"
+]);
+var GIT_CONTEXT_ENV_OVERRIDES = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"];
+function hasGitContextEnvOverride(envAssignments) {
+  for (const name of GIT_CONTEXT_ENV_OVERRIDES) {
+    if (envAssignments?.has(name) || Object.hasOwn(process.env, name)) {
+      return true;
+    }
+  }
+  return false;
+}
+function getGitExecutionContext(tokens, cwd) {
+  if (!cwd) {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
+  let gitCwd = resolve(cwd);
+  if (!isDirectory(gitCwd)) {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
+  let hasExplicitGitContext = false;
+  let i = 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token)
+      break;
+    if (token === "--") {
+      break;
+    }
+    if (!token.startsWith("-")) {
+      break;
+    }
+    if (token === "-C") {
+      const target = tokens[i + 1];
+      if (!target) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      const resolvedCwd = resolveGitCwd(gitCwd, target);
+      if (!resolvedCwd) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      gitCwd = resolvedCwd;
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("-C") && token.length > 2) {
+      const resolvedCwd = resolveGitCwd(gitCwd, token.slice(2));
+      if (!resolvedCwd) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      gitCwd = resolvedCwd;
+      i++;
+      continue;
+    }
+    if (token === "--git-dir" || token === "--work-tree") {
+      hasExplicitGitContext = true;
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("--git-dir=") || token.startsWith("--work-tree=")) {
+      hasExplicitGitContext = true;
+      i++;
+      continue;
+    }
+    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(token)) {
+      i += 2;
+    } else if (token.startsWith("-c") && token.length > 2) {
+      i++;
+    } else {
+      i++;
+    }
+  }
+  return { gitCwd, hasExplicitGitContext };
+}
+function isLinkedWorktree(cwd) {
+  const dotGitPath = findDotGit(cwd);
+  if (!dotGitPath) {
+    return false;
+  }
+  try {
+    const stat = statSync(dotGitPath);
+    if (!stat.isFile()) {
+      return false;
+    }
+    const content = readFileSync(dotGitPath, "utf-8");
+    const firstLine = content.split(/\r?\n/, 1)[0]?.trim() ?? "";
+    if (!firstLine.startsWith("gitdir:")) {
+      return false;
+    }
+    const rawGitDir = firstLine.slice("gitdir:".length).trim();
+    if (rawGitDir === "") {
+      return false;
+    }
+    const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve(dirname(dotGitPath), rawGitDir);
+    return existsSync(join(gitDir, "commondir"));
+  } catch {
+    return false;
+  }
+}
+function resolveGitCwd(baseCwd, target) {
+  const resolved = isAbsolute(target) ? target : resolve(baseCwd, target);
+  return isDirectory(resolved) ? resolved : null;
+}
+function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+function findDotGit(cwd) {
+  let current;
+  try {
+    current = realpathSync(cwd);
+  } catch {
+    return null;
+  }
+  while (true) {
+    const dotGitPath = join(current, ".git");
+    if (existsSync(dotGitPath)) {
+      return dotGitPath;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
 // src/core/rules-git.ts
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
@@ -1403,15 +1542,6 @@ var REASON_BRANCH_DELETE = "git branch -D force-deletes without merge check. Use
 var REASON_STASH_DROP = "git stash drop permanently deletes stashed changes. Consider 'git stash list' first.";
 var REASON_STASH_CLEAR = "git stash clear deletes ALL stashed changes permanently.";
 var REASON_WORKTREE_REMOVE_FORCE = "git worktree remove --force can delete uncommitted changes. Remove --force flag.";
-var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
-  "-c",
-  "-C",
-  "--git-dir",
-  "--work-tree",
-  "--namespace",
-  "--super-prefix",
-  "--config-env"
-]);
 var CHECKOUT_OPTS_WITH_VALUE = new Set([
   "-b",
   "-B",
@@ -1470,33 +1600,72 @@ function splitAtDoubleDash(tokens) {
     after: tokens.slice(index + 1)
   };
 }
-function analyzeGit(tokens) {
+function analyzeGit(tokens, options = {}) {
+  const match = analyzeGitRule(tokens);
+  if (!match) {
+    return null;
+  }
+  if (getGitWorktreeRelaxationForMatch(tokens, match, options)) {
+    return null;
+  }
+  return match.reason;
+}
+function getGitWorktreeRelaxation(tokens, options = {}) {
+  const match = analyzeGitRule(tokens);
+  if (!match) {
+    return null;
+  }
+  return getGitWorktreeRelaxationForMatch(tokens, match, options);
+}
+function analyzeGitRule(tokens) {
   const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
   if (!subcommand) {
     return null;
   }
   switch (subcommand.toLowerCase()) {
     case "checkout":
-      return analyzeGitCheckout(rest);
+      return localDiscard(analyzeGitCheckout(rest));
     case "switch":
-      return analyzeGitSwitch(rest);
+      return localDiscard(analyzeGitSwitch(rest));
     case "restore":
-      return analyzeGitRestore(rest);
+      return localDiscard(analyzeGitRestore(rest));
     case "reset":
-      return analyzeGitReset(rest);
+      return localDiscard(analyzeGitReset(rest));
     case "clean":
-      return analyzeGitClean(rest);
+      return localDiscard(analyzeGitClean(rest));
     case "push":
-      return analyzeGitPush(rest);
+      return sharedState(analyzeGitPush(rest));
     case "branch":
-      return analyzeGitBranch(rest);
+      return sharedState(analyzeGitBranch(rest));
     case "stash":
-      return analyzeGitStash(rest);
+      return sharedState(analyzeGitStash(rest));
     case "worktree":
-      return analyzeGitWorktree(rest);
+      return sharedState(analyzeGitWorktree(rest));
     default:
       return null;
   }
+}
+function localDiscard(reason) {
+  return reason ? { reason, localDiscard: true } : null;
+}
+function sharedState(reason) {
+  return reason ? { reason, localDiscard: false } : null;
+}
+function getGitWorktreeRelaxationForMatch(tokens, match, options) {
+  if (!match.localDiscard || !options.worktreeMode || hasGitContextEnvOverride(options.envAssignments)) {
+    return null;
+  }
+  const context = getGitExecutionContext(tokens, options.cwd);
+  if (!context.gitCwd || context.hasExplicitGitContext) {
+    return null;
+  }
+  if (!isLinkedWorktree(context.gitCwd)) {
+    return null;
+  }
+  return {
+    originalReason: match.reason,
+    gitCwd: context.gitCwd
+  };
 }
 function extractGitSubcommandAndRest(tokens) {
   if (tokens.length === 0) {
@@ -1703,9 +1872,9 @@ function analyzeGitWorktree(tokens) {
 }
 
 // src/core/rules-rm.ts
-import { realpathSync } from "node:fs";
+import { realpathSync as realpathSync2 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { normalize, resolve, sep } from "node:path";
+import { normalize, resolve as resolve2, sep } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison(p) {
   let normalized = normalize(p);
@@ -1877,13 +2046,13 @@ function isCwdSelfTarget(target, cwd) {
     return true;
   }
   try {
-    const resolved = resolve(cwd, target);
-    const realCwd = realpathSync(cwd);
-    const realResolved = realpathSync(resolved);
+    const resolved = resolve2(cwd, target);
+    const realCwd = realpathSync2(cwd);
+    const realResolved = realpathSync2(resolved);
     return normalizePathForComparison(realResolved) === normalizePathForComparison(realCwd);
   } catch {
     try {
-      const resolved = resolve(cwd, target);
+      const resolved = resolve2(cwd, target);
       return normalizePathForComparison(resolved) === normalizePathForComparison(cwd);
     } catch {
       return false;
@@ -1909,7 +2078,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   if (target.startsWith("./") || target.startsWith(".\\") || !target.includes("/") && !target.includes("\\")) {
     try {
-      const resolved = resolve(resolveCwd, target);
+      const resolved = resolve2(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison(resolved);
       const normalizedOriginalCwd = normalizePathForComparison(originalCwd);
       return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep}`) || normalizedResolved === normalizedOriginalCwd;
@@ -1921,7 +2090,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     return false;
   }
   try {
-    const resolved = resolve(resolveCwd, target);
+    const resolved = resolve2(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison(resolved);
     const normalizedCwd = normalizePathForComparison(originalCwd);
     return normalizedResolved.startsWith(`${normalizedCwd}${sep}`) || normalizedResolved === normalizedCwd;
@@ -2032,7 +2201,11 @@ function analyzeParallel(tokens, context) {
     }
   }
   if (head === "git") {
-    const gitResult = analyzeGit(childTokens);
+    const gitResult = analyzeGit(childTokens, {
+      cwd: context.cwd,
+      envAssignments: context.envAssignments,
+      worktreeMode: context.worktreeMode
+    });
     if (gitResult) {
       return gitResult;
     }
@@ -2189,7 +2362,11 @@ function analyzeXargs(tokens, context) {
     }
   }
   if (head === "git") {
-    const gitResult = analyzeGit(childTokens);
+    const gitResult = analyzeGit(childTokens, {
+      cwd: context.cwd,
+      envAssignments: context.envAssignments,
+      worktreeMode: context.worktreeMode
+    });
     if (gitResult) {
       return gitResult;
     }
@@ -2406,7 +2583,11 @@ function analyzeSegment(tokens, depth, options) {
   const isXargs = basename === "xargs";
   const isParallel = basename === "parallel";
   if (isGit) {
-    const gitResult = analyzeGit(stripped);
+    const gitResult = analyzeGit(stripped, {
+      cwd: cwdForRm,
+      envAssignments,
+      worktreeMode: options.worktreeMode
+    });
     if (gitResult) {
       return gitResult;
     }
@@ -2433,7 +2614,9 @@ function analyzeSegment(tokens, depth, options) {
       cwd: cwdForRm,
       originalCwd,
       paranoidRm: options.paranoidRm,
-      allowTmpdirVar
+      allowTmpdirVar,
+      envAssignments,
+      worktreeMode: options.worktreeMode
     });
     if (xargsResult) {
       return xargsResult;
@@ -2445,6 +2628,8 @@ function analyzeSegment(tokens, depth, options) {
       originalCwd,
       paranoidRm: options.paranoidRm,
       allowTmpdirVar,
+      envAssignments,
+      worktreeMode: options.worktreeMode,
       analyzeNested: options.analyzeNested
     });
     if (parallelResult) {
@@ -2473,7 +2658,11 @@ function analyzeSegment(tokens, depth, options) {
         }
         if (cmd === "git") {
           const gitTokens = ["git", ...stripped.slice(i + 1)];
-          const reason = analyzeGit(gitTokens);
+          const reason = analyzeGit(gitTokens, {
+            cwd: cwdForRm,
+            envAssignments,
+            worktreeMode: options.worktreeMode
+          });
           if (reason) {
             return reason;
           }
@@ -2571,28 +2760,28 @@ function analyzeCommandInternal(command, depth, options) {
 }
 
 // src/core/config.ts
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
 import { homedir as homedir2 } from "node:os";
-import { join, resolve as resolve2 } from "node:path";
+import { join as join2, resolve as resolve3 } from "node:path";
 var DEFAULT_CONFIG = {
   version: 1,
   rules: []
 };
 function loadConfig(cwd, options) {
   const safeCwd = typeof cwd === "string" ? cwd : process.cwd();
-  const userConfigDir = options?.userConfigDir ?? join(homedir2(), ".cc-safety-net");
-  const userConfigPath = join(userConfigDir, "config.json");
-  const projectConfigPath = join(safeCwd, ".safety-net.json");
+  const userConfigDir = options?.userConfigDir ?? join2(homedir2(), ".cc-safety-net");
+  const userConfigPath = join2(userConfigDir, "config.json");
+  const projectConfigPath = join2(safeCwd, ".safety-net.json");
   const userConfig = loadSingleConfig(userConfigPath);
   const projectConfig = loadSingleConfig(projectConfigPath);
   return mergeConfigs(userConfig, projectConfig);
 }
 function loadSingleConfig(path) {
-  if (!existsSync(path)) {
+  if (!existsSync2(path)) {
     return null;
   }
   try {
-    const content = readFileSync(path, "utf-8");
+    const content = readFileSync2(path, "utf-8");
     if (!content.trim()) {
       return null;
     }
@@ -2714,12 +2903,12 @@ function validateRule(rule, index, ruleNames) {
 function validateConfigFile(path) {
   const errors = [];
   const ruleNames = new Set;
-  if (!existsSync(path)) {
+  if (!existsSync2(path)) {
     errors.push(`File not found: ${path}`);
     return { errors, ruleNames };
   }
   try {
-    const content = readFileSync(path, "utf-8");
+    const content = readFileSync2(path, "utf-8");
     if (!content.trim()) {
       errors.push("Config file is empty");
       return { errors, ruleNames };
@@ -2732,10 +2921,10 @@ function validateConfigFile(path) {
   }
 }
 function getUserConfigPath() {
-  return join(homedir2(), ".cc-safety-net", "config.json");
+  return join2(homedir2(), ".cc-safety-net", "config.json");
 }
 function getProjectConfigPath(cwd) {
-  return resolve2(cwd ?? process.cwd(), ".safety-net.json");
+  return resolve3(cwd ?? process.cwd(), ".safety-net.json");
 }
 
 // src/core/analyze.ts
@@ -2890,6 +3079,7 @@ var SafetyNetPlugin = async ({ directory }) => {
   const paranoidAll = envTruthy("SAFETY_NET_PARANOID");
   const paranoidRm = paranoidAll || envTruthy("SAFETY_NET_PARANOID_RM");
   const paranoidInterpreters = paranoidAll || envTruthy("SAFETY_NET_PARANOID_INTERPRETERS");
+  const worktreeMode = envTruthy("SAFETY_NET_WORKTREE");
   return {
     config: async (opencodeConfig) => {
       const builtinCommands = loadBuiltinCommands();
@@ -2907,7 +3097,8 @@ var SafetyNetPlugin = async ({ directory }) => {
           config: safetyNetConfig,
           strict,
           paranoidRm,
-          paranoidInterpreters
+          paranoidInterpreters,
+          worktreeMode
         });
         if (result) {
           const message = formatBlockedMessage({

--- a/dist/index.js
+++ b/dist/index.js
@@ -398,6 +398,9 @@ function hasRecursiveForceFlags(tokens) {
   return hasRecursive && hasForce;
 }
 
+// src/core/shell.ts
+import { isAbsolute, resolve } from "node:path";
+
 // node_modules/shell-quote/index.js
 var $quote = require_quote();
 var $parse = require_parse();
@@ -915,12 +918,13 @@ function stripEnvAssignmentsWithInfo(tokens) {
   }
   return { tokens: tokens.slice(i), envAssignments };
 }
-function stripWrappers(tokens) {
-  return stripWrappersWithInfo(tokens).tokens;
+function stripWrappers(tokens, cwd) {
+  return stripWrappersWithInfo(tokens, cwd).tokens;
 }
-function stripWrappersWithInfo(tokens) {
+function stripWrappersWithInfo(tokens, cwd) {
   let result = [...tokens];
   const allEnvAssignments = new Map;
+  let currentCwd = cwd;
   for (let iteration = 0;iteration < MAX_STRIP_ITERATIONS; iteration++) {
     const before = result.join(" ");
     const { tokens: strippedTokens, envAssignments } = stripEnvAssignmentsWithInfo(result);
@@ -943,8 +947,11 @@ function stripWrappersWithInfo(tokens) {
       result = stripSudo(result);
     }
     if (head === "env") {
-      const envResult = stripEnvWithInfo(result);
+      const envResult = stripEnvWithInfo(result, currentCwd);
       result = envResult.tokens;
+      if (envResult.cwd !== undefined) {
+        currentCwd = envResult.cwd;
+      }
       for (const [k, v] of envResult.envAssignments) {
         allEnvAssignments.set(k, v);
       }
@@ -959,7 +966,7 @@ function stripWrappersWithInfo(tokens) {
   for (const [k, v] of finalAssignments) {
     allEnvAssignments.set(k, v);
   }
-  return { tokens: finalTokens, envAssignments: allEnvAssignments };
+  return { tokens: finalTokens, envAssignments: allEnvAssignments, cwd: currentCwd };
 }
 var SUDO_OPTS_WITH_VALUE = new Set(["-u", "-g", "-C", "-D", "-h", "-p", "-r", "-t", "-T", "-U"]);
 function stripSudo(tokens) {
@@ -992,8 +999,9 @@ var ENV_OPTS_WITH_VALUE = new Set([
   "--split-string",
   "-P"
 ]);
-function stripEnvWithInfo(tokens) {
+function stripEnvWithInfo(tokens, cwd) {
   const envAssignments = new Map;
+  let currentCwd = cwd;
   let i = 1;
   while (i < tokens.length) {
     const token = tokens[i];
@@ -1007,6 +1015,10 @@ function stripEnvWithInfo(tokens) {
       continue;
     }
     if (ENV_OPTS_WITH_VALUE.has(token)) {
+      if (token === "-C" || token === "--chdir") {
+        const target = tokens[i + 1];
+        currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
+      }
       i += 2;
       continue;
     }
@@ -1015,6 +1027,8 @@ function stripEnvWithInfo(tokens) {
       continue;
     }
     if (token.startsWith("-C=") || token.startsWith("--chdir=")) {
+      const target = token.startsWith("-C=") ? token.slice("-C=".length) : token.slice("--chdir=".length);
+      currentCwd = resolveWrapperCwd(currentCwd, target);
       i++;
       continue;
     }
@@ -1033,7 +1047,19 @@ function stripEnvWithInfo(tokens) {
     envAssignments.set(assignment.name, assignment.value);
     i++;
   }
-  return { tokens: tokens.slice(i), envAssignments };
+  return { tokens: tokens.slice(i), envAssignments, cwd: currentCwd };
+}
+function resolveWrapperCwd(cwd, target) {
+  if (target === "") {
+    return null;
+  }
+  if (isAbsolute(target)) {
+    return resolve(target);
+  }
+  if (!cwd) {
+    return null;
+  }
+  return resolve(cwd, target);
 }
 function stripCommand(tokens) {
   let i = 1;
@@ -1387,7 +1413,7 @@ function extractDashCArg(tokens) {
 
 // src/core/worktree.ts
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute as isAbsolute2, join, resolve as resolve2 } from "node:path";
 var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
   "-c",
   "-C",
@@ -1410,7 +1436,7 @@ function getGitExecutionContext(tokens, cwd) {
   if (!cwd) {
     return { gitCwd: null, hasExplicitGitContext: false };
   }
-  let gitCwd = resolve(cwd);
+  let gitCwd = resolve2(cwd);
   if (!isDirectory(gitCwd)) {
     return { gitCwd: null, hasExplicitGitContext: false };
   }
@@ -1487,14 +1513,14 @@ function isLinkedWorktree(cwd) {
     if (rawGitDir === "") {
       return false;
     }
-    const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve(dirname(dotGitPath), rawGitDir);
+    const gitDir = isAbsolute2(rawGitDir) ? rawGitDir : resolve2(dirname(dotGitPath), rawGitDir);
     return existsSync(join(gitDir, "commondir"));
   } catch {
     return false;
   }
 }
 function resolveGitCwd(baseCwd, target) {
-  const resolved = isAbsolute(target) ? target : resolve(baseCwd, target);
+  const resolved = isAbsolute2(target) ? target : resolve2(baseCwd, target);
   return isDirectory(resolved) ? resolved : null;
 }
 function isDirectory(path) {
@@ -1630,7 +1656,7 @@ function analyzeGitRule(tokens) {
     case "restore":
       return localDiscard(analyzeGitRestore(rest));
     case "reset":
-      return localDiscard(analyzeGitReset(rest));
+      return analyzeGitReset(rest);
     case "clean":
       return localDiscard(analyzeGitClean(rest));
     case "push":
@@ -1804,15 +1830,32 @@ function analyzeGitRestore(tokens) {
   return hasStaged ? null : REASON_RESTORE;
 }
 function analyzeGitReset(tokens) {
+  let reason = null;
   for (const token of tokens) {
     if (token === "--hard") {
-      return REASON_RESET_HARD;
+      reason = REASON_RESET_HARD;
+      break;
     }
     if (token === "--merge") {
-      return REASON_RESET_MERGE;
+      reason = REASON_RESET_MERGE;
+      break;
     }
   }
-  return null;
+  if (!reason) {
+    return null;
+  }
+  return resetHasRef(tokens) ? sharedState(reason) : localDiscard(reason);
+}
+function resetHasRef(tokens) {
+  for (const token of tokens) {
+    if (token === "--") {
+      return false;
+    }
+    if (!token.startsWith("-")) {
+      return true;
+    }
+  }
+  return false;
 }
 function analyzeGitClean(tokens) {
   for (const token of tokens) {
@@ -1874,7 +1917,7 @@ function analyzeGitWorktree(tokens) {
 // src/core/rules-rm.ts
 import { realpathSync as realpathSync2 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { normalize, resolve as resolve2, sep } from "node:path";
+import { normalize, resolve as resolve3, sep } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison(p) {
   let normalized = normalize(p);
@@ -2046,13 +2089,13 @@ function isCwdSelfTarget(target, cwd) {
     return true;
   }
   try {
-    const resolved = resolve2(cwd, target);
+    const resolved = resolve3(cwd, target);
     const realCwd = realpathSync2(cwd);
     const realResolved = realpathSync2(resolved);
     return normalizePathForComparison(realResolved) === normalizePathForComparison(realCwd);
   } catch {
     try {
-      const resolved = resolve2(cwd, target);
+      const resolved = resolve3(cwd, target);
       return normalizePathForComparison(resolved) === normalizePathForComparison(cwd);
     } catch {
       return false;
@@ -2078,7 +2121,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   if (target.startsWith("./") || target.startsWith(".\\") || !target.includes("/") && !target.includes("\\")) {
     try {
-      const resolved = resolve2(resolveCwd, target);
+      const resolved = resolve3(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison(resolved);
       const normalizedOriginalCwd = normalizePathForComparison(originalCwd);
       return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep}`) || normalizedResolved === normalizedOriginalCwd;
@@ -2090,7 +2133,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     return false;
   }
   try {
-    const resolved = resolve2(resolveCwd, target);
+    const resolved = resolve3(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison(resolved);
     const normalizedCwd = normalizePathForComparison(originalCwd);
     return normalizedResolved.startsWith(`${normalizedCwd}${sep}`) || normalizedResolved === normalizedCwd;
@@ -2107,17 +2150,25 @@ function analyzeParallel(tokens, context) {
   if (!parseResult) {
     return null;
   }
-  const { template, args, hasPlaceholder } = parseResult;
+  const { template, args, hasPlaceholder, runsRemotely } = parseResult;
   if (template.length === 0) {
+    const nestedOverrides2 = runsRemotely ? { worktreeMode: false } : undefined;
     for (const arg of args) {
-      const reason = context.analyzeNested(arg);
+      const reason = context.analyzeNested(arg, nestedOverrides2);
       if (reason) {
         return reason;
       }
     }
     return null;
   }
-  let childTokens = stripWrappers([...template]);
+  const childWrapperInfo = stripWrappersWithInfo([...template], context.cwd);
+  let childTokens = childWrapperInfo.tokens;
+  const childEnvAssignments = new Map(context.envAssignments ?? []);
+  for (const [k, v] of childWrapperInfo.envAssignments) {
+    childEnvAssignments.set(k, v);
+  }
+  const childCwd = childWrapperInfo.cwd === null ? undefined : childWrapperInfo.cwd ?? context.cwd;
+  const nestedOverrides = buildNestedOverrides(childEnvAssignments, childWrapperInfo.cwd, runsRemotely);
   let head = getBasename(childTokens[0] ?? "").toLowerCase();
   if (head === "busybox" && childTokens.length > 1) {
     childTokens = childTokens.slice(1);
@@ -2133,20 +2184,20 @@ function analyzeParallel(tokens, context) {
         if (args.length > 0) {
           for (const arg of args) {
             const expandedScript = dashCArg.replace(/{}/g, arg);
-            const reason3 = context.analyzeNested(expandedScript);
+            const reason3 = context.analyzeNested(expandedScript, nestedOverrides);
             if (reason3) {
               return reason3;
             }
           }
           return null;
         }
-        const reason2 = context.analyzeNested(dashCArg);
+        const reason2 = context.analyzeNested(dashCArg, nestedOverrides);
         if (reason2) {
           return reason2;
         }
         return null;
       }
-      const reason = context.analyzeNested(dashCArg);
+      const reason = context.analyzeNested(dashCArg, nestedOverrides);
       if (reason) {
         return reason;
       }
@@ -2202,15 +2253,25 @@ function analyzeParallel(tokens, context) {
   }
   if (head === "git") {
     const gitResult = analyzeGit(childTokens, {
-      cwd: context.cwd,
-      envAssignments: context.envAssignments,
-      worktreeMode: context.worktreeMode
+      cwd: childCwd,
+      envAssignments: childEnvAssignments,
+      worktreeMode: runsRemotely ? false : context.worktreeMode
     });
     if (gitResult) {
       return gitResult;
     }
   }
   return null;
+}
+function buildNestedOverrides(envAssignments, cwd, runsRemotely) {
+  const overrides = { envAssignments };
+  if (cwd !== undefined) {
+    overrides.effectiveCwd = cwd;
+  }
+  if (runsRemotely) {
+    overrides.worktreeMode = false;
+  }
+  return overrides;
 }
 function parseParallelCommand(tokens) {
   const parallelOptsWithValue = new Set([
@@ -2230,6 +2291,7 @@ function parseParallelCommand(tokens) {
   let i = 1;
   const templateTokens = [];
   let markerIndex = -1;
+  let runsRemotely = false;
   while (i < tokens.length) {
     const token = tokens[i];
     if (!token)
@@ -2253,6 +2315,21 @@ function parseParallelCommand(tokens) {
       break;
     }
     if (token.startsWith("-")) {
+      if (token === "-S" || token === "--sshlogin" || token === "--slf" || token === "--sshloginfile") {
+        runsRemotely = true;
+        i += 2;
+        continue;
+      }
+      if (token.startsWith("-S") && token.length > 2) {
+        runsRemotely = true;
+        i++;
+        continue;
+      }
+      if (token.startsWith("--sshlogin=") || token.startsWith("--slf=") || token.startsWith("--sshloginfile=")) {
+        runsRemotely = true;
+        i++;
+        continue;
+      }
       if (token.startsWith("-j") && token.length > 2 && /^\d+$/.test(token.slice(2))) {
         i++;
         continue;
@@ -2297,7 +2374,7 @@ function parseParallelCommand(tokens) {
   if (templateTokens.length === 0 && markerIndex === -1) {
     return null;
   }
-  return { template: templateTokens, args, hasPlaceholder };
+  return { template: templateTokens, args, hasPlaceholder, runsRemotely };
 }
 
 // src/core/analyze/tmpdir.ts
@@ -2331,7 +2408,13 @@ var REASON_XARGS_RM = "xargs rm -rf with dynamic input is dangerous. Use explici
 var REASON_XARGS_SHELL = "xargs with shell -c can execute arbitrary commands from dynamic input.";
 function analyzeXargs(tokens, context) {
   const { childTokens: rawChildTokens } = extractXargsChildCommandWithInfo(tokens);
-  let childTokens = stripWrappers(rawChildTokens);
+  const childWrapperInfo = stripWrappersWithInfo(rawChildTokens, context.cwd);
+  let childTokens = childWrapperInfo.tokens;
+  const childEnvAssignments = new Map(context.envAssignments ?? []);
+  for (const [k, v] of childWrapperInfo.envAssignments) {
+    childEnvAssignments.set(k, v);
+  }
+  const childCwd = childWrapperInfo.cwd === null ? undefined : childWrapperInfo.cwd ?? context.cwd;
   if (childTokens.length === 0) {
     return null;
   }
@@ -2363,8 +2446,8 @@ function analyzeXargs(tokens, context) {
   }
   if (head === "git") {
     const gitResult = analyzeGit(childTokens, {
-      cwd: context.cwd,
-      envAssignments: context.envAssignments,
+      cwd: childCwd,
+      envAssignments: childEnvAssignments,
       worktreeMode: context.worktreeMode
     });
     if (gitResult) {
@@ -2536,9 +2619,17 @@ function analyzeSegment(tokens, depth, options) {
   if (tokens.length === 0) {
     return null;
   }
+  const { cwdForRm: baseCwdForRm, originalCwd } = deriveCwdContext(options);
   const { tokens: strippedEnv, envAssignments: leadingEnvAssignments } = stripEnvAssignmentsWithInfo(tokens);
-  const { tokens: stripped, envAssignments: wrapperEnvAssignments } = stripWrappersWithInfo(strippedEnv);
-  const envAssignments = new Map(leadingEnvAssignments);
+  const {
+    tokens: stripped,
+    envAssignments: wrapperEnvAssignments,
+    cwd: wrapperCwd
+  } = stripWrappersWithInfo(strippedEnv, baseCwdForRm);
+  const envAssignments = new Map(options.envAssignments ?? []);
+  for (const [k, v] of leadingEnvAssignments) {
+    envAssignments.set(k, v);
+  }
   for (const [k, v] of wrapperEnvAssignments) {
     envAssignments.set(k, v);
   }
@@ -2551,12 +2642,16 @@ function analyzeSegment(tokens, depth, options) {
   }
   const normalizedHead = normalizeCommandToken(head);
   const basename = getBasename(head);
-  const { cwdForRm, originalCwd } = deriveCwdContext(options);
+  const cwdForRm = wrapperCwd === null ? undefined : wrapperCwd ?? baseCwdForRm;
+  const nestedEffectiveCwd = wrapperCwd === undefined ? options.effectiveCwd : wrapperCwd;
   const allowTmpdirVar = !isTmpdirOverriddenToNonTemp(envAssignments);
   if (SHELL_WRAPPERS.has(normalizedHead)) {
     const dashCArg = extractDashCArg(stripped);
     if (dashCArg) {
-      return options.analyzeNested(dashCArg);
+      return options.analyzeNested(dashCArg, {
+        effectiveCwd: nestedEffectiveCwd,
+        envAssignments
+      });
     }
   }
   if (INTERPRETERS.has(normalizedHead)) {
@@ -2661,7 +2756,7 @@ function analyzeSegment(tokens, depth, options) {
           const reason = analyzeGit(gitTokens, {
             cwd: cwdForRm,
             envAssignments,
-            worktreeMode: options.worktreeMode
+            worktreeMode: false
           });
           if (reason) {
             return reason;
@@ -2745,8 +2840,14 @@ function analyzeCommandInternal(command, depth, options) {
       ...options,
       cwd: originalCwd,
       effectiveCwd,
-      analyzeNested: (nestedCommand) => {
-        return analyzeCommandInternal(nestedCommand, depth + 1, { ...options, effectiveCwd })?.reason ?? null;
+      analyzeNested: (nestedCommand, overrides) => {
+        const nestedEffectiveCwd = overrides && Object.hasOwn(overrides, "effectiveCwd") ? overrides.effectiveCwd : effectiveCwd;
+        return analyzeCommandInternal(nestedCommand, depth + 1, {
+          ...options,
+          effectiveCwd: nestedEffectiveCwd,
+          envAssignments: overrides?.envAssignments ?? options.envAssignments,
+          worktreeMode: overrides?.worktreeMode ?? options.worktreeMode
+        })?.reason ?? null;
       }
     });
     if (reason) {
@@ -2762,7 +2863,7 @@ function analyzeCommandInternal(command, depth, options) {
 // src/core/config.ts
 import { existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
 import { homedir as homedir2 } from "node:os";
-import { join as join2, resolve as resolve3 } from "node:path";
+import { join as join2, resolve as resolve4 } from "node:path";
 var DEFAULT_CONFIG = {
   version: 1,
   rules: []
@@ -2924,7 +3025,7 @@ function getUserConfigPath() {
   return join2(homedir2(), ".cc-safety-net", "config.json");
 }
 function getProjectConfigPath(cwd) {
-  return resolve3(cwd ?? process.cwd(), ".safety-net.json");
+  return resolve4(cwd ?? process.cwd(), ".safety-net.json");
 }
 
 // src/core/analyze.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -460,7 +460,12 @@ function getGitExecutionContext(tokens, cwd) {
   if (!cwd) {
     return { gitCwd: null, hasExplicitGitContext: false };
   }
-  let gitCwd = resolve(cwd);
+  let gitCwd;
+  try {
+    gitCwd = realpathSync(resolve(cwd));
+  } catch {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
   if (!isDirectory(gitCwd)) {
     return { gitCwd: null, hasExplicitGitContext: false };
   }
@@ -524,8 +529,8 @@ function isLinkedWorktree(cwd) {
     return false;
   }
   try {
-    const stat = statSync(dotGitPath);
-    if (!stat.isFile()) {
+    const stat = lstatSync(dotGitPath);
+    if (stat.isSymbolicLink() || !stat.isFile()) {
       return false;
     }
     const content = readFileSync(dotGitPath, "utf-8");
@@ -670,6 +675,7 @@ var ENV_PROXY = new Proxy({}, {
 });
 var ARITHMETIC_SENTINEL = "__CC_SAFETY_NET_ARITH_SENTINEL__";
 var BACKTICK_ATTACHED_SUFFIX_SENTINEL = "__CC_SAFETY_NET_BACKTICK_SUFFIX__";
+var DYNAMIC_SUBSTITUTION_TOKEN = "$__CC_SAFETY_NET_DYNAMIC_SUBSTITUTION__";
 function splitShellCommands(command) {
   if (hasUnclosedQuotes(command)) {
     return [[command]];
@@ -713,9 +719,14 @@ function splitShellCommands(command) {
       const { innerSegments, endIndex } = extractCommandSubstitution(tokens, i + 2);
       const attachedSuffix = _getBacktickAttachedSuffix(tokens[endIndex + 1]);
       const shouldKeepCurrent = attachedSuffix !== null && !_isRedirectOp(tokens[i - 1]) && !isOperatorToken(tokens[i - 1]);
-      if (!shouldKeepCurrent && current.length > 0) {
-        segments.push(current);
-        current = [];
+      if (current.length > 0) {
+        if (_containsGitCommandToken(current)) {
+          current.push(DYNAMIC_SUBSTITUTION_TOKEN);
+        }
+        if (!shouldKeepCurrent) {
+          segments.push(current);
+          current = [];
+        }
       }
       for (const seg of innerSegments) {
         segments.push(seg);
@@ -733,6 +744,9 @@ function splitShellCommands(command) {
         if (prefix) {
           current.push(prefix);
         }
+      }
+      if (_containsGitCommandToken(current)) {
+        current.push(DYNAMIC_SUBSTITUTION_TOKEN);
       }
       const { innerSegments, endIndex } = extractCommandSubstitution(tokens, i + 2);
       for (const seg of innerSegments) {
@@ -819,6 +833,9 @@ function _getCommandTokenText(token) {
     return token.pattern;
   }
   return null;
+}
+function _containsGitCommandToken(tokens) {
+  return tokens.some((token) => (token.split("/").pop() ?? token).toLowerCase() === "git");
 }
 function extractCommandSubstitution(tokens, startIndex) {
   if (tokens[startIndex] === ARITHMETIC_SENTINEL) {
@@ -1392,7 +1409,8 @@ function resolveWrapperCwd(cwd, target) {
     if (!cwd && !isAbsolute2(target)) {
       return null;
     }
-    return resolveChdirTarget2(cwd ?? "/", target);
+    const baseCwd = isAbsolute2(target) ? "/" : realpathSync2(cwd ?? "/");
+    return resolveChdirTarget2(baseCwd, target);
   } catch {
     return null;
   }
@@ -1767,6 +1785,7 @@ function extractDashCArg(tokens) {
 
 // src/core/rules-git.ts
 import { execFileSync } from "node:child_process";
+import { existsSync as existsSync2 } from "node:fs";
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
 var REASON_CHECKOUT_REF_PATH = "git checkout <ref> -- <path> overwrites working tree with ref version. Use 'git stash' first.";
@@ -1796,6 +1815,14 @@ var CHECKOUT_OPTS_WITH_VALUE = new Set([
 var CHECKOUT_OPTS_WITH_OPTIONAL_VALUE = new Set(["--recurse-submodules", "--track", "-t"]);
 var CHECKOUT_SHORT_OPTS_WITH_VALUE = new Set(["-b", "-B", "-U"]);
 var SWITCH_SHORT_OPTS_WITH_VALUE = new Set(["-c", "-C"]);
+var GIT_CONFIG_AFFECTING_ENV_NAMES = new Set([
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_CONFIG_SYSTEM",
+  "HOME",
+  "XDG_CONFIG_HOME"
+]);
+var TRUSTED_GIT_BINARIES = ["/usr/bin/git"];
 var CHECKOUT_KNOWN_OPTS_NO_VALUE = new Set([
   "-q",
   "--quiet",
@@ -2097,7 +2124,7 @@ function isNonRelaxableLocalDiscard(tokens, options, gitCwd) {
   return normalizedSubcommand === "clean" && countCleanForceFlags(rest) > 1;
 }
 function hasDynamicGitArgument(tokens) {
-  return tokens.some((token) => token.includes("$"));
+  return tokens.some((token) => /[$*?[]/.test(token));
 }
 function hasRecursiveSubmoduleConfig(tokens, options, gitCwd) {
   const commandLineConfig = commandLineRecursiveSubmoduleConfig(tokens, options.envAssignments);
@@ -2107,6 +2134,9 @@ function hasRecursiveSubmoduleConfig(tokens, options, gitCwd) {
   const envConfig = envRecursiveSubmoduleConfig(options.envAssignments);
   if (envConfig !== null) {
     return envConfig;
+  }
+  if (hasConfigAffectingEnvAssignment(options.envAssignments)) {
+    return true;
   }
   return effectiveGitConfigEnablesRecursiveSubmodules(gitCwd);
 }
@@ -2162,6 +2192,9 @@ function commandLineRecursiveSubmoduleConfig(tokens, envAssignments) {
   return recursiveSubmoduleConfig;
 }
 function envRecursiveSubmoduleConfig(envAssignments) {
+  if (getEnvConfigValue("GIT_CONFIG_PARAMETERS", envAssignments) !== undefined) {
+    return true;
+  }
   const countValue = getEnvConfigValue("GIT_CONFIG_COUNT", envAssignments);
   if (countValue === undefined) {
     return null;
@@ -2181,12 +2214,27 @@ function envRecursiveSubmoduleConfig(envAssignments) {
   }
   return recursiveSubmoduleConfig;
 }
+function hasConfigAffectingEnvAssignment(envAssignments) {
+  if (!envAssignments) {
+    return false;
+  }
+  for (const key of envAssignments.keys()) {
+    if (GIT_CONFIG_AFFECTING_ENV_NAMES.has(key)) {
+      return true;
+    }
+  }
+  return false;
+}
 function getEnvConfigValue(name, envAssignments) {
   return envAssignments?.get(name) ?? process.env[name];
 }
 function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
+  const gitBinary = getTrustedGitBinary();
+  if (gitBinary === null) {
+    return true;
+  }
   try {
-    const value = execFileSync("git", ["config", "--get", "submodule.recurse"], {
+    const value = execFileSync(gitBinary, ["config", "--get", "submodule.recurse"], {
       cwd,
       encoding: "utf8",
       env: withoutGitConfigEnv(process.env),
@@ -2197,10 +2245,18 @@ function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
     return !isGitConfigUnsetError(error);
   }
 }
+function getTrustedGitBinary() {
+  for (const gitBinary of TRUSTED_GIT_BINARIES) {
+    if (existsSync2(gitBinary)) {
+      return gitBinary;
+    }
+  }
+  return null;
+}
 function withoutGitConfigEnv(env) {
   const nextEnv = { ...env };
   for (const key of Object.keys(nextEnv)) {
-    if (key === "GIT_CONFIG_COUNT" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(key)) {
+    if (key === "GIT_CONFIG_COUNT" || key === "GIT_CONFIG_PARAMETERS" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(key)) {
       delete nextEnv[key];
     }
   }
@@ -2215,6 +2271,9 @@ function recursiveSubmoduleConfigValue(config) {
   }
   const eqIdx = config.indexOf("=");
   const key = (eqIdx === -1 ? config : config.slice(0, eqIdx)).toLowerCase();
+  if (isIncludeConfigKey(key)) {
+    return true;
+  }
   if (key !== "submodule.recurse") {
     return null;
   }
@@ -2230,11 +2289,18 @@ function recursiveSubmoduleConfigEnvValue(configEnv, envAssignments) {
   if (!configEnv || eqIdx === -1) {
     return null;
   }
-  if (configEnv.slice(0, eqIdx).toLowerCase() !== "submodule.recurse") {
+  const key = configEnv.slice(0, eqIdx).toLowerCase();
+  if (isIncludeConfigKey(key)) {
+    return true;
+  }
+  if (key !== "submodule.recurse") {
     return null;
   }
   const value = getEnvConfigValue(configEnv.slice(eqIdx + 1), envAssignments);
   return value === undefined || gitConfigValueEnablesRecursiveSubmodules(value);
+}
+function isIncludeConfigKey(key) {
+  return key === "include.path" || key.startsWith("includeif.") && key.endsWith(".path");
 }
 function isForcedBranchReset(subcommand, rest) {
   if (subcommand === "checkout") {
@@ -2252,13 +2318,17 @@ function isForcedBranchReset(subcommand, rest) {
       shortOptsWithValue: SWITCH_SHORT_OPTS_WITH_VALUE
     });
     const hasForce = before.includes("--force") || before.includes("--discard-changes") || shortOpts.has("-f");
-    const hasForceCreate = before.some((token) => token === "-C" || token.startsWith("-C") || token === "--force-create" || token.startsWith("--force-create=")) || shortOpts.has("-C");
+    const hasForceCreate = before.some((token) => token === "-C" || token.startsWith("-C") || isForceCreateOption(token)) || shortOpts.has("-C");
     return hasForce && hasForceCreate;
   }
   return false;
 }
+function isForceCreateOption(token) {
+  const optionName = token.split("=", 1)[0] ?? token;
+  return optionName === "--force-create" || optionName.length >= "--force-c".length && "--force-create".startsWith(optionName);
+}
 function hasRecurseSubmodulesOption(tokens) {
-  return tokens.some((token) => token === "--recurse-submodules" || token.startsWith("--recurse-submodules="));
+  return tokens.some((token) => token.startsWith("--recurse-sub"));
 }
 function countCleanForceFlags(tokens) {
   let count = 0;
@@ -2553,6 +2623,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
 // src/core/analyze/parallel.ts
 var REASON_PARALLEL_RM = "parallel rm -rf with dynamic input is dangerous. Use explicit file list instead.";
 var REASON_PARALLEL_SHELL = "parallel with shell -c can execute arbitrary commands from dynamic input.";
+var PARALLEL_PLACEHOLDER_RE = /\{[^{}\s]*\}/;
 function analyzeParallel(tokens, context) {
   const parseResult = parseParallelCommand(tokens);
   if (!parseResult) {
@@ -2586,13 +2657,13 @@ function analyzeParallel(tokens, context) {
   if (SHELL_WRAPPERS.has(head)) {
     const dashCArg = extractDashCArg(childTokens);
     if (dashCArg) {
-      if (dashCArg === "{}" || dashCArg === "{1}") {
+      if (isOnlyParallelPlaceholder(dashCArg)) {
         return REASON_PARALLEL_SHELL;
       }
-      if (dashCArg.includes("{}")) {
+      if (hasParallelPlaceholder(dashCArg)) {
         if (args.length > 0) {
           for (const arg of args) {
-            const expandedScript = dashCArg.replace(/{}/g, arg);
+            const expandedScript = replaceParallelPlaceholder(dashCArg, arg);
             const reason3 = context.analyzeNested(expandedScript, nestedOverrides);
             if (reason3) {
               return reason3;
@@ -2662,7 +2733,7 @@ function analyzeParallel(tokens, context) {
   }
   if (head === "git") {
     const gitTokenSets = hasPlaceholder && args.length > 0 ? args.map((arg) => childTokens.map((token) => replaceParallelPlaceholder(token, arg))) : !hasPlaceholder && args.length > 0 ? args.map((arg) => [...childTokens, arg]) : [childTokens];
-    const dynamicGitArgs = usesStdin || hasPlaceholder && args.length === 0;
+    const dynamicGitArgs = usesStdin || hasPlaceholder;
     for (const gitTokens of gitTokenSets) {
       const gitResult = analyzeGit(gitTokens, {
         cwd: childCwd,
@@ -2700,7 +2771,13 @@ function buildCommandsModeOverrides(context, runsRemotely) {
   return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 function replaceParallelPlaceholder(token, arg) {
-  return token.replace(/\{\}/g, arg).replace(/\{1\}/g, arg).replace(/\{\.\}/g, arg);
+  return token.replace(/\{[^{}\s]*\}/g, arg);
+}
+function hasParallelPlaceholder(token) {
+  return PARALLEL_PLACEHOLDER_RE.test(token);
+}
+function isOnlyParallelPlaceholder(token) {
+  return /^\{[^{}\s]*\}$/.test(token);
 }
 function parseParallelCommand(tokens) {
   const parallelOptsWithValue = new Set([
@@ -2799,7 +2876,7 @@ function parseParallelCommand(tokens) {
       }
     }
   }
-  const hasPlaceholder = templateTokens.some((t) => t.includes("{}") || t.includes("{1}") || t.includes("{.}"));
+  const hasPlaceholder = templateTokens.some(hasParallelPlaceholder);
   if (templateTokens.length === 0 && markerIndex === -1) {
     return null;
   }
@@ -3260,6 +3337,13 @@ function stripLeadingGrouping(tokens) {
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES2 = new Set(GIT_CONTEXT_ENV_OVERRIDES);
+var GIT_CONFIG_AFFECTING_ENV_NAMES2 = new Set([
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_CONFIG_SYSTEM",
+  "HOME",
+  "XDG_CONFIG_HOME"
+]);
 var GIT_CONTEXT_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 function analyzeCommandInternal(command, depth, options) {
   if (depth >= MAX_RECURSION_DEPTH) {
@@ -3362,7 +3446,7 @@ function applyShellGitContextEnvSegment(tokens, state) {
     return;
   }
   for (const token of tokens.slice(operandsInfo.operandsStart)) {
-    addTypesetGitContextEnvAssignment(state, token, operandsInfo.exports);
+    addTypesetGitContextEnvAssignment(state, token, operandsInfo.exports, command === "readonly" ? leadingAssignments : undefined);
   }
 }
 function getSegmentGitContextEnvAssignments(tokens, state) {
@@ -3392,7 +3476,7 @@ function getShellCommandInfo(tokens) {
     if (!assignment) {
       break;
     }
-    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
+    if (isTrackedGitEnvName(assignment.name)) {
       leadingAssignments.set(assignment.name, assignment);
     }
     i++;
@@ -3404,6 +3488,9 @@ function getShellCommandInfo(tokens) {
   let command = tokens[commandIndex] ?? null;
   if (command === "builtin") {
     commandIndex++;
+    if (tokens[commandIndex] === "--") {
+      commandIndex++;
+    }
     command = tokens[commandIndex] ?? null;
   }
   if (command === "command") {
@@ -3447,7 +3534,7 @@ function parseShellAssignment(token) {
 }
 function parseGitContextEnvAssignment(token) {
   const assignment = parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment2(token);
-  if (!assignment || !GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
+  if (!assignment || !isTrackedGitEnvName(assignment.name)) {
     return null;
   }
   return assignment;
@@ -3460,6 +3547,12 @@ function parseGitContextAppendEnvAssignment2(token) {
   }
   const eqIdx = token.indexOf("=");
   return { name, value: token.slice(eqIdx + 1) };
+}
+function isTrackedGitEnvName(name) {
+  return GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES2.has(name) || isGitConfigEnvName(name);
+}
+function isGitConfigEnvName(name) {
+  return name === "GIT_CONFIG_COUNT" || name === "GIT_CONFIG_PARAMETERS" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(name);
 }
 function setShellGitContextAssignment(state, assignment) {
   state.shellAssignments.set(assignment.name, assignment.value);
@@ -3480,15 +3573,17 @@ function addExportedGitContextEnvAssignment(state, token) {
     setEffectiveGitContextAssignment(state, assignment);
     return;
   }
-  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
+  if (isTrackedGitEnvName(token)) {
     state.exportedNames.add(token);
     const value = state.shellAssignments.get(token);
     if (value !== undefined) {
       setEffectiveGitContextAssignment(state, { name: token, value });
+    } else {
+      setEffectiveGitContextAssignment(state, { name: token, value: "" });
     }
   }
 }
-function addTypesetGitContextEnvAssignment(state, token, exports) {
+function addTypesetGitContextEnvAssignment(state, token, exports, readonlyLeadingAssignments) {
   const assignment = parseGitContextEnvAssignment(token);
   if (assignment) {
     state.shellAssignments.set(assignment.name, assignment.value);
@@ -3500,11 +3595,19 @@ function addTypesetGitContextEnvAssignment(state, token, exports) {
     }
     return;
   }
-  if (exports && GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
+  const readonlyAssignment = readonlyLeadingAssignments?.get(token);
+  if (readonlyAssignment) {
+    state.exportedNames.add(token);
+    setEffectiveGitContextAssignment(state, readonlyAssignment);
+    return;
+  }
+  if (exports && isTrackedGitEnvName(token)) {
     state.exportedNames.add(token);
     const value = state.shellAssignments.get(token);
     if (value !== undefined) {
       setEffectiveGitContextAssignment(state, { name: token, value });
+    } else {
+      setEffectiveGitContextAssignment(state, { name: token, value: "" });
     }
   }
 }
@@ -3607,7 +3710,7 @@ function getSetOptionChanges(tokens, commandIndex) {
 }
 
 // src/core/config.ts
-import { existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
+import { existsSync as existsSync3, readFileSync as readFileSync2 } from "node:fs";
 import { homedir as homedir2 } from "node:os";
 import { join as join2, resolve as resolve3 } from "node:path";
 var DEFAULT_CONFIG = {
@@ -3624,7 +3727,7 @@ function loadConfig(cwd, options) {
   return mergeConfigs(userConfig, projectConfig);
 }
 function loadSingleConfig(path) {
-  if (!existsSync2(path)) {
+  if (!existsSync3(path)) {
     return null;
   }
   try {
@@ -3750,7 +3853,7 @@ function validateRule(rule, index, ruleNames) {
 function validateConfigFile(path) {
   const errors = [];
   const ruleNames = new Set;
-  if (!existsSync2(path)) {
+  if (!existsSync3(path)) {
     errors.push(`File not found: ${path}`);
     return { errors, ruleNames };
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -399,7 +399,7 @@ function hasRecursiveForceFlags(tokens) {
 }
 
 // src/core/shell.ts
-import { isAbsolute, resolve } from "node:path";
+import { isAbsolute as isAbsolute2, resolve as resolve2 } from "node:path";
 
 // node_modules/shell-quote/index.js
 var $quote = require_quote();
@@ -428,6 +428,193 @@ var DANGEROUS_PATTERNS = [
 var PARANOID_INTERPRETERS_SUFFIX = `
 
 (Paranoid mode: interpreter one-liners are blocked.)`;
+
+// src/core/worktree.ts
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
+  "-c",
+  "-C",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--super-prefix",
+  "--config-env"
+]);
+var GIT_CONTEXT_ENV_OVERRIDES = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"];
+function hasGitContextEnvOverride(envAssignments) {
+  for (const name of GIT_CONTEXT_ENV_OVERRIDES) {
+    if (envAssignments?.has(name) || Object.hasOwn(process.env, name)) {
+      return true;
+    }
+  }
+  return false;
+}
+function getGitExecutionContext(tokens, cwd) {
+  if (!cwd) {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
+  let gitCwd = resolve(cwd);
+  if (!isDirectory(gitCwd)) {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
+  let hasExplicitGitContext = false;
+  let i = 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token)
+      break;
+    if (token === "--") {
+      break;
+    }
+    if (!token.startsWith("-")) {
+      break;
+    }
+    if (token === "-C") {
+      const target = tokens[i + 1];
+      if (!target) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      const resolvedCwd = resolveGitCwd(gitCwd, target);
+      if (!resolvedCwd) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      gitCwd = resolvedCwd;
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("-C") && token.length > 2) {
+      const resolvedCwd = resolveGitCwd(gitCwd, token.slice(2));
+      if (!resolvedCwd) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      gitCwd = resolvedCwd;
+      i++;
+      continue;
+    }
+    if (token === "--git-dir" || token === "--work-tree") {
+      hasExplicitGitContext = true;
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("--git-dir=") || token.startsWith("--work-tree=")) {
+      hasExplicitGitContext = true;
+      i++;
+      continue;
+    }
+    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(token)) {
+      i += 2;
+    } else if (token.startsWith("-c") && token.length > 2) {
+      i++;
+    } else {
+      i++;
+    }
+  }
+  return { gitCwd, hasExplicitGitContext };
+}
+function isLinkedWorktree(cwd) {
+  const dotGitPath = findDotGit(cwd);
+  if (!dotGitPath) {
+    return false;
+  }
+  try {
+    const stat = statSync(dotGitPath);
+    if (!stat.isFile()) {
+      return false;
+    }
+    const content = readFileSync(dotGitPath, "utf-8");
+    const firstLine = content.split(/\r?\n/, 1)[0]?.trim() ?? "";
+    if (!firstLine.startsWith("gitdir:")) {
+      return false;
+    }
+    const rawGitDir = firstLine.slice("gitdir:".length).trim();
+    if (rawGitDir === "") {
+      return false;
+    }
+    const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve(dirname(dotGitPath), rawGitDir);
+    if (!existsSync(join(gitDir, "commondir"))) {
+      return false;
+    }
+    return worktreeConfigMatchesRoot(gitDir, dirname(dotGitPath));
+  } catch {
+    return false;
+  }
+}
+function worktreeConfigMatchesRoot(gitDir, worktreeRoot) {
+  const configWorktreePath = join(gitDir, "config.worktree");
+  if (!existsSync(configWorktreePath)) {
+    return true;
+  }
+  const configuredWorktree = readCoreWorktree(configWorktreePath);
+  if (configuredWorktree === null) {
+    return true;
+  }
+  const resolvedConfiguredWorktree = isAbsolute(configuredWorktree) ? configuredWorktree : resolve(gitDir, configuredWorktree);
+  try {
+    return realpathSync(resolvedConfiguredWorktree) === realpathSync(worktreeRoot);
+  } catch {
+    return false;
+  }
+}
+function readCoreWorktree(configPath) {
+  const content = readFileSync(configPath, "utf-8");
+  let inCore = false;
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith(";")) {
+      continue;
+    }
+    if (trimmed.startsWith("[")) {
+      inCore = /^\[core\]$/i.test(trimmed);
+      continue;
+    }
+    if (!inCore) {
+      continue;
+    }
+    const match = trimmed.match(/^worktree\s*=\s*(.*)$/i);
+    if (match) {
+      return unquoteGitConfigValue(match[1] ?? "");
+    }
+  }
+  return null;
+}
+function unquoteGitConfigValue(value) {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') || trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+function resolveGitCwd(baseCwd, target) {
+  const resolved = isAbsolute(target) ? target : resolve(baseCwd, target);
+  return isDirectory(resolved) ? resolved : null;
+}
+function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+function findDotGit(cwd) {
+  let current;
+  try {
+    current = realpathSync(cwd);
+  } catch {
+    return null;
+  }
+  while (true) {
+    const dotGitPath = join(current, ".git");
+    if (existsSync(dotGitPath)) {
+      return dotGitPath;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
 
 // src/core/shell.ts
 var ENV_PROXY = new Proxy({}, {
@@ -894,12 +1081,23 @@ function _stripAttachedIoNumbers(command) {
   return result;
 }
 var ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
+var ENV_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
+var GIT_CONTEXT_ENV_OVERRIDE_NAMES = new Set(GIT_CONTEXT_ENV_OVERRIDES);
 function parseEnvAssignment(token) {
   if (!ENV_ASSIGNMENT_RE.test(token)) {
     return null;
   }
   const eqIdx = token.indexOf("=");
   return { name: token.slice(0, eqIdx), value: token.slice(eqIdx + 1) };
+}
+function parseGitContextAppendEnvAssignment(token) {
+  const match = token.match(ENV_APPEND_ASSIGNMENT_RE);
+  const name = match?.[1];
+  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name)) {
+    return null;
+  }
+  const eqIdx = token.indexOf("=");
+  return { name, value: token.slice(eqIdx + 1) };
 }
 function stripEnvAssignmentsWithInfo(tokens) {
   const envAssignments = new Map;
@@ -935,6 +1133,10 @@ function stripWrappersWithInfo(tokens, cwd) {
     if (result.length === 0)
       break;
     while (result.length > 0 && result[0]?.includes("=") && !ENV_ASSIGNMENT_RE.test(result[0] ?? "")) {
+      const appendAssignment = parseGitContextAppendEnvAssignment(result[0] ?? "");
+      if (appendAssignment) {
+        allEnvAssignments.set(appendAssignment.name, appendAssignment.value);
+      }
       result = result.slice(1);
     }
     if (result.length === 0)
@@ -986,10 +1188,15 @@ function stripSudoWithInfo(tokens, cwd) {
     if (!token.startsWith("-")) {
       break;
     }
-    if (token === "-D") {
+    if (token === "-D" || token === "--chdir") {
       const target = tokens[i + 1];
       currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
       i += 2;
+      continue;
+    }
+    if (token.startsWith("--chdir=")) {
+      currentCwd = resolveWrapperCwd(currentCwd, token.slice("--chdir=".length));
+      i++;
       continue;
     }
     if (SUDO_OPTS_WITH_VALUE.has(token)) {
@@ -1123,13 +1330,13 @@ function resolveWrapperCwd(cwd, target) {
   if (target === "") {
     return null;
   }
-  if (isAbsolute(target)) {
-    return resolve(target);
+  if (isAbsolute2(target)) {
+    return resolve2(target);
   }
   if (!cwd) {
     return null;
   }
-  return resolve(cwd, target);
+  return resolve2(cwd, target);
 }
 function stripCommand(tokens) {
   let i = 1;
@@ -1481,145 +1688,6 @@ function extractDashCArg(tokens) {
   return null;
 }
 
-// src/core/worktree.ts
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
-import { dirname, isAbsolute as isAbsolute2, join, resolve as resolve2 } from "node:path";
-var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
-  "-c",
-  "-C",
-  "--git-dir",
-  "--work-tree",
-  "--namespace",
-  "--super-prefix",
-  "--config-env"
-]);
-var GIT_CONTEXT_ENV_OVERRIDES = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"];
-function hasGitContextEnvOverride(envAssignments) {
-  for (const name of GIT_CONTEXT_ENV_OVERRIDES) {
-    if (envAssignments?.has(name) || Object.hasOwn(process.env, name)) {
-      return true;
-    }
-  }
-  return false;
-}
-function getGitExecutionContext(tokens, cwd) {
-  if (!cwd) {
-    return { gitCwd: null, hasExplicitGitContext: false };
-  }
-  let gitCwd = resolve2(cwd);
-  if (!isDirectory(gitCwd)) {
-    return { gitCwd: null, hasExplicitGitContext: false };
-  }
-  let hasExplicitGitContext = false;
-  let i = 1;
-  while (i < tokens.length) {
-    const token = tokens[i];
-    if (!token)
-      break;
-    if (token === "--") {
-      break;
-    }
-    if (!token.startsWith("-")) {
-      break;
-    }
-    if (token === "-C") {
-      const target = tokens[i + 1];
-      if (!target) {
-        return { gitCwd: null, hasExplicitGitContext };
-      }
-      const resolvedCwd = resolveGitCwd(gitCwd, target);
-      if (!resolvedCwd) {
-        return { gitCwd: null, hasExplicitGitContext };
-      }
-      gitCwd = resolvedCwd;
-      i += 2;
-      continue;
-    }
-    if (token.startsWith("-C") && token.length > 2) {
-      const resolvedCwd = resolveGitCwd(gitCwd, token.slice(2));
-      if (!resolvedCwd) {
-        return { gitCwd: null, hasExplicitGitContext };
-      }
-      gitCwd = resolvedCwd;
-      i++;
-      continue;
-    }
-    if (token === "--git-dir" || token === "--work-tree") {
-      hasExplicitGitContext = true;
-      i += 2;
-      continue;
-    }
-    if (token.startsWith("--git-dir=") || token.startsWith("--work-tree=")) {
-      hasExplicitGitContext = true;
-      i++;
-      continue;
-    }
-    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(token)) {
-      i += 2;
-    } else if (token.startsWith("-c") && token.length > 2) {
-      i++;
-    } else {
-      i++;
-    }
-  }
-  return { gitCwd, hasExplicitGitContext };
-}
-function isLinkedWorktree(cwd) {
-  const dotGitPath = findDotGit(cwd);
-  if (!dotGitPath) {
-    return false;
-  }
-  try {
-    const stat = statSync(dotGitPath);
-    if (!stat.isFile()) {
-      return false;
-    }
-    const content = readFileSync(dotGitPath, "utf-8");
-    const firstLine = content.split(/\r?\n/, 1)[0]?.trim() ?? "";
-    if (!firstLine.startsWith("gitdir:")) {
-      return false;
-    }
-    const rawGitDir = firstLine.slice("gitdir:".length).trim();
-    if (rawGitDir === "") {
-      return false;
-    }
-    const gitDir = isAbsolute2(rawGitDir) ? rawGitDir : resolve2(dirname(dotGitPath), rawGitDir);
-    return existsSync(join(gitDir, "commondir"));
-  } catch {
-    return false;
-  }
-}
-function resolveGitCwd(baseCwd, target) {
-  const resolved = isAbsolute2(target) ? target : resolve2(baseCwd, target);
-  return isDirectory(resolved) ? resolved : null;
-}
-function isDirectory(path) {
-  try {
-    return statSync(path).isDirectory();
-  } catch {
-    return false;
-  }
-}
-function findDotGit(cwd) {
-  let current;
-  try {
-    current = realpathSync(cwd);
-  } catch {
-    return null;
-  }
-  while (true) {
-    const dotGitPath = join(current, ".git");
-    if (existsSync(dotGitPath)) {
-      return dotGitPath;
-    }
-    const parent = dirname(current);
-    if (parent === current) {
-      return null;
-    }
-    current = parent;
-  }
-}
-
 // src/core/rules-git.ts
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
@@ -1748,7 +1816,7 @@ function sharedState(reason) {
   return reason ? { reason, localDiscard: false } : null;
 }
 function getGitWorktreeRelaxationForMatch(tokens, match, options) {
-  if (!match.localDiscard || !options.worktreeMode || hasGitContextEnvOverride(options.envAssignments)) {
+  if (!match.localDiscard || !options.worktreeMode || hasGitContextEnvOverride(options.envAssignments) || isNonRelaxableLocalDiscard(tokens)) {
     return null;
   }
   const context = getGitExecutionContext(tokens, options.cwd);
@@ -1938,6 +2006,34 @@ function analyzeGitClean(tokens) {
     return REASON_CLEAN;
   }
   return null;
+}
+function isNonRelaxableLocalDiscard(tokens) {
+  const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
+  const normalizedSubcommand = subcommand?.toLowerCase();
+  if (hasRecurseSubmodulesOption(rest)) {
+    return true;
+  }
+  return normalizedSubcommand === "clean" && countCleanForceFlags(rest) > 1;
+}
+function hasRecurseSubmodulesOption(tokens) {
+  return tokens.some((token) => token === "--recurse-submodules" || token.startsWith("--recurse-submodules="));
+}
+function countCleanForceFlags(tokens) {
+  let count = 0;
+  for (const token of tokens) {
+    if (token === "--force") {
+      count++;
+      continue;
+    }
+    if (token.startsWith("-") && !token.startsWith("--")) {
+      for (const opt of token.slice(1)) {
+        if (opt === "f") {
+          count++;
+        }
+      }
+    }
+  }
+  return count;
 }
 function analyzeGitPush(tokens) {
   let hasForceWithLease = false;
@@ -2909,7 +3005,7 @@ function stripLeadingGrouping(tokens) {
 // src/core/analyze/analyze-command.ts
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
-var GIT_CONTEXT_ENV_OVERRIDE_NAMES = new Set(GIT_CONTEXT_ENV_OVERRIDES);
+var GIT_CONTEXT_ENV_OVERRIDE_NAMES2 = new Set(GIT_CONTEXT_ENV_OVERRIDES);
 function analyzeCommandInternal(command, depth, options) {
   if (depth >= MAX_RECURSION_DEPTH) {
     return { reason: REASON_RECURSION_LIMIT, segment: command };
@@ -2921,6 +3017,7 @@ function analyzeCommandInternal(command, depth, options) {
   const originalCwd = options.cwd;
   let effectiveCwd = options.effectiveCwd !== undefined ? options.effectiveCwd : options.cwd;
   let effectiveEnvAssignments = options.envAssignments;
+  const shellGitContextAssignments = new Map;
   for (const segment of segments) {
     const segmentStr = segment.join(" ");
     const segmentEnvAssignments = effectiveEnvAssignments;
@@ -2955,7 +3052,11 @@ function analyzeCommandInternal(command, depth, options) {
     if (segmentChangesCwd(segment)) {
       effectiveCwd = null;
     }
-    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment);
+    const shellAssignments = getShellGitContextEnvAssignments(segment);
+    for (const [k, v] of shellAssignments) {
+      shellGitContextAssignments.set(k, v);
+    }
+    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment, shellGitContextAssignments);
     if (exportedEnvAssignments.size > 0) {
       const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
       for (const [k, v] of exportedEnvAssignments) {
@@ -2966,21 +3067,84 @@ function analyzeCommandInternal(command, depth, options) {
   }
   return null;
 }
-function getExportedGitContextEnvAssignments(tokens) {
+function getShellGitContextEnvAssignments(tokens) {
   const result = new Map;
-  if (tokens[0] !== "export") {
-    return result;
-  }
-  for (const token of tokens.slice(1)) {
-    if (token.startsWith("-")) {
+  for (const token of tokens) {
+    const assignment = parseEnvAssignment(token);
+    if (!assignment) {
       return new Map;
     }
-    const assignment = parseEnvAssignment(token);
-    if (assignment && GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
+    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
       result.set(assignment.name, assignment.value);
     }
   }
   return result;
+}
+function getExportedGitContextEnvAssignments(tokens, shellGitContextAssignments) {
+  const result = new Map;
+  const command = tokens[0];
+  if (!command) {
+    return result;
+  }
+  const operandsStart = command === "export" ? getExportOperandsStart(tokens) : command === "typeset" || command === "declare" ? getTypesetExportOperandsStart(tokens) : null;
+  if (operandsStart === null) {
+    return result;
+  }
+  for (const token of tokens.slice(operandsStart)) {
+    addExportedGitContextEnvAssignment(result, shellGitContextAssignments, token);
+  }
+  return result;
+}
+function getExportOperandsStart(tokens) {
+  const firstOperand = tokens[1];
+  if (firstOperand === undefined) {
+    return 1;
+  }
+  if (firstOperand === "--") {
+    return 2;
+  }
+  if (firstOperand.startsWith("-")) {
+    return null;
+  }
+  return 1;
+}
+function getTypesetExportOperandsStart(tokens) {
+  let i = 1;
+  let hasExportFlag = false;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    if (token === "--") {
+      return hasExportFlag ? i + 1 : null;
+    }
+    if (token.startsWith("-")) {
+      hasExportFlag = hasExportFlag || token.slice(1).includes("x");
+      i++;
+      continue;
+    }
+    if (token.startsWith("+")) {
+      return null;
+    }
+    return hasExportFlag ? i : null;
+  }
+  return hasExportFlag ? i : null;
+}
+function addExportedGitContextEnvAssignment(result, shellGitContextAssignments, token) {
+  const assignment = parseEnvAssignment(token);
+  if (assignment) {
+    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
+      result.set(assignment.name, assignment.value);
+    }
+    return;
+  }
+  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
+    const value = shellGitContextAssignments.get(token);
+    if (value !== undefined) {
+      result.set(token, value);
+    }
+  }
 }
 
 // src/core/config.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -399,7 +399,8 @@ function hasRecursiveForceFlags(tokens) {
 }
 
 // src/core/shell.ts
-import { isAbsolute as isAbsolute2, resolve as resolve2 } from "node:path";
+import { lstatSync as lstatSync2, realpathSync as realpathSync2 } from "node:fs";
+import { dirname as dirname2, isAbsolute as isAbsolute2 } from "node:path";
 
 // node_modules/shell-quote/index.js
 var $quote = require_quote();
@@ -430,7 +431,7 @@ var PARANOID_INTERPRETERS_SUFFIX = `
 (Paranoid mode: interpreter one-liners are blocked.)`;
 
 // src/core/worktree.ts
-import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
   "-c",
@@ -441,7 +442,12 @@ var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
   "--super-prefix",
   "--config-env"
 ]);
-var GIT_CONTEXT_ENV_OVERRIDES = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"];
+var GIT_CONTEXT_ENV_OVERRIDES = [
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_COMMON_DIR",
+  "GIT_INDEX_FILE"
+];
 function hasGitContextEnvOverride(envAssignments) {
   for (const name of GIT_CONTEXT_ENV_OVERRIDES) {
     if (envAssignments?.has(name) || Object.hasOwn(process.env, name)) {
@@ -535,7 +541,26 @@ function isLinkedWorktree(cwd) {
     if (!existsSync(join(gitDir, "commondir"))) {
       return false;
     }
+    if (!worktreeGitdirBacklinkMatches(gitDir, dotGitPath)) {
+      return false;
+    }
     return worktreeConfigMatchesRoot(gitDir, dirname(dotGitPath));
+  } catch {
+    return false;
+  }
+}
+function worktreeGitdirBacklinkMatches(gitDir, dotGitPath) {
+  const backlinkPath = join(gitDir, "gitdir");
+  if (!existsSync(backlinkPath)) {
+    return false;
+  }
+  const rawBacklink = readFileSync(backlinkPath, "utf-8").split(/\r?\n/, 1)[0]?.trim() ?? "";
+  if (rawBacklink === "") {
+    return false;
+  }
+  const linkedDotGitPath = isAbsolute(rawBacklink) ? rawBacklink : resolve(gitDir, rawBacklink);
+  try {
+    return realpathSync(linkedDotGitPath) === realpathSync(dotGitPath);
   } catch {
     return false;
   }
@@ -559,6 +584,7 @@ function worktreeConfigMatchesRoot(gitDir, worktreeRoot) {
 function readCoreWorktree(configPath) {
   const content = readFileSync(configPath, "utf-8");
   let inCore = false;
+  let configuredWorktree = null;
   for (const line of content.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith(";")) {
@@ -573,10 +599,10 @@ function readCoreWorktree(configPath) {
     }
     const match = trimmed.match(/^worktree\s*=\s*(.*)$/i);
     if (match) {
-      return unquoteGitConfigValue(match[1] ?? "");
+      configuredWorktree = unquoteGitConfigValue(match[1] ?? "");
     }
   }
-  return null;
+  return configuredWorktree;
 }
 function unquoteGitConfigValue(value) {
   const trimmed = value.trim();
@@ -586,8 +612,30 @@ function unquoteGitConfigValue(value) {
   return trimmed;
 }
 function resolveGitCwd(baseCwd, target) {
-  const resolved = isAbsolute(target) ? target : resolve(baseCwd, target);
-  return isDirectory(resolved) ? resolved : null;
+  try {
+    const resolved = resolveChdirTarget(baseCwd, target);
+    return isDirectory(resolved) ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+function resolveChdirTarget(baseCwd, target) {
+  let current = isAbsolute(target) ? "/" : baseCwd;
+  for (const component of target.split("/")) {
+    if (component === "" || component === ".") {
+      continue;
+    }
+    if (component === "..") {
+      current = dirname(current);
+      continue;
+    }
+    const candidate = appendPathWithoutNormalizing(current, component);
+    current = lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
+  }
+  return current;
+}
+function appendPathWithoutNormalizing(base, target) {
+  return base.endsWith("/") ? `${base}${target}` : `${base}/${target}`;
 }
 function isDirectory(path) {
   try {
@@ -1199,6 +1247,16 @@ function stripSudoWithInfo(tokens, cwd) {
       i++;
       continue;
     }
+    if (token.startsWith("-D") && token.length > 2) {
+      currentCwd = resolveWrapperCwd(currentCwd, token.slice(2));
+      i++;
+      continue;
+    }
+    if (token === "-i" || token === "--login") {
+      currentCwd = null;
+      i++;
+      continue;
+    }
     if (SUDO_OPTS_WITH_VALUE.has(token)) {
       i += 2;
       continue;
@@ -1330,13 +1388,32 @@ function resolveWrapperCwd(cwd, target) {
   if (target === "") {
     return null;
   }
-  if (isAbsolute2(target)) {
-    return resolve2(target);
-  }
-  if (!cwd) {
+  try {
+    if (!cwd && !isAbsolute2(target)) {
+      return null;
+    }
+    return resolveChdirTarget2(cwd ?? "/", target);
+  } catch {
     return null;
   }
-  return resolve2(cwd, target);
+}
+function resolveChdirTarget2(baseCwd, target) {
+  let current = isAbsolute2(target) ? "/" : baseCwd;
+  for (const component of target.split("/")) {
+    if (component === "" || component === ".") {
+      continue;
+    }
+    if (component === "..") {
+      current = dirname2(current);
+      continue;
+    }
+    const candidate = appendPathWithoutNormalizing2(current, component);
+    current = lstatSync2(candidate).isSymbolicLink() ? realpathSync2(candidate) : candidate;
+  }
+  return current;
+}
+function appendPathWithoutNormalizing2(base, target) {
+  return base.endsWith("/") ? `${base}${target}` : `${base}/${target}`;
 }
 function stripCommand(tokens) {
   let i = 1;
@@ -2010,10 +2087,95 @@ function analyzeGitClean(tokens) {
 function isNonRelaxableLocalDiscard(tokens) {
   const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
   const normalizedSubcommand = subcommand?.toLowerCase();
-  if (hasRecurseSubmodulesOption(rest)) {
+  if (hasRecursiveSubmoduleConfig(tokens) || hasRecurseSubmodulesOption(rest) || isForcedBranchReset(normalizedSubcommand, rest)) {
     return true;
   }
   return normalizedSubcommand === "clean" && countCleanForceFlags(rest) > 1;
+}
+function hasRecursiveSubmoduleConfig(tokens) {
+  let i = 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token || token === "--") {
+      return false;
+    }
+    if (!token.startsWith("-")) {
+      return false;
+    }
+    if (token === "-c") {
+      if (configEnablesRecursiveSubmodules(tokens[i + 1])) {
+        return true;
+      }
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("-c") && token.length > 2) {
+      if (configEnablesRecursiveSubmodules(token.slice(2))) {
+        return true;
+      }
+      i++;
+      continue;
+    }
+    if (token === "--config-env") {
+      if (configEnvTargetsRecursiveSubmodules(tokens[i + 1])) {
+        return true;
+      }
+      i += 2;
+      continue;
+    }
+    if (token.startsWith("--config-env=")) {
+      if (configEnvTargetsRecursiveSubmodules(token.slice("--config-env=".length))) {
+        return true;
+      }
+      i++;
+      continue;
+    }
+    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(token)) {
+      i += 2;
+    } else {
+      i++;
+    }
+  }
+  return false;
+}
+function configEnablesRecursiveSubmodules(config) {
+  if (!config) {
+    return false;
+  }
+  const eqIdx = config.indexOf("=");
+  const key = (eqIdx === -1 ? config : config.slice(0, eqIdx)).toLowerCase();
+  if (key !== "submodule.recurse") {
+    return false;
+  }
+  const value = eqIdx === -1 ? "true" : config.slice(eqIdx + 1).toLowerCase();
+  return value !== "false" && value !== "no" && value !== "off" && value !== "0";
+}
+function configEnvTargetsRecursiveSubmodules(configEnv) {
+  const eqIdx = configEnv?.indexOf("=") ?? -1;
+  if (!configEnv || eqIdx === -1) {
+    return false;
+  }
+  return configEnv.slice(0, eqIdx).toLowerCase() === "submodule.recurse";
+}
+function isForcedBranchReset(subcommand, rest) {
+  if (subcommand === "checkout") {
+    const { before } = splitAtDoubleDash(rest);
+    const shortOpts = extractShortOpts(before, {
+      shortOptsWithValue: CHECKOUT_SHORT_OPTS_WITH_VALUE
+    });
+    const hasForce = before.includes("--force") || shortOpts.has("-f");
+    return hasForce && before.some((token) => token === "-B" || token.startsWith("-B"));
+  }
+  if (subcommand === "switch") {
+    const { before } = splitAtDoubleDash(rest);
+    const shortOpts = extractShortOpts(before, {
+      shortOptsWithValue: SWITCH_SHORT_OPTS_WITH_VALUE
+    });
+    const hasForce = before.includes("--force") || shortOpts.has("-f");
+    const hasForceCreate = before.some((token) => token === "-C" || token.startsWith("-C") || token === "--force-create" || token.startsWith("--force-create="));
+    return hasForce && hasForceCreate;
+  }
+  return false;
 }
 function hasRecurseSubmodulesOption(tokens) {
   return tokens.some((token) => token === "--recurse-submodules" || token.startsWith("--recurse-submodules="));
@@ -2081,9 +2243,9 @@ function analyzeGitWorktree(tokens) {
 }
 
 // src/core/rules-rm.ts
-import { realpathSync as realpathSync2 } from "node:fs";
+import { realpathSync as realpathSync3 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { normalize, resolve as resolve3, sep } from "node:path";
+import { normalize, resolve as resolve2, sep } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison(p) {
   let normalized = normalize(p);
@@ -2255,13 +2417,13 @@ function isCwdSelfTarget(target, cwd) {
     return true;
   }
   try {
-    const resolved = resolve3(cwd, target);
-    const realCwd = realpathSync2(cwd);
-    const realResolved = realpathSync2(resolved);
+    const resolved = resolve2(cwd, target);
+    const realCwd = realpathSync3(cwd);
+    const realResolved = realpathSync3(resolved);
     return normalizePathForComparison(realResolved) === normalizePathForComparison(realCwd);
   } catch {
     try {
-      const resolved = resolve3(cwd, target);
+      const resolved = resolve2(cwd, target);
       return normalizePathForComparison(resolved) === normalizePathForComparison(cwd);
     } catch {
       return false;
@@ -2287,7 +2449,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   }
   if (target.startsWith("./") || target.startsWith(".\\") || !target.includes("/") && !target.includes("\\")) {
     try {
-      const resolved = resolve3(resolveCwd, target);
+      const resolved = resolve2(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison(resolved);
       const normalizedOriginalCwd = normalizePathForComparison(originalCwd);
       return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep}`) || normalizedResolved === normalizedOriginalCwd;
@@ -2299,7 +2461,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     return false;
   }
   try {
-    const resolved = resolve3(resolveCwd, target);
+    const resolved = resolve2(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison(resolved);
     const normalizedCwd = normalizePathForComparison(originalCwd);
     return normalizedResolved.startsWith(`${normalizedCwd}${sep}`) || normalizedResolved === normalizedCwd;
@@ -2316,7 +2478,7 @@ function analyzeParallel(tokens, context) {
   if (!parseResult) {
     return null;
   }
-  const { template, args, hasPlaceholder, runsRemotely } = parseResult;
+  const { template, args, hasPlaceholder, runsRemotely, usesStdin } = parseResult;
   if (template.length === 0) {
     const nestedOverrides2 = buildCommandsModeOverrides(context, runsRemotely);
     for (const arg of args) {
@@ -2418,12 +2580,13 @@ function analyzeParallel(tokens, context) {
     }
   }
   if (head === "git") {
-    const gitTokenSets = !hasPlaceholder && args.length > 0 ? args.map((arg) => [...childTokens, arg]) : [childTokens];
+    const gitTokenSets = hasPlaceholder && args.length > 0 ? args.map((arg) => childTokens.map((token) => replaceParallelPlaceholder(token, arg))) : !hasPlaceholder && args.length > 0 ? args.map((arg) => [...childTokens, arg]) : [childTokens];
+    const dynamicGitArgs = usesStdin || hasPlaceholder && args.length === 0;
     for (const gitTokens of gitTokenSets) {
       const gitResult = analyzeGit(gitTokens, {
         cwd: childCwd,
         envAssignments: childEnvAssignments,
-        worktreeMode: runsRemotely ? false : context.worktreeMode
+        worktreeMode: runsRemotely || dynamicGitArgs ? false : context.worktreeMode
       });
       if (gitResult) {
         return gitResult;
@@ -2454,6 +2617,9 @@ function buildCommandsModeOverrides(context, runsRemotely) {
     overrides.worktreeMode = false;
   }
   return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
+function replaceParallelPlaceholder(token, arg) {
+  return token.replace(/\{\}/g, arg).replace(/\{1\}/g, arg).replace(/\{\.\}/g, arg);
 }
 function parseParallelCommand(tokens) {
   const parallelOptsWithValue = new Set([
@@ -2556,7 +2722,13 @@ function parseParallelCommand(tokens) {
   if (templateTokens.length === 0 && markerIndex === -1) {
     return null;
   }
-  return { template: templateTokens, args, hasPlaceholder, runsRemotely };
+  return {
+    template: templateTokens,
+    args,
+    hasPlaceholder,
+    runsRemotely,
+    usesStdin: markerIndex === -1
+  };
 }
 
 // src/core/analyze/tmpdir.ts
@@ -2632,7 +2804,7 @@ function analyzeXargs(tokens, context) {
     const gitResult = analyzeGit(gitTokens, {
       cwd: childCwd,
       envAssignments: childEnvAssignments,
-      worktreeMode: context.worktreeMode
+      worktreeMode: replacementToken === null ? false : context.worktreeMode
     });
     if (gitResult) {
       return gitResult;
@@ -3006,6 +3178,7 @@ function stripLeadingGrouping(tokens) {
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES2 = new Set(GIT_CONTEXT_ENV_OVERRIDES);
+var GIT_CONTEXT_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 function analyzeCommandInternal(command, depth, options) {
   if (depth >= MAX_RECURSION_DEPTH) {
     return { reason: REASON_RECURSION_LIMIT, segment: command };
@@ -3016,11 +3189,10 @@ function analyzeCommandInternal(command, depth, options) {
   }
   const originalCwd = options.cwd;
   let effectiveCwd = options.effectiveCwd !== undefined ? options.effectiveCwd : options.cwd;
-  let effectiveEnvAssignments = options.envAssignments;
-  const shellGitContextAssignments = new Map;
+  const shellGitContextState = createShellGitContextEnvState(options.envAssignments);
   for (const segment of segments) {
     const segmentStr = segment.join(" ");
-    const segmentEnvAssignments = effectiveEnvAssignments;
+    const segmentEnvAssignments = shellGitContextState.effectiveEnvAssignments;
     if (segment.length === 1 && segment[0]?.includes(" ")) {
       const textReason = dangerousInText(segment[0]);
       if (textReason) {
@@ -3052,64 +3224,173 @@ function analyzeCommandInternal(command, depth, options) {
     if (segmentChangesCwd(segment)) {
       effectiveCwd = null;
     }
-    const shellAssignments = getShellGitContextEnvAssignments(segment);
-    for (const [k, v] of shellAssignments) {
-      shellGitContextAssignments.set(k, v);
-    }
-    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment, shellGitContextAssignments);
-    if (exportedEnvAssignments.size > 0) {
-      const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
-      for (const [k, v] of exportedEnvAssignments) {
-        nextEnvAssignments.set(k, v);
-      }
-      effectiveEnvAssignments = nextEnvAssignments;
-    }
+    applyShellGitContextEnvSegment(segment, shellGitContextState);
   }
   return null;
 }
-function getShellGitContextEnvAssignments(tokens) {
-  const result = new Map;
-  for (const token of tokens) {
-    const assignment = parseEnvAssignment(token);
+function createShellGitContextEnvState(effectiveEnvAssignments) {
+  return {
+    effectiveEnvAssignments,
+    shellAssignments: new Map,
+    exportedNames: new Set,
+    allexport: false
+  };
+}
+function applyShellGitContextEnvSegment(tokens, state) {
+  const commandInfo = getShellCommandInfo(tokens);
+  if (!commandInfo) {
+    return;
+  }
+  const { command, commandIndex, leadingAssignments } = commandInfo;
+  if (command === null) {
+    for (const assignment of leadingAssignments.values()) {
+      setShellGitContextAssignment(state, assignment);
+    }
+    return;
+  }
+  if (command === "set") {
+    const allexport = getAllexportChange(tokens, commandIndex);
+    if (allexport !== null) {
+      state.allexport = allexport;
+    }
+    return;
+  }
+  if (command !== "export" && command !== "typeset" && command !== "declare") {
+    return;
+  }
+  for (const assignment of leadingAssignments.values()) {
+    setShellGitContextAssignment(state, assignment);
+  }
+  if (command === "export") {
+    const operandsStart = getExportOperandsStart(tokens, commandIndex);
+    if (operandsStart === null) {
+      return;
+    }
+    for (const token of tokens.slice(operandsStart)) {
+      addExportedGitContextEnvAssignment(state, token);
+    }
+    return;
+  }
+  const operandsInfo = getTypesetOperandsInfo(tokens, commandIndex);
+  if (operandsInfo === null) {
+    return;
+  }
+  for (const token of tokens.slice(operandsInfo.operandsStart)) {
+    addTypesetGitContextEnvAssignment(state, token, operandsInfo.exports);
+  }
+}
+function getShellCommandInfo(tokens) {
+  const leadingAssignments = new Map;
+  let i = 0;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    const assignment = parseShellAssignment(token);
     if (!assignment) {
-      return new Map;
+      break;
     }
     if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
-      result.set(assignment.name, assignment.value);
+      leadingAssignments.set(assignment.name, assignment);
+    }
+    i++;
+  }
+  if (i >= tokens.length) {
+    return { command: null, commandIndex: i, leadingAssignments };
+  }
+  let commandIndex = i;
+  let command = tokens[commandIndex] ?? null;
+  if (command === "builtin" || command === "command") {
+    commandIndex++;
+    command = tokens[commandIndex] ?? null;
+  }
+  if (command === null) {
+    return null;
+  }
+  return { command, commandIndex, leadingAssignments };
+}
+function parseShellAssignment(token) {
+  return parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment2(token);
+}
+function parseGitContextEnvAssignment(token) {
+  const assignment = parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment2(token);
+  if (!assignment || !GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
+    return null;
+  }
+  return assignment;
+}
+function parseGitContextAppendEnvAssignment2(token) {
+  const match = token.match(GIT_CONTEXT_APPEND_ASSIGNMENT_RE);
+  const name = match?.[1];
+  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name)) {
+    return null;
+  }
+  const eqIdx = token.indexOf("=");
+  return { name, value: token.slice(eqIdx + 1) };
+}
+function setShellGitContextAssignment(state, assignment) {
+  state.shellAssignments.set(assignment.name, assignment.value);
+  if (state.allexport || state.exportedNames.has(assignment.name)) {
+    setEffectiveGitContextAssignment(state, assignment);
+  }
+}
+function setEffectiveGitContextAssignment(state, assignment) {
+  const nextEnvAssignments = new Map(state.effectiveEnvAssignments ?? []);
+  nextEnvAssignments.set(assignment.name, assignment.value);
+  state.effectiveEnvAssignments = nextEnvAssignments;
+}
+function addExportedGitContextEnvAssignment(state, token) {
+  const assignment = parseGitContextEnvAssignment(token);
+  if (assignment) {
+    state.shellAssignments.set(assignment.name, assignment.value);
+    state.exportedNames.add(assignment.name);
+    setEffectiveGitContextAssignment(state, assignment);
+    return;
+  }
+  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
+    state.exportedNames.add(token);
+    const value = state.shellAssignments.get(token);
+    if (value !== undefined) {
+      setEffectiveGitContextAssignment(state, { name: token, value });
     }
   }
-  return result;
 }
-function getExportedGitContextEnvAssignments(tokens, shellGitContextAssignments) {
-  const result = new Map;
-  const command = tokens[0];
-  if (!command) {
-    return result;
+function addTypesetGitContextEnvAssignment(state, token, exports) {
+  const assignment = parseGitContextEnvAssignment(token);
+  if (assignment) {
+    state.shellAssignments.set(assignment.name, assignment.value);
+    if (exports) {
+      state.exportedNames.add(assignment.name);
+      setEffectiveGitContextAssignment(state, assignment);
+    } else if (state.allexport || state.exportedNames.has(assignment.name)) {
+      setEffectiveGitContextAssignment(state, assignment);
+    }
+    return;
   }
-  const operandsStart = command === "export" ? getExportOperandsStart(tokens) : command === "typeset" || command === "declare" ? getTypesetExportOperandsStart(tokens) : null;
-  if (operandsStart === null) {
-    return result;
+  if (exports && GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
+    state.exportedNames.add(token);
+    const value = state.shellAssignments.get(token);
+    if (value !== undefined) {
+      setEffectiveGitContextAssignment(state, { name: token, value });
+    }
   }
-  for (const token of tokens.slice(operandsStart)) {
-    addExportedGitContextEnvAssignment(result, shellGitContextAssignments, token);
-  }
-  return result;
 }
-function getExportOperandsStart(tokens) {
-  const firstOperand = tokens[1];
+function getExportOperandsStart(tokens, commandIndex) {
+  const firstOperand = tokens[commandIndex + 1];
   if (firstOperand === undefined) {
-    return 1;
+    return commandIndex + 1;
   }
   if (firstOperand === "--") {
-    return 2;
+    return commandIndex + 2;
   }
   if (firstOperand.startsWith("-")) {
     return null;
   }
-  return 1;
+  return commandIndex + 1;
 }
-function getTypesetExportOperandsStart(tokens) {
-  let i = 1;
+function getTypesetOperandsInfo(tokens, commandIndex) {
+  let i = commandIndex + 1;
   let hasExportFlag = false;
   while (i < tokens.length) {
     const token = tokens[i];
@@ -3117,7 +3398,7 @@ function getTypesetExportOperandsStart(tokens) {
       return null;
     }
     if (token === "--") {
-      return hasExportFlag ? i + 1 : null;
+      return { operandsStart: i + 1, exports: hasExportFlag };
     }
     if (token.startsWith("-")) {
       hasExportFlag = hasExportFlag || token.slice(1).includes("x");
@@ -3127,30 +3408,39 @@ function getTypesetExportOperandsStart(tokens) {
     if (token.startsWith("+")) {
       return null;
     }
-    return hasExportFlag ? i : null;
+    return { operandsStart: i, exports: hasExportFlag };
   }
-  return hasExportFlag ? i : null;
+  return { operandsStart: i, exports: hasExportFlag };
 }
-function addExportedGitContextEnvAssignment(result, shellGitContextAssignments, token) {
-  const assignment = parseEnvAssignment(token);
-  if (assignment) {
-    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(assignment.name)) {
-      result.set(assignment.name, assignment.value);
+function getAllexportChange(tokens, commandIndex) {
+  let i = commandIndex + 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
     }
-    return;
-  }
-  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(token)) {
-    const value = shellGitContextAssignments.get(token);
-    if (value !== undefined) {
-      result.set(token, value);
+    if (token === "-o" || token === "+o") {
+      if (tokens[i + 1] === "allexport") {
+        return token === "-o";
+      }
+      i += 2;
+      continue;
     }
+    if (token.startsWith("-") && token.slice(1).includes("a")) {
+      return true;
+    }
+    if (token.startsWith("+") && token.slice(1).includes("a")) {
+      return false;
+    }
+    i++;
   }
+  return null;
 }
 
 // src/core/config.ts
 import { existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
 import { homedir as homedir2 } from "node:os";
-import { join as join2, resolve as resolve4 } from "node:path";
+import { join as join2, resolve as resolve3 } from "node:path";
 var DEFAULT_CONFIG = {
   version: 1,
   rules: []
@@ -3312,7 +3602,7 @@ function getUserConfigPath() {
   return join2(homedir2(), ".cc-safety-net", "config.json");
 }
 function getProjectConfigPath(cwd) {
-  return resolve4(cwd ?? process.cwd(), ".safety-net.json");
+  return resolve3(cwd ?? process.cwd(), ".safety-net.json");
 }
 
 // src/core/analyze.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -594,10 +594,14 @@ function sameFilesystemPath(left, right) {
       return true;
     }
   } catch {}
-  return normalizePathForComparison(realpathSync(left)) === normalizePathForComparison(realpathSync(right));
+  return getCanonicalPathForComparison(left) === getCanonicalPathForComparison(right);
+}
+function getCanonicalPathForComparison(path) {
+  return normalizePathForComparison(realpathSync.native(path));
 }
 function normalizePathForComparison(path) {
-  let normalized = path.replace(/\\/g, "/");
+  let normalized = path.replace(/^\\\\\?\\UNC\\/i, "//").replace(/^\\\\\?\\/i, "");
+  normalized = normalized.replace(/\\/g, "/");
   if (normalized.length > 1 && normalized.endsWith("/")) {
     normalized = normalized.slice(0, -1);
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1766,6 +1766,7 @@ function extractDashCArg(tokens) {
 }
 
 // src/core/rules-git.ts
+import { execFileSync } from "node:child_process";
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
 var REASON_CHECKOUT_REF_PATH = "git checkout <ref> -- <path> overwrites working tree with ref version. Use 'git stash' first.";
@@ -1893,7 +1894,7 @@ function sharedState(reason) {
   return reason ? { reason, localDiscard: false } : null;
 }
 function getGitWorktreeRelaxationForMatch(tokens, match, options) {
-  if (!match.localDiscard || !options.worktreeMode || hasGitContextEnvOverride(options.envAssignments) || isNonRelaxableLocalDiscard(tokens)) {
+  if (!match.localDiscard || !options.worktreeMode || hasGitContextEnvOverride(options.envAssignments)) {
     return null;
   }
   const context = getGitExecutionContext(tokens, options.cwd);
@@ -1901,6 +1902,9 @@ function getGitWorktreeRelaxationForMatch(tokens, match, options) {
     return null;
   }
   if (!isLinkedWorktree(context.gitCwd)) {
+    return null;
+  }
+  if (isNonRelaxableLocalDiscard(tokens, options, context.gitCwd)) {
     return null;
   }
   return {
@@ -2084,48 +2088,67 @@ function analyzeGitClean(tokens) {
   }
   return null;
 }
-function isNonRelaxableLocalDiscard(tokens) {
+function isNonRelaxableLocalDiscard(tokens, options, gitCwd) {
   const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
   const normalizedSubcommand = subcommand?.toLowerCase();
-  if (hasRecursiveSubmoduleConfig(tokens) || hasRecurseSubmodulesOption(rest) || isForcedBranchReset(normalizedSubcommand, rest)) {
+  if (hasDynamicGitArgument(rest) || hasRecursiveSubmoduleConfig(tokens, options, gitCwd) || hasRecurseSubmodulesOption(rest) || isForcedBranchReset(normalizedSubcommand, rest)) {
     return true;
   }
   return normalizedSubcommand === "clean" && countCleanForceFlags(rest) > 1;
 }
-function hasRecursiveSubmoduleConfig(tokens) {
+function hasDynamicGitArgument(tokens) {
+  return tokens.some((token) => token.includes("$"));
+}
+function hasRecursiveSubmoduleConfig(tokens, options, gitCwd) {
+  const commandLineConfig = commandLineRecursiveSubmoduleConfig(tokens, options.envAssignments);
+  if (commandLineConfig !== null) {
+    return commandLineConfig;
+  }
+  const envConfig = envRecursiveSubmoduleConfig(options.envAssignments);
+  if (envConfig !== null) {
+    return envConfig;
+  }
+  return effectiveGitConfigEnablesRecursiveSubmodules(gitCwd);
+}
+function commandLineRecursiveSubmoduleConfig(tokens, envAssignments) {
+  let recursiveSubmoduleConfig = null;
   let i = 1;
   while (i < tokens.length) {
     const token = tokens[i];
     if (!token || token === "--") {
-      return false;
+      return recursiveSubmoduleConfig;
     }
     if (!token.startsWith("-")) {
-      return false;
+      return recursiveSubmoduleConfig;
     }
     if (token === "-c") {
-      if (configEnablesRecursiveSubmodules(tokens[i + 1])) {
-        return true;
+      const configValue = recursiveSubmoduleConfigValue(tokens[i + 1]);
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i += 2;
       continue;
     }
     if (token.startsWith("-c") && token.length > 2) {
-      if (configEnablesRecursiveSubmodules(token.slice(2))) {
-        return true;
+      const configValue = recursiveSubmoduleConfigValue(token.slice(2));
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i++;
       continue;
     }
     if (token === "--config-env") {
-      if (configEnvTargetsRecursiveSubmodules(tokens[i + 1])) {
-        return true;
+      const configValue = recursiveSubmoduleConfigEnvValue(tokens[i + 1], envAssignments);
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i += 2;
       continue;
     }
     if (token.startsWith("--config-env=")) {
-      if (configEnvTargetsRecursiveSubmodules(token.slice("--config-env=".length))) {
-        return true;
+      const configValue = recursiveSubmoduleConfigEnvValue(token.slice("--config-env=".length), envAssignments);
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i++;
       continue;
@@ -2136,26 +2159,82 @@ function hasRecursiveSubmoduleConfig(tokens) {
       i++;
     }
   }
-  return false;
+  return recursiveSubmoduleConfig;
 }
-function configEnablesRecursiveSubmodules(config) {
+function envRecursiveSubmoduleConfig(envAssignments) {
+  const countValue = getEnvConfigValue("GIT_CONFIG_COUNT", envAssignments);
+  if (countValue === undefined) {
+    return null;
+  }
+  const count = Number.parseInt(countValue, 10);
+  if (!Number.isInteger(count) || count < 0) {
+    return true;
+  }
+  let recursiveSubmoduleConfig = null;
+  for (let i = 0;i < count; i++) {
+    const key = getEnvConfigValue(`GIT_CONFIG_KEY_${i}`, envAssignments);
+    if (key?.toLowerCase() !== "submodule.recurse") {
+      continue;
+    }
+    const value = getEnvConfigValue(`GIT_CONFIG_VALUE_${i}`, envAssignments);
+    recursiveSubmoduleConfig = value === undefined || gitConfigValueEnablesRecursiveSubmodules(value);
+  }
+  return recursiveSubmoduleConfig;
+}
+function getEnvConfigValue(name, envAssignments) {
+  return envAssignments?.get(name) ?? process.env[name];
+}
+function effectiveGitConfigEnablesRecursiveSubmodules(cwd) {
+  try {
+    const value = execFileSync("git", ["config", "--get", "submodule.recurse"], {
+      cwd,
+      encoding: "utf8",
+      env: withoutGitConfigEnv(process.env),
+      stdio: ["ignore", "pipe", "ignore"]
+    }).trim();
+    return gitConfigValueEnablesRecursiveSubmodules(value);
+  } catch (error) {
+    return !isGitConfigUnsetError(error);
+  }
+}
+function withoutGitConfigEnv(env) {
+  const nextEnv = { ...env };
+  for (const key of Object.keys(nextEnv)) {
+    if (key === "GIT_CONFIG_COUNT" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(key)) {
+      delete nextEnv[key];
+    }
+  }
+  return nextEnv;
+}
+function isGitConfigUnsetError(error) {
+  return typeof error === "object" && error !== null && "status" in error && error.status === 1;
+}
+function recursiveSubmoduleConfigValue(config) {
   if (!config) {
-    return false;
+    return null;
   }
   const eqIdx = config.indexOf("=");
   const key = (eqIdx === -1 ? config : config.slice(0, eqIdx)).toLowerCase();
   if (key !== "submodule.recurse") {
-    return false;
+    return null;
   }
   const value = eqIdx === -1 ? "true" : config.slice(eqIdx + 1).toLowerCase();
-  return value !== "false" && value !== "no" && value !== "off" && value !== "0";
+  return gitConfigValueEnablesRecursiveSubmodules(value);
 }
-function configEnvTargetsRecursiveSubmodules(configEnv) {
+function gitConfigValueEnablesRecursiveSubmodules(value) {
+  const normalizedValue = value.toLowerCase();
+  return normalizedValue !== "false" && normalizedValue !== "no" && normalizedValue !== "off" && normalizedValue !== "0";
+}
+function recursiveSubmoduleConfigEnvValue(configEnv, envAssignments) {
   const eqIdx = configEnv?.indexOf("=") ?? -1;
   if (!configEnv || eqIdx === -1) {
-    return false;
+    return null;
   }
-  return configEnv.slice(0, eqIdx).toLowerCase() === "submodule.recurse";
+  if (configEnv.slice(0, eqIdx).toLowerCase() !== "submodule.recurse") {
+    return null;
+  }
+  const value = getEnvConfigValue(configEnv.slice(eqIdx + 1), envAssignments);
+  return value === undefined || gitConfigValueEnablesRecursiveSubmodules(value);
 }
 function isForcedBranchReset(subcommand, rest) {
   if (subcommand === "checkout") {
@@ -2164,15 +2243,16 @@ function isForcedBranchReset(subcommand, rest) {
       shortOptsWithValue: CHECKOUT_SHORT_OPTS_WITH_VALUE
     });
     const hasForce = before.includes("--force") || shortOpts.has("-f");
-    return hasForce && before.some((token) => token === "-B" || token.startsWith("-B"));
+    const hasBranchReset = shortOpts.has("-B") || before.some((token) => token === "-B" || token.startsWith("-B"));
+    return hasForce && hasBranchReset;
   }
   if (subcommand === "switch") {
     const { before } = splitAtDoubleDash(rest);
     const shortOpts = extractShortOpts(before, {
       shortOptsWithValue: SWITCH_SHORT_OPTS_WITH_VALUE
     });
-    const hasForce = before.includes("--force") || shortOpts.has("-f");
-    const hasForceCreate = before.some((token) => token === "-C" || token.startsWith("-C") || token === "--force-create" || token.startsWith("--force-create="));
+    const hasForce = before.includes("--force") || before.includes("--discard-changes") || shortOpts.has("-f");
+    const hasForceCreate = before.some((token) => token === "-C" || token.startsWith("-C") || token === "--force-create" || token.startsWith("--force-create=")) || shortOpts.has("-C");
     return hasForce && hasForceCreate;
   }
   return false;
@@ -2479,6 +2559,7 @@ function analyzeParallel(tokens, context) {
     return null;
   }
   const { template, args, hasPlaceholder, runsRemotely, usesStdin } = parseResult;
+  const hasDynamicStdinPlaceholder = usesStdin && hasPlaceholder;
   if (template.length === 0) {
     const nestedOverrides2 = buildCommandsModeOverrides(context, runsRemotely);
     for (const arg of args) {
@@ -2496,7 +2577,7 @@ function analyzeParallel(tokens, context) {
     childEnvAssignments.set(k, v);
   }
   const childCwd = childWrapperInfo.cwd === null ? undefined : childWrapperInfo.cwd ?? context.cwd;
-  const nestedOverrides = buildNestedOverrides(childEnvAssignments, childWrapperInfo.cwd, runsRemotely);
+  const nestedOverrides = buildNestedOverrides(childEnvAssignments, childWrapperInfo.cwd, runsRemotely || hasDynamicStdinPlaceholder);
   let head = getBasename(childTokens[0] ?? "").toLowerCase();
   if (head === "busybox" && childTokens.length > 1) {
     childTokens = childTokens.slice(1);
@@ -2801,10 +2882,11 @@ function analyzeXargs(tokens, context) {
   }
   if (head === "git") {
     const gitTokens = replacementToken === null ? [...childTokens, XARGS_APPENDED_INPUT] : childTokens;
+    const hasDynamicReplacement = replacementToken !== null && childTokens.some((token) => token.includes(replacementToken));
     const gitResult = analyzeGit(gitTokens, {
       cwd: childCwd,
       envAssignments: childEnvAssignments,
-      worktreeMode: replacementToken === null ? false : context.worktreeMode
+      worktreeMode: replacementToken === null || hasDynamicReplacement ? false : context.worktreeMode
     });
     if (gitResult) {
       return gitResult;
@@ -3192,7 +3274,7 @@ function analyzeCommandInternal(command, depth, options) {
   const shellGitContextState = createShellGitContextEnvState(options.envAssignments);
   for (const segment of segments) {
     const segmentStr = segment.join(" ");
-    const segmentEnvAssignments = shellGitContextState.effectiveEnvAssignments;
+    const segmentEnvAssignments = getSegmentGitContextEnvAssignments(segment, shellGitContextState);
     if (segment.length === 1 && segment[0]?.includes(" ")) {
       const textReason = dangerousInText(segment[0]);
       if (textReason) {
@@ -3233,7 +3315,8 @@ function createShellGitContextEnvState(effectiveEnvAssignments) {
     effectiveEnvAssignments,
     shellAssignments: new Map,
     exportedNames: new Set,
-    allexport: false
+    allexport: false,
+    keywordExport: false
   };
 }
 function applyShellGitContextEnvSegment(tokens, state) {
@@ -3249,13 +3332,16 @@ function applyShellGitContextEnvSegment(tokens, state) {
     return;
   }
   if (command === "set") {
-    const allexport = getAllexportChange(tokens, commandIndex);
-    if (allexport !== null) {
-      state.allexport = allexport;
+    const changes = getSetOptionChanges(tokens, commandIndex);
+    if (changes.allexport !== null) {
+      state.allexport = changes.allexport;
+    }
+    if (changes.keywordExport !== null) {
+      state.keywordExport = changes.keywordExport;
     }
     return;
   }
-  if (command !== "export" && command !== "typeset" && command !== "declare") {
+  if (command !== "export" && command !== "typeset" && command !== "declare" && command !== "readonly") {
     return;
   }
   for (const assignment of leadingAssignments.values()) {
@@ -3279,6 +3365,21 @@ function applyShellGitContextEnvSegment(tokens, state) {
     addTypesetGitContextEnvAssignment(state, token, operandsInfo.exports);
   }
 }
+function getSegmentGitContextEnvAssignments(tokens, state) {
+  if (!state.keywordExport) {
+    return state.effectiveEnvAssignments;
+  }
+  let nextEnvAssignments = null;
+  for (const token of tokens) {
+    const assignment = parseGitContextEnvAssignment(token);
+    if (!assignment) {
+      continue;
+    }
+    nextEnvAssignments ??= new Map(state.effectiveEnvAssignments ?? []);
+    nextEnvAssignments.set(assignment.name, assignment.value);
+  }
+  return nextEnvAssignments ?? state.effectiveEnvAssignments;
+}
 function getShellCommandInfo(tokens) {
   const leadingAssignments = new Map;
   let i = 0;
@@ -3301,14 +3402,45 @@ function getShellCommandInfo(tokens) {
   }
   let commandIndex = i;
   let command = tokens[commandIndex] ?? null;
-  if (command === "builtin" || command === "command") {
+  if (command === "builtin") {
     commandIndex++;
     command = tokens[commandIndex] ?? null;
+  }
+  if (command === "command") {
+    const commandBuiltinInfo = getCommandBuiltinTarget(tokens, commandIndex);
+    if (!commandBuiltinInfo) {
+      return null;
+    }
+    commandIndex = commandBuiltinInfo.commandIndex;
+    command = commandBuiltinInfo.command;
   }
   if (command === null) {
     return null;
   }
   return { command, commandIndex, leadingAssignments };
+}
+function getCommandBuiltinTarget(tokens, commandIndex) {
+  let i = commandIndex + 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    if (token === "--") {
+      i++;
+      break;
+    }
+    if (token === "-p") {
+      i++;
+      continue;
+    }
+    if (token === "-v" || token === "-V") {
+      return null;
+    }
+    break;
+  }
+  const command = tokens[i];
+  return command ? { command, commandIndex: i } : null;
 }
 function parseShellAssignment(token) {
   return parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment2(token);
@@ -3377,17 +3509,25 @@ function addTypesetGitContextEnvAssignment(state, token, exports) {
   }
 }
 function getExportOperandsStart(tokens, commandIndex) {
-  const firstOperand = tokens[commandIndex + 1];
-  if (firstOperand === undefined) {
-    return commandIndex + 1;
+  let i = commandIndex + 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    if (token === "--") {
+      return i + 1;
+    }
+    if (token === "-p") {
+      i++;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return null;
+    }
+    return i;
   }
-  if (firstOperand === "--") {
-    return commandIndex + 2;
-  }
-  if (firstOperand.startsWith("-")) {
-    return null;
-  }
-  return commandIndex + 1;
+  return i;
 }
 function getTypesetOperandsInfo(tokens, commandIndex) {
   let i = commandIndex + 1;
@@ -3401,40 +3541,69 @@ function getTypesetOperandsInfo(tokens, commandIndex) {
       return { operandsStart: i + 1, exports: hasExportFlag };
     }
     if (token.startsWith("-")) {
-      hasExportFlag = hasExportFlag || token.slice(1).includes("x");
+      if (token.slice(1).includes("x")) {
+        hasExportFlag = true;
+      }
       i++;
       continue;
     }
     if (token.startsWith("+")) {
-      return null;
+      if (token.slice(1).includes("x")) {
+        hasExportFlag = false;
+      }
+      i++;
+      continue;
     }
     return { operandsStart: i, exports: hasExportFlag };
   }
   return { operandsStart: i, exports: hasExportFlag };
 }
-function getAllexportChange(tokens, commandIndex) {
+function getSetOptionChanges(tokens, commandIndex) {
+  const changes = { allexport: null, keywordExport: null };
   let i = commandIndex + 1;
   while (i < tokens.length) {
     const token = tokens[i];
     if (!token) {
-      return null;
+      return changes;
+    }
+    if (token === "--") {
+      return changes;
     }
     if (token === "-o" || token === "+o") {
       if (tokens[i + 1] === "allexport") {
-        return token === "-o";
+        changes.allexport = token === "-o";
+      }
+      if (tokens[i + 1] === "keyword") {
+        changes.keywordExport = token === "-o";
       }
       i += 2;
       continue;
     }
-    if (token.startsWith("-") && token.slice(1).includes("a")) {
-      return true;
+    if (token.startsWith("-") && token.length > 1) {
+      const flags = token.slice(1);
+      if (flags.includes("a")) {
+        changes.allexport = true;
+      }
+      if (flags.includes("k")) {
+        changes.keywordExport = true;
+      }
+      i++;
+      continue;
     }
-    if (token.startsWith("+") && token.slice(1).includes("a")) {
-      return false;
+    if (token.startsWith("+") && token.length > 1) {
+      const flags = token.slice(1);
+      if (flags.includes("a")) {
+        changes.allexport = false;
+      }
+      if (flags.includes("k")) {
+        changes.keywordExport = false;
+      }
+      i++;
+      continue;
     }
-    i++;
+    return changes;
   }
-  return null;
+  return changes;
 }
 
 // src/core/config.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -399,12 +399,42 @@ function hasRecursiveForceFlags(tokens) {
 }
 
 // src/core/shell.ts
-import { lstatSync as lstatSync2, realpathSync as realpathSync2 } from "node:fs";
-import { dirname as dirname2, isAbsolute as isAbsolute2, parse as parsePath2, sep as sep2 } from "node:path";
+import { realpathSync as realpathSync3 } from "node:fs";
+import { isAbsolute as isAbsolute3, parse as parsePath2 } from "node:path";
 
 // node_modules/shell-quote/index.js
 var $quote = require_quote();
 var $parse = require_parse();
+
+// src/core/path.ts
+import { lstatSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, parse as parsePath, sep } from "node:path";
+function resolveChdirTarget(baseCwd, target) {
+  const root = isAbsolute(target) ? getPathRoot(target) : "";
+  let current = root || baseCwd;
+  for (const component of getPathComponents(root ? target.slice(root.length) : target)) {
+    if (component === "" || component === ".") {
+      continue;
+    }
+    if (component === "..") {
+      current = dirname(current);
+      continue;
+    }
+    const candidate = appendPathWithoutNormalizing(current, component);
+    current = lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
+  }
+  return current;
+}
+function appendPathWithoutNormalizing(base, target) {
+  return base.endsWith("/") || base.endsWith("\\") ? `${base}${target}` : `${base}${sep}${target}`;
+}
+function getPathRoot(target) {
+  return parsePath(target).root;
+}
+function getPathComponents(target) {
+  const separator = process.platform === "win32" ? /[\\/]+/ : /\/+/;
+  return target.split(separator);
+}
 
 // src/types.ts
 var MAX_RECURSION_DEPTH = 10;
@@ -431,8 +461,8 @@ var PARANOID_INTERPRETERS_SUFFIX = `
 (Paranoid mode: interpreter one-liners are blocked.)`;
 
 // src/core/worktree.ts
-import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join, parse as parsePath, resolve, sep } from "node:path";
+import { existsSync, lstatSync as lstatSync2, readFileSync, realpathSync as realpathSync2, statSync } from "node:fs";
+import { dirname as dirname2, isAbsolute as isAbsolute2, join, resolve } from "node:path";
 var GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
   "-c",
   "-C",
@@ -448,6 +478,13 @@ var GIT_CONTEXT_ENV_OVERRIDES = [
   "GIT_COMMON_DIR",
   "GIT_INDEX_FILE"
 ];
+var GIT_CONFIG_AFFECTING_ENV_NAMES = new Set([
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_CONFIG_SYSTEM",
+  "HOME",
+  "XDG_CONFIG_HOME"
+]);
 function hasGitContextEnvOverride(envAssignments) {
   for (const name of GIT_CONTEXT_ENV_OVERRIDES) {
     if (envAssignments?.has(name) || Object.hasOwn(process.env, name)) {
@@ -462,7 +499,7 @@ function getGitExecutionContext(tokens, cwd) {
   }
   let gitCwd;
   try {
-    gitCwd = realpathSync(resolve(cwd));
+    gitCwd = realpathSync2(resolve(cwd));
   } catch {
     return { gitCwd: null, hasExplicitGitContext: false };
   }
@@ -529,7 +566,7 @@ function isLinkedWorktree(cwd) {
     return false;
   }
   try {
-    const stat = lstatSync(dotGitPath);
+    const stat = lstatSync2(dotGitPath);
     if (stat.isSymbolicLink() || !stat.isFile()) {
       return false;
     }
@@ -542,14 +579,14 @@ function isLinkedWorktree(cwd) {
     if (rawGitDir === "") {
       return false;
     }
-    const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve(dirname(dotGitPath), rawGitDir);
+    const gitDir = isAbsolute2(rawGitDir) ? rawGitDir : resolve(dirname2(dotGitPath), rawGitDir);
     if (!existsSync(join(gitDir, "commondir"))) {
       return false;
     }
     if (!worktreeGitdirBacklinkMatches(gitDir, dotGitPath)) {
       return false;
     }
-    return worktreeConfigMatchesRoot(gitDir, dirname(dotGitPath));
+    return worktreeConfigMatchesRoot(gitDir, dirname2(dotGitPath));
   } catch {
     return false;
   }
@@ -563,7 +600,7 @@ function worktreeGitdirBacklinkMatches(gitDir, dotGitPath) {
   if (rawBacklink === "") {
     return false;
   }
-  const linkedDotGitPath = isAbsolute(rawBacklink) ? rawBacklink : resolve(gitDir, rawBacklink);
+  const linkedDotGitPath = isAbsolute2(rawBacklink) ? rawBacklink : resolve(gitDir, rawBacklink);
   try {
     return sameFilesystemPath(linkedDotGitPath, dotGitPath);
   } catch {
@@ -579,7 +616,7 @@ function worktreeConfigMatchesRoot(gitDir, worktreeRoot) {
   if (configuredWorktree === null) {
     return true;
   }
-  const resolvedConfiguredWorktree = isAbsolute(configuredWorktree) ? configuredWorktree : resolve(gitDir, configuredWorktree);
+  const resolvedConfiguredWorktree = isAbsolute2(configuredWorktree) ? configuredWorktree : resolve(gitDir, configuredWorktree);
   try {
     return sameFilesystemPath(resolvedConfiguredWorktree, worktreeRoot);
   } catch {
@@ -597,7 +634,7 @@ function sameFilesystemPath(left, right) {
   return getCanonicalPathForComparison(left) === getCanonicalPathForComparison(right);
 }
 function getCanonicalPathForComparison(path) {
-  return normalizePathForComparison(realpathSync.native(path));
+  return normalizePathForComparison(realpathSync2.native(path));
 }
 function normalizePathForComparison(path) {
   let normalized = path.replace(/^\\\\\?\\UNC\\/i, "//").replace(/^\\\\\?\\/i, "");
@@ -625,17 +662,53 @@ function readCoreWorktree(configPath) {
     }
     const match = trimmed.match(/^worktree\s*=\s*(.*)$/i);
     if (match) {
-      configuredWorktree = unquoteGitConfigValue(match[1] ?? "");
+      configuredWorktree = parseGitConfigValue(match[1] ?? "");
     }
   }
   return configuredWorktree;
 }
-function unquoteGitConfigValue(value) {
+function parseGitConfigValue(value) {
   const trimmed = value.trim();
-  if (trimmed.startsWith('"') && trimmed.endsWith('"') || trimmed.startsWith("'") && trimmed.endsWith("'")) {
-    return trimmed.slice(1, -1);
+  if (!trimmed.startsWith('"') || !trimmed.endsWith('"')) {
+    return trimmed;
   }
-  return trimmed;
+  return unescapeDoubleQuotedGitConfigValue(trimmed.slice(1, -1));
+}
+function unescapeDoubleQuotedGitConfigValue(value) {
+  let result = "";
+  for (let i = 0;i < value.length; i++) {
+    const char = value[i];
+    if (char !== "\\") {
+      result += char;
+      continue;
+    }
+    const next = value[i + 1];
+    if (next === undefined) {
+      result += char;
+      continue;
+    }
+    switch (next) {
+      case "\\":
+      case '"':
+        result += next;
+        break;
+      case "n":
+        result += `
+`;
+        break;
+      case "t":
+        result += "\t";
+        break;
+      case "b":
+        result += "\b";
+        break;
+      default:
+        result += `\\${next}`;
+        break;
+    }
+    i++;
+  }
+  return result;
 }
 function resolveGitCwd(baseCwd, target) {
   try {
@@ -644,32 +717,6 @@ function resolveGitCwd(baseCwd, target) {
   } catch {
     return null;
   }
-}
-function resolveChdirTarget(baseCwd, target) {
-  const root = isAbsolute(target) ? getPathRoot(target) : "";
-  let current = root || baseCwd;
-  for (const component of getPathComponents(root ? target.slice(root.length) : target)) {
-    if (component === "" || component === ".") {
-      continue;
-    }
-    if (component === "..") {
-      current = dirname(current);
-      continue;
-    }
-    const candidate = appendPathWithoutNormalizing(current, component);
-    current = lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
-  }
-  return current;
-}
-function appendPathWithoutNormalizing(base, target) {
-  return base.endsWith("/") || base.endsWith("\\") ? `${base}${target}` : `${base}${sep}${target}`;
-}
-function getPathRoot(target) {
-  return parsePath(target).root;
-}
-function getPathComponents(target) {
-  const separator = process.platform === "win32" ? /[\\/]+/ : /\/+/;
-  return target.split(separator);
 }
 function isDirectory(path) {
   try {
@@ -681,7 +728,7 @@ function isDirectory(path) {
 function findDotGit(cwd) {
   let current;
   try {
-    current = realpathSync(cwd);
+    current = realpathSync2(cwd);
   } catch {
     return null;
   }
@@ -690,7 +737,7 @@ function findDotGit(cwd) {
     if (existsSync(dotGitPath)) {
       return dotGitPath;
     }
-    const parent = dirname(current);
+    const parent = dirname2(current);
     if (parent === current) {
       return null;
     }
@@ -1177,13 +1224,6 @@ function _stripAttachedIoNumbers(command) {
 var ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
 var ENV_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES = new Set(GIT_CONTEXT_ENV_OVERRIDES);
-var GIT_CONFIG_AFFECTING_ENV_NAMES = new Set([
-  "GIT_CONFIG_GLOBAL",
-  "GIT_CONFIG_NOSYSTEM",
-  "GIT_CONFIG_SYSTEM",
-  "HOME",
-  "XDG_CONFIG_HOME"
-]);
 function parseEnvAssignment(token) {
   if (!ENV_ASSIGNMENT_RE.test(token)) {
     return null;
@@ -1448,40 +1488,17 @@ function resolveWrapperCwd(cwd, target) {
     return null;
   }
   try {
-    if (!cwd && !isAbsolute2(target)) {
+    if (!cwd && !isAbsolute3(target)) {
       return null;
     }
-    const baseCwd = isAbsolute2(target) ? getPathRoot2(target) : realpathSync2(cwd ?? "/");
-    return resolveChdirTarget2(baseCwd, target);
+    const baseCwd = isAbsolute3(target) ? getPathRoot2(target) : realpathSync3(cwd ?? "/");
+    return resolveChdirTarget(baseCwd, target);
   } catch {
     return null;
   }
 }
-function resolveChdirTarget2(baseCwd, target) {
-  const root = isAbsolute2(target) ? getPathRoot2(target) : "";
-  let current = root || baseCwd;
-  for (const component of getPathComponents2(root ? target.slice(root.length) : target)) {
-    if (component === "" || component === ".") {
-      continue;
-    }
-    if (component === "..") {
-      current = dirname2(current);
-      continue;
-    }
-    const candidate = appendPathWithoutNormalizing2(current, component);
-    current = lstatSync2(candidate).isSymbolicLink() ? realpathSync2(candidate) : candidate;
-  }
-  return current;
-}
-function appendPathWithoutNormalizing2(base, target) {
-  return base.endsWith("/") || base.endsWith("\\") ? `${base}${target}` : `${base}${sep2}${target}`;
-}
 function getPathRoot2(target) {
   return parsePath2(target).root;
-}
-function getPathComponents2(target) {
-  const separator = process.platform === "win32" ? /[\\/]+/ : /\/+/;
-  return target.split(separator);
 }
 function stripCommand(tokens) {
   let i = 1;
@@ -1836,7 +1853,7 @@ function extractDashCArg(tokens) {
 // src/core/rules-git.ts
 import { execFileSync } from "node:child_process";
 import { existsSync as existsSync2, readFileSync as readFileSync2 } from "node:fs";
-import { dirname as dirname3, isAbsolute as isAbsolute3, join as join2, resolve as resolve2 } from "node:path";
+import { dirname as dirname3, isAbsolute as isAbsolute4, join as join2, resolve as resolve2 } from "node:path";
 var REASON_CHECKOUT_DOUBLE_DASH = "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
 var REASON_CHECKOUT_FORCE = "git checkout --force discards uncommitted changes. Use 'git stash' first.";
 var REASON_CHECKOUT_REF_PATH = "git checkout <ref> -- <path> overwrites working tree with ref version. Use 'git stash' first.";
@@ -1866,14 +1883,11 @@ var CHECKOUT_OPTS_WITH_VALUE = new Set([
 var CHECKOUT_OPTS_WITH_OPTIONAL_VALUE = new Set(["--recurse-submodules", "--track", "-t"]);
 var CHECKOUT_SHORT_OPTS_WITH_VALUE = new Set(["-b", "-B", "-U"]);
 var SWITCH_SHORT_OPTS_WITH_VALUE = new Set(["-c", "-C"]);
-var GIT_CONFIG_AFFECTING_ENV_NAMES2 = new Set([
-  "GIT_CONFIG_GLOBAL",
-  "GIT_CONFIG_NOSYSTEM",
-  "GIT_CONFIG_SYSTEM",
-  "HOME",
-  "XDG_CONFIG_HOME"
-]);
-var TRUSTED_GIT_BINARIES = ["/usr/bin/git"];
+var TRUSTED_GIT_BINARIES = [
+  "/usr/bin/git",
+  "/usr/local/bin/git",
+  "/opt/homebrew/bin/git"
+];
 var CHECKOUT_KNOWN_OPTS_NO_VALUE = new Set([
   "-q",
   "--quiet",
@@ -2270,7 +2284,7 @@ function hasConfigAffectingEnvAssignment(envAssignments) {
     return false;
   }
   for (const key of envAssignments.keys()) {
-    if (GIT_CONFIG_AFFECTING_ENV_NAMES2.has(key)) {
+    if (GIT_CONFIG_AFFECTING_ENV_NAMES.has(key)) {
       return true;
     }
   }
@@ -2376,7 +2390,7 @@ function resolveGitDirFromDotGit(dotGitPath) {
     if (rawGitDir === "") {
       return null;
     }
-    return isAbsolute3(rawGitDir) ? rawGitDir : resolve2(dirname3(dotGitPath), rawGitDir);
+    return isAbsolute4(rawGitDir) ? rawGitDir : resolve2(dirname3(dotGitPath), rawGitDir);
   } catch {
     return null;
   }
@@ -2391,7 +2405,7 @@ function resolveCommonGitDir(gitDir) {
     if (rawCommonDir === "") {
       return null;
     }
-    return isAbsolute3(rawCommonDir) ? rawCommonDir : resolve2(gitDir, rawCommonDir);
+    return isAbsolute4(rawCommonDir) ? rawCommonDir : resolve2(gitDir, rawCommonDir);
   } catch {
     return null;
   }
@@ -2558,9 +2572,9 @@ function analyzeGitWorktree(tokens) {
 }
 
 // src/core/rules-rm.ts
-import { realpathSync as realpathSync3 } from "node:fs";
+import { realpathSync as realpathSync4 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { normalize, resolve as resolve3, sep as sep3 } from "node:path";
+import { normalize, resolve as resolve3, sep as sep2 } from "node:path";
 var IS_WINDOWS = process.platform === "win32";
 function normalizePathForComparison2(p) {
   let normalized = normalize(p);
@@ -2704,7 +2718,7 @@ function isTempTarget(path, allowTmpdirVar) {
   const systemTmpdir = tmpdir();
   const normalizedTmpdir = normalizePathForComparison2(systemTmpdir);
   const pathToCompare = normalizePathForComparison2(normalized);
-  if (pathToCompare.startsWith(`${normalizedTmpdir}${sep3}`) || pathToCompare === normalizedTmpdir) {
+  if (pathToCompare.startsWith(`${normalizedTmpdir}${sep2}`) || pathToCompare === normalizedTmpdir) {
     return true;
   }
   if (allowTmpdirVar) {
@@ -2733,8 +2747,8 @@ function isCwdSelfTarget(target, cwd) {
   }
   try {
     const resolved = resolve3(cwd, target);
-    const realCwd = realpathSync3(cwd);
-    const realResolved = realpathSync3(resolved);
+    const realCwd = realpathSync4(cwd);
+    const realResolved = realpathSync4(resolved);
     return normalizePathForComparison2(realResolved) === normalizePathForComparison2(realCwd);
   } catch {
     try {
@@ -2756,7 +2770,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
   if (target.startsWith("/") || /^[A-Za-z]:[\\/]/.test(target)) {
     try {
       const normalizedTarget = normalizePathForComparison2(target);
-      const normalizedCwd = `${normalizePathForComparison2(originalCwd)}${sep3}`;
+      const normalizedCwd = `${normalizePathForComparison2(originalCwd)}${sep2}`;
       return normalizedTarget.startsWith(normalizedCwd);
     } catch {
       return false;
@@ -2767,7 +2781,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
       const resolved = resolve3(resolveCwd, target);
       const normalizedResolved = normalizePathForComparison2(resolved);
       const normalizedOriginalCwd = normalizePathForComparison2(originalCwd);
-      return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep3}`) || normalizedResolved === normalizedOriginalCwd;
+      return normalizedResolved.startsWith(`${normalizedOriginalCwd}${sep2}`) || normalizedResolved === normalizedOriginalCwd;
     } catch {
       return false;
     }
@@ -2779,7 +2793,7 @@ function isTargetWithinCwd(target, originalCwd, effectiveCwd) {
     const resolved = resolve3(resolveCwd, target);
     const normalizedResolved = normalizePathForComparison2(resolved);
     const normalizedCwd = normalizePathForComparison2(originalCwd);
-    return normalizedResolved.startsWith(`${normalizedCwd}${sep3}`) || normalizedResolved === normalizedCwd;
+    return normalizedResolved.startsWith(`${normalizedCwd}${sep2}`) || normalizedResolved === normalizedCwd;
   } catch {
     return false;
   }
@@ -3056,7 +3070,7 @@ function parseParallelCommand(tokens) {
 
 // src/core/analyze/tmpdir.ts
 import { tmpdir as tmpdir2 } from "node:os";
-import { normalize as normalize2, sep as sep4 } from "node:path";
+import { normalize as normalize2, sep as sep3 } from "node:path";
 function isTmpdirOverriddenToNonTemp(envAssignments) {
   if (!envAssignments.has("TMPDIR")) {
     return false;
@@ -3076,7 +3090,7 @@ function isPathOrSubpath(path, basePath) {
   if (path === basePath) {
     return true;
   }
-  const baseWithSlash = basePath.endsWith(sep4) ? basePath : `${basePath}${sep4}`;
+  const baseWithSlash = basePath.endsWith(sep3) ? basePath : `${basePath}${sep3}`;
   return path.startsWith(baseWithSlash);
 }
 
@@ -3502,13 +3516,6 @@ function stripLeadingGrouping(tokens) {
 var REASON_STRICT_UNPARSEABLE = "Command could not be safely analyzed (strict mode). Verify manually.";
 var REASON_RECURSION_LIMIT = "Command exceeds maximum recursion depth and cannot be safely analyzed.";
 var GIT_CONTEXT_ENV_OVERRIDE_NAMES2 = new Set(GIT_CONTEXT_ENV_OVERRIDES);
-var GIT_CONFIG_AFFECTING_ENV_NAMES3 = new Set([
-  "GIT_CONFIG_GLOBAL",
-  "GIT_CONFIG_NOSYSTEM",
-  "GIT_CONFIG_SYSTEM",
-  "HOME",
-  "XDG_CONFIG_HOME"
-]);
 var GIT_CONTEXT_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 function analyzeCommandInternal(command, depth, options) {
   if (depth >= MAX_RECURSION_DEPTH) {
@@ -3714,7 +3721,7 @@ function parseGitContextAppendEnvAssignment2(token) {
   return { name, value: token.slice(eqIdx + 1) };
 }
 function isTrackedGitEnvName2(name) {
-  return GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES3.has(name) || isGitConfigEnvName2(name);
+  return GIT_CONTEXT_ENV_OVERRIDE_NAMES2.has(name) || GIT_CONFIG_AFFECTING_ENV_NAMES.has(name) || isGitConfigEnvName2(name);
 }
 function isGitConfigEnvName2(name) {
   return name === "GIT_CONFIG_COUNT" || name === "GIT_CONFIG_PARAMETERS" || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(name);

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -97,6 +97,8 @@ export interface AnalyzeOptions {
     cwd?: string;
     /** Effective cwd after cd commands (null = unknown, undefined = use cwd) */
     effectiveCwd?: string | null;
+    /** Environment assignments inherited by nested command analysis */
+    envAssignments?: ReadonlyMap<string, string>;
     /** Loaded configuration */
     config?: Config;
     /** Fail-closed on unparseable commands */
@@ -109,6 +111,11 @@ export interface AnalyzeOptions {
     worktreeMode?: boolean;
     /** Allow $TMPDIR paths (false when TMPDIR is overridden to non-temp) */
     allowTmpdirVar?: boolean;
+}
+export interface AnalyzeNestedOverrides {
+    effectiveCwd?: string | null;
+    envAssignments?: ReadonlyMap<string, string>;
+    worktreeMode?: boolean;
 }
 /** Audit log entry */
 export interface AuditLogEntry {

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -105,6 +105,8 @@ export interface AnalyzeOptions {
     paranoidRm?: boolean;
     /** Block interpreter one-liners */
     paranoidInterpreters?: boolean;
+    /** Allow local Git discard commands in linked worktrees */
+    worktreeMode?: boolean;
     /** Allow $TMPDIR paths (false when TMPDIR is overridden to non-temp) */
     allowTmpdirVar?: boolean;
 }
@@ -169,6 +171,10 @@ export type TraceStep = {
     ruleFunction: string;
     matched: boolean;
     reason?: string;
+} | {
+    type: 'worktree-relaxation';
+    originalReason: string;
+    gitCwd: string;
 } | {
     type: 'tmpdir-check';
     tmpdirValue: string | null;

--- a/src/bin/doctor/environment.ts
+++ b/src/bin/doctor/environment.ts
@@ -29,6 +29,11 @@ const ENV_VARS: Array<{
     description: 'Block interpreter one-liners',
     defaultBehavior: 'off',
   },
+  {
+    name: 'SAFETY_NET_WORKTREE',
+    description: 'Allow local git discards in linked worktrees',
+    defaultBehavior: 'off',
+  },
 ];
 
 export function getEnvironmentInfo(): EnvVarInfo[] {

--- a/src/bin/explain/analyze.ts
+++ b/src/bin/explain/analyze.ts
@@ -10,8 +10,8 @@ import {
   REASON_STRICT_UNPARSEABLE,
 } from '@/bin/explain/segment';
 import {
-  getExportedGitContextEnvAssignments,
-  getShellGitContextEnvAssignments,
+  applyShellGitContextEnvSegment,
+  createShellGitContextEnvState,
 } from '@/core/analyze/analyze-command';
 import { dangerousInText } from '@/core/analyze/dangerous-text';
 import { segmentChangesCwd } from '@/core/analyze/segment';
@@ -67,8 +67,7 @@ export function explainCommand(command: string, options?: ExplainOptions): Expla
   let blockReason: string | undefined;
   let blockSegment: string | undefined;
   let effectiveCwd: string | null | undefined = analyzeOpts.effectiveCwd;
-  let effectiveEnvAssignments = analyzeOpts.envAssignments;
-  const shellGitContextAssignments = new Map<string, string>();
+  const shellGitContextState = createShellGitContextEnvState(analyzeOpts.envAssignments);
 
   for (let i = 0; i < segments.length; i++) {
     const segment = segments[i];
@@ -122,7 +121,11 @@ export function explainCommand(command: string, options?: ExplainOptions): Expla
     const result = explainSegment(
       segment,
       0,
-      { ...analyzeOpts, effectiveCwd, envAssignments: effectiveEnvAssignments },
+      {
+        ...analyzeOpts,
+        effectiveCwd,
+        envAssignments: shellGitContextState.effectiveEnvAssignments,
+      },
       segmentSteps,
     );
 
@@ -141,22 +144,7 @@ export function explainCommand(command: string, options?: ExplainOptions): Expla
       effectiveCwd = null;
     }
 
-    const shellAssignments = getShellGitContextEnvAssignments(segment);
-    for (const [k, v] of shellAssignments) {
-      shellGitContextAssignments.set(k, v);
-    }
-
-    const exportedEnvAssignments = getExportedGitContextEnvAssignments(
-      segment,
-      shellGitContextAssignments,
-    );
-    if (exportedEnvAssignments.size > 0) {
-      const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
-      for (const [k, v] of exportedEnvAssignments) {
-        nextEnvAssignments.set(k, v);
-      }
-      effectiveEnvAssignments = nextEnvAssignments;
-    }
+    applyShellGitContextEnvSegment(segment, shellGitContextState);
 
     trace.segments.push({ index: i, steps: segmentSteps });
   }

--- a/src/bin/explain/analyze.ts
+++ b/src/bin/explain/analyze.ts
@@ -12,6 +12,7 @@ import {
 import {
   applyShellGitContextEnvSegment,
   createShellGitContextEnvState,
+  getSegmentGitContextEnvAssignments,
 } from '@/core/analyze/analyze-command';
 import { dangerousInText } from '@/core/analyze/dangerous-text';
 import { segmentChangesCwd } from '@/core/analyze/segment';
@@ -124,7 +125,7 @@ export function explainCommand(command: string, options?: ExplainOptions): Expla
       {
         ...analyzeOpts,
         effectiveCwd,
-        envAssignments: shellGitContextState.effectiveEnvAssignments,
+        envAssignments: getSegmentGitContextEnvAssignments(segment, shellGitContextState),
       },
       segmentSteps,
     );

--- a/src/bin/explain/analyze.ts
+++ b/src/bin/explain/analyze.ts
@@ -9,6 +9,10 @@ import {
   isUnparseableCommand,
   REASON_STRICT_UNPARSEABLE,
 } from '@/bin/explain/segment';
+import {
+  getExportedGitContextEnvAssignments,
+  getShellGitContextEnvAssignments,
+} from '@/core/analyze/analyze-command';
 import { dangerousInText } from '@/core/analyze/dangerous-text';
 import { segmentChangesCwd } from '@/core/analyze/segment';
 import { splitShellCommands } from '@/core/shell';
@@ -63,6 +67,8 @@ export function explainCommand(command: string, options?: ExplainOptions): Expla
   let blockReason: string | undefined;
   let blockSegment: string | undefined;
   let effectiveCwd: string | null | undefined = analyzeOpts.effectiveCwd;
+  let effectiveEnvAssignments = analyzeOpts.envAssignments;
+  const shellGitContextAssignments = new Map<string, string>();
 
   for (let i = 0; i < segments.length; i++) {
     const segment = segments[i];
@@ -113,7 +119,12 @@ export function explainCommand(command: string, options?: ExplainOptions): Expla
       continue;
     }
 
-    const result = explainSegment(segment, 0, { ...analyzeOpts, effectiveCwd }, segmentSteps);
+    const result = explainSegment(
+      segment,
+      0,
+      { ...analyzeOpts, effectiveCwd, envAssignments: effectiveEnvAssignments },
+      segmentSteps,
+    );
 
     if (result) {
       blocked = true;
@@ -128,6 +139,23 @@ export function explainCommand(command: string, options?: ExplainOptions): Expla
         effectiveCwdNowUnknown: true,
       });
       effectiveCwd = null;
+    }
+
+    const shellAssignments = getShellGitContextEnvAssignments(segment);
+    for (const [k, v] of shellAssignments) {
+      shellGitContextAssignments.set(k, v);
+    }
+
+    const exportedEnvAssignments = getExportedGitContextEnvAssignments(
+      segment,
+      shellGitContextAssignments,
+    );
+    if (exportedEnvAssignments.size > 0) {
+      const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
+      for (const [k, v] of exportedEnvAssignments) {
+        nextEnvAssignments.set(k, v);
+      }
+      effectiveEnvAssignments = nextEnvAssignments;
     }
 
     trace.segments.push({ index: i, steps: segmentSteps });

--- a/src/bin/explain/config.ts
+++ b/src/bin/explain/config.ts
@@ -67,5 +67,6 @@ export function buildAnalyzeOptions(explainOptions?: ExplainOptions): AnalyzeOpt
     strict: explainOptions?.strict ?? envTruthy('SAFETY_NET_STRICT'),
     paranoidRm: paranoidAll || envTruthy('SAFETY_NET_PARANOID_RM'),
     paranoidInterpreters: paranoidAll || envTruthy('SAFETY_NET_PARANOID_INTERPRETERS'),
+    worktreeMode: envTruthy('SAFETY_NET_WORKTREE'),
   };
 }

--- a/src/bin/explain/format-helpers.ts
+++ b/src/bin/explain/format-helpers.ts
@@ -180,6 +180,15 @@ export function formatStepStyleD(
       return { lines, incrementStep: true };
     }
 
+    case 'worktree-relaxation': {
+      lines.push('');
+      lines.push(`STEP ${stepNum} ${box.h} Worktree relaxation`);
+      lines.push(`  Mode:   SAFETY_NET_WORKTREE`);
+      lines.push(`  Git cwd: ${step.gitCwd}`);
+      lines.push(`  Result: Allowed local discard in linked worktree`);
+      return { lines, incrementStep: true };
+    }
+
     case 'tmpdir-check':
       // This is internal detail, skip in Style D output
       return null;

--- a/src/bin/explain/segment.ts
+++ b/src/bin/explain/segment.ts
@@ -8,7 +8,11 @@ import {
   redactEnvAssignmentTokens,
   redactEnvVars,
 } from '@/bin/explain/redact';
-import { REASON_RECURSION_LIMIT } from '@/core/analyze/analyze-command';
+import {
+  applyShellGitContextEnvSegment,
+  createShellGitContextEnvState,
+  REASON_RECURSION_LIMIT,
+} from '@/core/analyze/analyze-command';
 import { DISPLAY_COMMANDS } from '@/core/analyze/constants';
 import { dangerousInText } from '@/core/analyze/dangerous-text';
 import { analyzeFind } from '@/core/analyze/find';
@@ -87,6 +91,7 @@ function explainInnerSegments(
   // Preserve null (unknown CWD after cd/pushd) - only fall back to cwd when undefined
   let effectiveCwd: string | null | undefined =
     options.effectiveCwd === undefined ? options.cwd : options.effectiveCwd;
+  const shellGitContextState = createShellGitContextEnvState(options.envAssignments);
 
   for (const segment of innerSegments) {
     // Check for unparseable segment (single token with spaces) - matches guard behavior
@@ -117,7 +122,16 @@ function explainInnerSegments(
       continue;
     }
 
-    const result = explainSegment(segment, depth + 1, { ...options, effectiveCwd }, steps);
+    const result = explainSegment(
+      segment,
+      depth + 1,
+      {
+        ...options,
+        effectiveCwd,
+        envAssignments: shellGitContextState.effectiveEnvAssignments,
+      },
+      steps,
+    );
     if (result) return result;
 
     if (segmentChangesCwd(segment)) {
@@ -128,6 +142,7 @@ function explainInnerSegments(
       });
       effectiveCwd = null;
     }
+    applyShellGitContextEnvSegment(segment, shellGitContextState);
   }
 
   return null;

--- a/src/bin/explain/segment.ts
+++ b/src/bin/explain/segment.ts
@@ -23,7 +23,7 @@ import { extractDashCArg } from '@/core/analyze/shell-wrappers';
 import { isTmpdirOverriddenToNonTemp } from '@/core/analyze/tmpdir';
 import { analyzeXargs } from '@/core/analyze/xargs';
 import { checkCustomRules } from '@/core/rules-custom';
-import { analyzeGit } from '@/core/rules-git';
+import { analyzeGit, getGitWorktreeRelaxation } from '@/core/rules-git';
 import { analyzeRm } from '@/core/rules-rm';
 import {
   normalizeCommandToken,
@@ -289,14 +289,27 @@ export function explainSegment(
   }
 
   if (isGit) {
-    const reason = analyzeGit(strippedTokens);
+    const gitOptions = {
+      cwd: cwdForRm,
+      envAssignments,
+      worktreeMode: options.worktreeMode,
+    };
+    const relaxation = getGitWorktreeRelaxation(strippedTokens, gitOptions);
+    const reason = analyzeGit(strippedTokens, gitOptions);
     steps.push({
       type: 'rule-check',
       ruleModule: 'rules-git.ts',
       ruleFunction: 'analyzeGit',
-      matched: !!reason,
-      reason: reason ?? undefined,
+      matched: !!reason || !!relaxation,
+      reason: reason ?? relaxation?.originalReason,
     });
+    if (relaxation) {
+      steps.push({
+        type: 'worktree-relaxation',
+        originalReason: relaxation.originalReason,
+        gitCwd: relaxation.gitCwd,
+      });
+    }
     if (reason) return { reason };
   }
 
@@ -335,6 +348,8 @@ export function explainSegment(
       originalCwd,
       paranoidRm: options.paranoidRm,
       allowTmpdirVar,
+      envAssignments,
+      worktreeMode: options.worktreeMode,
     });
     steps.push({
       type: 'rule-check',
@@ -356,6 +371,8 @@ export function explainSegment(
       originalCwd,
       paranoidRm: options.paranoidRm,
       allowTmpdirVar,
+      envAssignments,
+      worktreeMode: options.worktreeMode,
       analyzeNested,
     });
     steps.push({
@@ -371,6 +388,7 @@ export function explainSegment(
   const matchedKnown = isGit || isRm || isFind || isXargs || isParallel;
   const tokensScanned: string[] = [];
   let fallbackReason: string | null = null;
+  let fallbackRelaxation: ReturnType<typeof getGitWorktreeRelaxation> = null;
   let embeddedCommandFound: string | undefined;
 
   if (!matchedKnown && !DISPLAY_COMMANDS.has(normalizeCommandToken(head))) {
@@ -393,7 +411,13 @@ export function explainSegment(
       if (!fallbackReason && cmd === 'git') {
         embeddedCommandFound = 'git';
         const gitTokens = ['git', ...strippedTokens.slice(i + 1)];
-        fallbackReason = analyzeGit(gitTokens);
+        const gitOptions = {
+          cwd: cwdForRm,
+          envAssignments,
+          worktreeMode: options.worktreeMode,
+        };
+        fallbackRelaxation = getGitWorktreeRelaxation(gitTokens, gitOptions);
+        fallbackReason = analyzeGit(gitTokens, gitOptions);
       }
       if (!fallbackReason && cmd === 'find') {
         embeddedCommandFound = 'find';
@@ -407,6 +431,13 @@ export function explainSegment(
     tokensScanned,
     embeddedCommandFound,
   });
+  if (fallbackRelaxation) {
+    steps.push({
+      type: 'worktree-relaxation',
+      originalReason: fallbackRelaxation.originalReason,
+      gitCwd: fallbackRelaxation.gitCwd,
+    });
+  }
   if (fallbackReason) return { reason: fallbackReason };
 
   const shouldCheckCustomRules = depth === 0 || !matchedKnown;

--- a/src/bin/explain/segment.ts
+++ b/src/bin/explain/segment.ts
@@ -11,6 +11,7 @@ import {
 import {
   applyShellGitContextEnvSegment,
   createShellGitContextEnvState,
+  getSegmentGitContextEnvAssignments,
   REASON_RECURSION_LIMIT,
 } from '@/core/analyze/analyze-command';
 import { DISPLAY_COMMANDS } from '@/core/analyze/constants';
@@ -128,7 +129,7 @@ function explainInnerSegments(
       {
         ...options,
         effectiveCwd,
-        envAssignments: shellGitContextState.effectiveEnvAssignments,
+        envAssignments: getSegmentGitContextEnvAssignments(segment, shellGitContextState),
       },
       steps,
     );

--- a/src/bin/explain/segment.ts
+++ b/src/bin/explain/segment.ts
@@ -157,7 +157,13 @@ export function explainSegment(
     });
   }
 
-  const wrapperResult = stripWrappersWithInfo(envResult.tokens);
+  // Preserve null (unknown CWD after cd/pushd) - only fall back to cwd when undefined
+  const effectiveCwd = options.effectiveCwd === undefined ? options.cwd : options.effectiveCwd;
+  const cwdUnknown = effectiveCwd === null;
+  const baseCwdForRm = cwdUnknown ? undefined : (effectiveCwd ?? options.cwd);
+  const originalCwd = cwdUnknown ? undefined : options.cwd;
+
+  const wrapperResult = stripWrappersWithInfo(envResult.tokens, baseCwdForRm);
   const removed = envResult.tokens.slice(0, envResult.tokens.length - wrapperResult.tokens.length);
   if (removed.length > 0) {
     steps.push({
@@ -263,13 +269,7 @@ export function explainSegment(
   const allowTmpdirVar = !isTmpdirOverriddenToNonTemp(envAssignments);
   // Use command-scoped TMPDIR if set, otherwise fall back to process.env
   const tmpdirValue = envAssignments.get('TMPDIR') ?? process.env.TMPDIR ?? null;
-  // Preserve null (unknown CWD after cd/pushd) - only fall back to cwd when undefined
-  const effectiveCwd = options.effectiveCwd === undefined ? options.cwd : options.effectiveCwd;
-
-  // Derive CWD context matching guard behavior: when CWD is unknown, both become undefined
-  const cwdUnknown = effectiveCwd === null;
-  const cwdForRm = cwdUnknown ? undefined : (effectiveCwd ?? options.cwd);
-  const originalCwd = cwdUnknown ? undefined : options.cwd;
+  const cwdForRm = wrapperResult.cwd === null ? undefined : (wrapperResult.cwd ?? baseCwdForRm);
 
   // git uses case-insensitive matching (matches guard: basename.toLowerCase() === 'git')
   // rm/find/xargs/parallel use case-sensitive matching (matches guard)
@@ -414,7 +414,7 @@ export function explainSegment(
         const gitOptions = {
           cwd: cwdForRm,
           envAssignments,
-          worktreeMode: options.worktreeMode,
+          worktreeMode: false,
         };
         fallbackRelaxation = getGitWorktreeRelaxation(gitTokens, gitOptions);
         fallbackReason = analyzeGit(gitTokens, gitOptions);

--- a/src/bin/explain/segment.ts
+++ b/src/bin/explain/segment.ts
@@ -31,7 +31,7 @@ import {
   stripEnvAssignmentsWithInfo,
   stripWrappersWithInfo,
 } from '@/core/shell';
-import type { AnalyzeOptions, TraceStep } from '@/types';
+import type { AnalyzeNestedOverrides, AnalyzeOptions, TraceStep } from '@/types';
 import {
   INTERPRETERS,
   MAX_RECURSION_DEPTH,
@@ -175,6 +175,22 @@ export function explainSegment(
   }
 
   const strippedTokens = wrapperResult.tokens;
+  const envAssignments = new Map(options.envAssignments ?? []);
+  for (const [k, v] of envResult.envAssignments) {
+    envAssignments.set(k, v);
+  }
+  for (const [k, v] of wrapperResult.envAssignments) {
+    envAssignments.set(k, v);
+  }
+  const cwdForRm = wrapperResult.cwd === null ? undefined : (wrapperResult.cwd ?? baseCwdForRm);
+  const nestedEffectiveCwd =
+    wrapperResult.cwd === undefined ? options.effectiveCwd : wrapperResult.cwd;
+  const nestedOptions = {
+    ...options,
+    effectiveCwd: nestedEffectiveCwd,
+    envAssignments,
+  };
+
   if (strippedTokens.length === 0) {
     return null;
   }
@@ -203,7 +219,7 @@ export function explainSegment(
         depth: depth + 1,
       });
 
-      return explainInnerSegments(innerCmd, depth, options, steps);
+      return explainInnerSegments(innerCmd, depth, nestedOptions, steps);
     }
   }
 
@@ -230,7 +246,7 @@ export function explainSegment(
         depth: depth + 1,
       });
 
-      const nestedResult = explainInnerSegments(codeArg, depth, options, steps);
+      const nestedResult = explainInnerSegments(codeArg, depth, nestedOptions, steps);
       if (nestedResult) return nestedResult;
 
       if (containsDangerousCode(codeArg)) {
@@ -259,17 +275,12 @@ export function explainSegment(
       innerCommand: redactEnvAssignmentsInString(busyboxInnerCmd),
       depth: depth + 1,
     });
-    return explainSegment(strippedTokens.slice(1), depth + 1, options, steps);
+    return explainSegment(strippedTokens.slice(1), depth + 1, nestedOptions, steps);
   }
 
-  const envAssignments = new Map(envResult.envAssignments);
-  for (const [k, v] of wrapperResult.envAssignments) {
-    envAssignments.set(k, v);
-  }
   const allowTmpdirVar = !isTmpdirOverriddenToNonTemp(envAssignments);
   // Use command-scoped TMPDIR if set, otherwise fall back to process.env
   const tmpdirValue = envAssignments.get('TMPDIR') ?? process.env.TMPDIR ?? null;
-  const cwdForRm = wrapperResult.cwd === null ? undefined : (wrapperResult.cwd ?? baseCwdForRm);
 
   // git uses case-insensitive matching (matches guard: basename.toLowerCase() === 'git')
   // rm/find/xargs/parallel use case-sensitive matching (matches guard)
@@ -362,8 +373,17 @@ export function explainSegment(
   }
 
   if (isParallel) {
-    const analyzeNested = (cmd: string): string | null => {
-      const result = explainInnerSegments(cmd, depth, options, steps);
+    const analyzeNested = (cmd: string, overrides?: AnalyzeNestedOverrides): string | null => {
+      const overriddenOptions = {
+        ...nestedOptions,
+        effectiveCwd:
+          overrides && Object.hasOwn(overrides, 'effectiveCwd')
+            ? overrides.effectiveCwd
+            : nestedOptions.effectiveCwd,
+        envAssignments: overrides?.envAssignments ?? nestedOptions.envAssignments,
+        worktreeMode: overrides?.worktreeMode ?? nestedOptions.worktreeMode,
+      };
+      const result = explainInnerSegments(cmd, depth, overriddenOptions, steps);
       return result?.reason ?? null;
     };
     const reason = analyzeParallel(strippedTokens, {

--- a/src/bin/help.ts
+++ b/src/bin/help.ts
@@ -113,6 +113,9 @@ export function printHelp(): void {
   lines.push(`${INDENT}SAFETY_NET_PARANOID=1             Enable all paranoid checks`);
   lines.push(`${INDENT}SAFETY_NET_PARANOID_RM=1          Block non-temp rm -rf within cwd`);
   lines.push(`${INDENT}SAFETY_NET_PARANOID_INTERPRETERS=1  Block interpreter one-liners`);
+  lines.push(
+    `${INDENT}SAFETY_NET_WORKTREE=1             Allow local git discards in linked worktrees`,
+  );
   lines.push('');
 
   // Config files

--- a/src/bin/hooks/claude-code.ts
+++ b/src/bin/hooks/claude-code.ts
@@ -60,6 +60,7 @@ export async function runClaudeCodeHook(): Promise<void> {
   const paranoidAll = envTruthy('SAFETY_NET_PARANOID');
   const paranoidRm = paranoidAll || envTruthy('SAFETY_NET_PARANOID_RM');
   const paranoidInterpreters = paranoidAll || envTruthy('SAFETY_NET_PARANOID_INTERPRETERS');
+  const worktreeMode = envTruthy('SAFETY_NET_WORKTREE');
 
   const config = loadConfig(cwd);
 
@@ -69,6 +70,7 @@ export async function runClaudeCodeHook(): Promise<void> {
     strict,
     paranoidRm,
     paranoidInterpreters,
+    worktreeMode,
   });
 
   if (result) {

--- a/src/bin/hooks/copilot-cli.ts
+++ b/src/bin/hooks/copilot-cli.ts
@@ -69,6 +69,7 @@ export async function runCopilotCliHook(): Promise<void> {
   const paranoidAll = envTruthy('SAFETY_NET_PARANOID');
   const paranoidRm = paranoidAll || envTruthy('SAFETY_NET_PARANOID_RM');
   const paranoidInterpreters = paranoidAll || envTruthy('SAFETY_NET_PARANOID_INTERPRETERS');
+  const worktreeMode = envTruthy('SAFETY_NET_WORKTREE');
 
   const config = loadConfig(cwd);
 
@@ -78,6 +79,7 @@ export async function runCopilotCliHook(): Promise<void> {
     strict,
     paranoidRm,
     paranoidInterpreters,
+    worktreeMode,
   });
 
   if (result) {

--- a/src/bin/hooks/gemini-cli.ts
+++ b/src/bin/hooks/gemini-cli.ts
@@ -63,6 +63,7 @@ export async function runGeminiCLIHook(): Promise<void> {
   const paranoidAll = envTruthy('SAFETY_NET_PARANOID');
   const paranoidRm = paranoidAll || envTruthy('SAFETY_NET_PARANOID_RM');
   const paranoidInterpreters = paranoidAll || envTruthy('SAFETY_NET_PARANOID_INTERPRETERS');
+  const worktreeMode = envTruthy('SAFETY_NET_WORKTREE');
 
   const config = loadConfig(cwd);
 
@@ -72,6 +73,7 @@ export async function runGeminiCLIHook(): Promise<void> {
     strict,
     paranoidRm,
     paranoidInterpreters,
+    worktreeMode,
   });
 
   if (result) {

--- a/src/bin/statusline.ts
+++ b/src/bin/statusline.ts
@@ -83,6 +83,7 @@ export async function printStatusline(): Promise<void> {
     const paranoidAll = envTruthy('SAFETY_NET_PARANOID');
     const paranoidRm = paranoidAll || envTruthy('SAFETY_NET_PARANOID_RM');
     const paranoidInterpreters = paranoidAll || envTruthy('SAFETY_NET_PARANOID_INTERPRETERS');
+    const worktreeMode = envTruthy('SAFETY_NET_WORKTREE');
 
     let modeEmojis = '';
 
@@ -99,6 +100,10 @@ export async function printStatusline(): Promise<void> {
       modeEmojis += '🗑️';
     } else if (paranoidInterpreters) {
       modeEmojis += '🐚';
+    }
+
+    if (worktreeMode) {
+      modeEmojis += '🌳';
     }
 
     // If no mode flags, show ✅

--- a/src/core/analyze/analyze-command.ts
+++ b/src/core/analyze/analyze-command.ts
@@ -16,6 +16,7 @@ const REASON_STRICT_UNPARSEABLE =
 export const REASON_RECURSION_LIMIT =
   'Command exceeds maximum recursion depth and cannot be safely analyzed.';
 const GIT_CONTEXT_ENV_OVERRIDE_NAMES: ReadonlySet<string> = new Set(GIT_CONTEXT_ENV_OVERRIDES);
+const GIT_CONTEXT_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 
 export type InternalOptions = AnalyzeOptions & { config: Config };
 
@@ -47,12 +48,11 @@ export function analyzeCommandInternal(
   // undefined = use cwd, null = unknown (after cd/pushd)
   let effectiveCwd: string | null | undefined =
     options.effectiveCwd !== undefined ? options.effectiveCwd : options.cwd;
-  let effectiveEnvAssignments = options.envAssignments;
-  const shellGitContextAssignments = new Map<string, string>();
+  const shellGitContextState = createShellGitContextEnvState(options.envAssignments);
 
   for (const segment of segments) {
     const segmentStr = segment.join(' ');
-    const segmentEnvAssignments = effectiveEnvAssignments;
+    const segmentEnvAssignments = shellGitContextState.effectiveEnvAssignments;
 
     if (segment.length === 1 && segment[0]?.includes(' ')) {
       const textReason = dangerousInText(segment[0]);
@@ -94,86 +94,239 @@ export function analyzeCommandInternal(
       effectiveCwd = null;
     }
 
-    const shellAssignments = getShellGitContextEnvAssignments(segment);
-    for (const [k, v] of shellAssignments) {
-      shellGitContextAssignments.set(k, v);
-    }
-
-    const exportedEnvAssignments = getExportedGitContextEnvAssignments(
-      segment,
-      shellGitContextAssignments,
-    );
-    if (exportedEnvAssignments.size > 0) {
-      const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
-      for (const [k, v] of exportedEnvAssignments) {
-        nextEnvAssignments.set(k, v);
-      }
-      effectiveEnvAssignments = nextEnvAssignments;
-    }
+    applyShellGitContextEnvSegment(segment, shellGitContextState);
   }
 
   return null;
 }
 
-export function getShellGitContextEnvAssignments(tokens: readonly string[]): Map<string, string> {
-  const result = new Map<string, string>();
+export interface ShellGitContextEnvState {
+  effectiveEnvAssignments?: ReadonlyMap<string, string>;
+  shellAssignments: Map<string, string>;
+  exportedNames: Set<string>;
+  allexport: boolean;
+}
 
-  for (const token of tokens) {
-    const assignment = parseEnvAssignment(token);
+export function createShellGitContextEnvState(
+  effectiveEnvAssignments?: ReadonlyMap<string, string>,
+): ShellGitContextEnvState {
+  return {
+    effectiveEnvAssignments,
+    shellAssignments: new Map(),
+    exportedNames: new Set(),
+    allexport: false,
+  };
+}
+
+export function applyShellGitContextEnvSegment(
+  tokens: readonly string[],
+  state: ShellGitContextEnvState,
+): void {
+  const commandInfo = getShellCommandInfo(tokens);
+  if (!commandInfo) {
+    return;
+  }
+
+  const { command, commandIndex, leadingAssignments } = commandInfo;
+  if (command === null) {
+    for (const assignment of leadingAssignments.values()) {
+      setShellGitContextAssignment(state, assignment);
+    }
+    return;
+  }
+
+  if (command === 'set') {
+    const allexport = getAllexportChange(tokens, commandIndex);
+    if (allexport !== null) {
+      state.allexport = allexport;
+    }
+    return;
+  }
+
+  if (command !== 'export' && command !== 'typeset' && command !== 'declare') {
+    return;
+  }
+
+  for (const assignment of leadingAssignments.values()) {
+    setShellGitContextAssignment(state, assignment);
+  }
+
+  if (command === 'export') {
+    const operandsStart = getExportOperandsStart(tokens, commandIndex);
+    if (operandsStart === null) {
+      return;
+    }
+    for (const token of tokens.slice(operandsStart)) {
+      addExportedGitContextEnvAssignment(state, token);
+    }
+    return;
+  }
+
+  const operandsInfo = getTypesetOperandsInfo(tokens, commandIndex);
+  if (operandsInfo === null) {
+    return;
+  }
+  for (const token of tokens.slice(operandsInfo.operandsStart)) {
+    addTypesetGitContextEnvAssignment(state, token, operandsInfo.exports);
+  }
+}
+
+interface GitContextAssignment {
+  name: string;
+  value: string;
+}
+
+interface ShellCommandInfo {
+  command: string | null;
+  commandIndex: number;
+  leadingAssignments: Map<string, GitContextAssignment>;
+}
+
+function getShellCommandInfo(tokens: readonly string[]): ShellCommandInfo | null {
+  const leadingAssignments = new Map<string, GitContextAssignment>();
+  let i = 0;
+
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    const assignment = parseShellAssignment(token);
     if (!assignment) {
-      return new Map();
+      break;
     }
     if (GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
-      result.set(assignment.name, assignment.value);
+      leadingAssignments.set(assignment.name, assignment);
+    }
+    i++;
+  }
+
+  if (i >= tokens.length) {
+    return { command: null, commandIndex: i, leadingAssignments };
+  }
+
+  let commandIndex = i;
+  let command = tokens[commandIndex] ?? null;
+  if (command === 'builtin' || command === 'command') {
+    commandIndex++;
+    command = tokens[commandIndex] ?? null;
+  }
+  if (command === null) {
+    return null;
+  }
+
+  return { command, commandIndex, leadingAssignments };
+}
+
+function parseShellAssignment(token: string): GitContextAssignment | null {
+  return parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment(token);
+}
+
+function parseGitContextEnvAssignment(token: string): GitContextAssignment | null {
+  const assignment = parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment(token);
+  if (!assignment || !GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
+    return null;
+  }
+  return assignment;
+}
+
+function parseGitContextAppendEnvAssignment(token: string): GitContextAssignment | null {
+  const match = token.match(GIT_CONTEXT_APPEND_ASSIGNMENT_RE);
+  const name = match?.[1];
+  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name)) {
+    return null;
+  }
+  const eqIdx = token.indexOf('=');
+  return { name, value: token.slice(eqIdx + 1) };
+}
+
+function setShellGitContextAssignment(
+  state: ShellGitContextEnvState,
+  assignment: GitContextAssignment,
+): void {
+  state.shellAssignments.set(assignment.name, assignment.value);
+  if (state.allexport || state.exportedNames.has(assignment.name)) {
+    setEffectiveGitContextAssignment(state, assignment);
+  }
+}
+
+function setEffectiveGitContextAssignment(
+  state: ShellGitContextEnvState,
+  assignment: GitContextAssignment,
+): void {
+  const nextEnvAssignments = new Map(state.effectiveEnvAssignments ?? []);
+  nextEnvAssignments.set(assignment.name, assignment.value);
+  state.effectiveEnvAssignments = nextEnvAssignments;
+}
+
+function addExportedGitContextEnvAssignment(state: ShellGitContextEnvState, token: string): void {
+  const assignment = parseGitContextEnvAssignment(token);
+  if (assignment) {
+    state.shellAssignments.set(assignment.name, assignment.value);
+    state.exportedNames.add(assignment.name);
+    setEffectiveGitContextAssignment(state, assignment);
+    return;
+  }
+
+  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(token)) {
+    state.exportedNames.add(token);
+    const value = state.shellAssignments.get(token);
+    if (value !== undefined) {
+      setEffectiveGitContextAssignment(state, { name: token, value });
     }
   }
-
-  return result;
 }
 
-export function getExportedGitContextEnvAssignments(
-  tokens: readonly string[],
-  shellGitContextAssignments: ReadonlyMap<string, string>,
-): Map<string, string> {
-  const result = new Map<string, string>();
-  const command = tokens[0];
-  if (!command) {
-    return result;
+function addTypesetGitContextEnvAssignment(
+  state: ShellGitContextEnvState,
+  token: string,
+  exports: boolean,
+): void {
+  const assignment = parseGitContextEnvAssignment(token);
+  if (assignment) {
+    state.shellAssignments.set(assignment.name, assignment.value);
+    if (exports) {
+      state.exportedNames.add(assignment.name);
+      setEffectiveGitContextAssignment(state, assignment);
+    } else if (state.allexport || state.exportedNames.has(assignment.name)) {
+      setEffectiveGitContextAssignment(state, assignment);
+    }
+    return;
   }
 
-  const operandsStart =
-    command === 'export'
-      ? getExportOperandsStart(tokens)
-      : command === 'typeset' || command === 'declare'
-        ? getTypesetExportOperandsStart(tokens)
-        : null;
-
-  if (operandsStart === null) {
-    return result;
+  if (exports && GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(token)) {
+    state.exportedNames.add(token);
+    const value = state.shellAssignments.get(token);
+    if (value !== undefined) {
+      setEffectiveGitContextAssignment(state, { name: token, value });
+    }
   }
-
-  for (const token of tokens.slice(operandsStart)) {
-    addExportedGitContextEnvAssignment(result, shellGitContextAssignments, token);
-  }
-  return result;
 }
 
-function getExportOperandsStart(tokens: readonly string[]): number | null {
-  const firstOperand = tokens[1];
+function getExportOperandsStart(tokens: readonly string[], commandIndex: number): number | null {
+  const firstOperand = tokens[commandIndex + 1];
   if (firstOperand === undefined) {
-    return 1;
+    return commandIndex + 1;
   }
   if (firstOperand === '--') {
-    return 2;
+    return commandIndex + 2;
   }
   if (firstOperand.startsWith('-')) {
     return null;
   }
-  return 1;
+  return commandIndex + 1;
 }
 
-function getTypesetExportOperandsStart(tokens: readonly string[]): number | null {
-  let i = 1;
+interface TypesetOperandsInfo {
+  operandsStart: number;
+  exports: boolean;
+}
+
+function getTypesetOperandsInfo(
+  tokens: readonly string[],
+  commandIndex: number,
+): TypesetOperandsInfo | null {
+  let i = commandIndex + 1;
   let hasExportFlag = false;
   while (i < tokens.length) {
     const token = tokens[i];
@@ -181,7 +334,7 @@ function getTypesetExportOperandsStart(tokens: readonly string[]): number | null
       return null;
     }
     if (token === '--') {
-      return hasExportFlag ? i + 1 : null;
+      return { operandsStart: i + 1, exports: hasExportFlag };
     }
     if (token.startsWith('-')) {
       hasExportFlag = hasExportFlag || token.slice(1).includes('x');
@@ -191,28 +344,32 @@ function getTypesetExportOperandsStart(tokens: readonly string[]): number | null
     if (token.startsWith('+')) {
       return null;
     }
-    return hasExportFlag ? i : null;
+    return { operandsStart: i, exports: hasExportFlag };
   }
-  return hasExportFlag ? i : null;
+  return { operandsStart: i, exports: hasExportFlag };
 }
 
-function addExportedGitContextEnvAssignment(
-  result: Map<string, string>,
-  shellGitContextAssignments: ReadonlyMap<string, string>,
-  token: string,
-): void {
-  const assignment = parseEnvAssignment(token);
-  if (assignment) {
-    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
-      result.set(assignment.name, assignment.value);
+function getAllexportChange(tokens: readonly string[], commandIndex: number): boolean | null {
+  let i = commandIndex + 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
     }
-    return;
-  }
-
-  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(token)) {
-    const value = shellGitContextAssignments.get(token);
-    if (value !== undefined) {
-      result.set(token, value);
+    if (token === '-o' || token === '+o') {
+      if (tokens[i + 1] === 'allexport') {
+        return token === '-o';
+      }
+      i += 2;
+      continue;
     }
+    if (token.startsWith('-') && token.slice(1).includes('a')) {
+      return true;
+    }
+    if (token.startsWith('+') && token.slice(1).includes('a')) {
+      return false;
+    }
+    i++;
   }
+  return null;
 }

--- a/src/core/analyze/analyze-command.ts
+++ b/src/core/analyze/analyze-command.ts
@@ -48,6 +48,7 @@ export function analyzeCommandInternal(
   let effectiveCwd: string | null | undefined =
     options.effectiveCwd !== undefined ? options.effectiveCwd : options.cwd;
   let effectiveEnvAssignments = options.envAssignments;
+  const shellGitContextAssignments = new Map<string, string>();
 
   for (const segment of segments) {
     const segmentStr = segment.join(' ');
@@ -93,7 +94,15 @@ export function analyzeCommandInternal(
       effectiveCwd = null;
     }
 
-    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment);
+    const shellAssignments = getShellGitContextEnvAssignments(segment);
+    for (const [k, v] of shellAssignments) {
+      shellGitContextAssignments.set(k, v);
+    }
+
+    const exportedEnvAssignments = getExportedGitContextEnvAssignments(
+      segment,
+      shellGitContextAssignments,
+    );
     if (exportedEnvAssignments.size > 0) {
       const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
       for (const [k, v] of exportedEnvAssignments) {
@@ -106,21 +115,104 @@ export function analyzeCommandInternal(
   return null;
 }
 
-function getExportedGitContextEnvAssignments(tokens: readonly string[]): Map<string, string> {
+export function getShellGitContextEnvAssignments(tokens: readonly string[]): Map<string, string> {
   const result = new Map<string, string>();
-  if (tokens[0] !== 'export') {
-    return result;
-  }
 
-  for (const token of tokens.slice(1)) {
-    if (token.startsWith('-')) {
+  for (const token of tokens) {
+    const assignment = parseEnvAssignment(token);
+    if (!assignment) {
       return new Map();
     }
-
-    const assignment = parseEnvAssignment(token);
-    if (assignment && GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
+    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
       result.set(assignment.name, assignment.value);
     }
   }
+
   return result;
+}
+
+export function getExportedGitContextEnvAssignments(
+  tokens: readonly string[],
+  shellGitContextAssignments: ReadonlyMap<string, string>,
+): Map<string, string> {
+  const result = new Map<string, string>();
+  const command = tokens[0];
+  if (!command) {
+    return result;
+  }
+
+  const operandsStart =
+    command === 'export'
+      ? getExportOperandsStart(tokens)
+      : command === 'typeset' || command === 'declare'
+        ? getTypesetExportOperandsStart(tokens)
+        : null;
+
+  if (operandsStart === null) {
+    return result;
+  }
+
+  for (const token of tokens.slice(operandsStart)) {
+    addExportedGitContextEnvAssignment(result, shellGitContextAssignments, token);
+  }
+  return result;
+}
+
+function getExportOperandsStart(tokens: readonly string[]): number | null {
+  const firstOperand = tokens[1];
+  if (firstOperand === undefined) {
+    return 1;
+  }
+  if (firstOperand === '--') {
+    return 2;
+  }
+  if (firstOperand.startsWith('-')) {
+    return null;
+  }
+  return 1;
+}
+
+function getTypesetExportOperandsStart(tokens: readonly string[]): number | null {
+  let i = 1;
+  let hasExportFlag = false;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    if (token === '--') {
+      return hasExportFlag ? i + 1 : null;
+    }
+    if (token.startsWith('-')) {
+      hasExportFlag = hasExportFlag || token.slice(1).includes('x');
+      i++;
+      continue;
+    }
+    if (token.startsWith('+')) {
+      return null;
+    }
+    return hasExportFlag ? i : null;
+  }
+  return hasExportFlag ? i : null;
+}
+
+function addExportedGitContextEnvAssignment(
+  result: Map<string, string>,
+  shellGitContextAssignments: ReadonlyMap<string, string>,
+  token: string,
+): void {
+  const assignment = parseEnvAssignment(token);
+  if (assignment) {
+    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
+      result.set(assignment.name, assignment.value);
+    }
+    return;
+  }
+
+  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(token)) {
+    const value = shellGitContextAssignments.get(token);
+    if (value !== undefined) {
+      result.set(token, value);
+    }
+  }
 }

--- a/src/core/analyze/analyze-command.ts
+++ b/src/core/analyze/analyze-command.ts
@@ -52,7 +52,7 @@ export function analyzeCommandInternal(
 
   for (const segment of segments) {
     const segmentStr = segment.join(' ');
-    const segmentEnvAssignments = shellGitContextState.effectiveEnvAssignments;
+    const segmentEnvAssignments = getSegmentGitContextEnvAssignments(segment, shellGitContextState);
 
     if (segment.length === 1 && segment[0]?.includes(' ')) {
       const textReason = dangerousInText(segment[0]);
@@ -105,6 +105,7 @@ export interface ShellGitContextEnvState {
   shellAssignments: Map<string, string>;
   exportedNames: Set<string>;
   allexport: boolean;
+  keywordExport: boolean;
 }
 
 export function createShellGitContextEnvState(
@@ -115,6 +116,7 @@ export function createShellGitContextEnvState(
     shellAssignments: new Map(),
     exportedNames: new Set(),
     allexport: false,
+    keywordExport: false,
   };
 }
 
@@ -136,14 +138,22 @@ export function applyShellGitContextEnvSegment(
   }
 
   if (command === 'set') {
-    const allexport = getAllexportChange(tokens, commandIndex);
-    if (allexport !== null) {
-      state.allexport = allexport;
+    const changes = getSetOptionChanges(tokens, commandIndex);
+    if (changes.allexport !== null) {
+      state.allexport = changes.allexport;
+    }
+    if (changes.keywordExport !== null) {
+      state.keywordExport = changes.keywordExport;
     }
     return;
   }
 
-  if (command !== 'export' && command !== 'typeset' && command !== 'declare') {
+  if (
+    command !== 'export' &&
+    command !== 'typeset' &&
+    command !== 'declare' &&
+    command !== 'readonly'
+  ) {
     return;
   }
 
@@ -169,6 +179,27 @@ export function applyShellGitContextEnvSegment(
   for (const token of tokens.slice(operandsInfo.operandsStart)) {
     addTypesetGitContextEnvAssignment(state, token, operandsInfo.exports);
   }
+}
+
+function getSegmentGitContextEnvAssignments(
+  tokens: readonly string[],
+  state: ShellGitContextEnvState,
+): ReadonlyMap<string, string> | undefined {
+  if (!state.keywordExport) {
+    return state.effectiveEnvAssignments;
+  }
+
+  let nextEnvAssignments: Map<string, string> | null = null;
+  for (const token of tokens) {
+    const assignment = parseGitContextEnvAssignment(token);
+    if (!assignment) {
+      continue;
+    }
+    nextEnvAssignments ??= new Map(state.effectiveEnvAssignments ?? []);
+    nextEnvAssignments.set(assignment.name, assignment.value);
+  }
+
+  return nextEnvAssignments ?? state.effectiveEnvAssignments;
 }
 
 interface GitContextAssignment {
@@ -207,15 +238,51 @@ function getShellCommandInfo(tokens: readonly string[]): ShellCommandInfo | null
 
   let commandIndex = i;
   let command = tokens[commandIndex] ?? null;
-  if (command === 'builtin' || command === 'command') {
+  if (command === 'builtin') {
     commandIndex++;
     command = tokens[commandIndex] ?? null;
+  }
+  if (command === 'command') {
+    const commandBuiltinInfo = getCommandBuiltinTarget(tokens, commandIndex);
+    if (!commandBuiltinInfo) {
+      return null;
+    }
+    commandIndex = commandBuiltinInfo.commandIndex;
+    command = commandBuiltinInfo.command;
   }
   if (command === null) {
     return null;
   }
 
   return { command, commandIndex, leadingAssignments };
+}
+
+function getCommandBuiltinTarget(
+  tokens: readonly string[],
+  commandIndex: number,
+): { command: string; commandIndex: number } | null {
+  let i = commandIndex + 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    if (token === '--') {
+      i++;
+      break;
+    }
+    if (token === '-p') {
+      i++;
+      continue;
+    }
+    if (token === '-v' || token === '-V') {
+      return null;
+    }
+    break;
+  }
+
+  const command = tokens[i];
+  return command ? { command, commandIndex: i } : null;
 }
 
 function parseShellAssignment(token: string): GitContextAssignment | null {
@@ -304,17 +371,25 @@ function addTypesetGitContextEnvAssignment(
 }
 
 function getExportOperandsStart(tokens: readonly string[], commandIndex: number): number | null {
-  const firstOperand = tokens[commandIndex + 1];
-  if (firstOperand === undefined) {
-    return commandIndex + 1;
+  let i = commandIndex + 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) {
+      return null;
+    }
+    if (token === '--') {
+      return i + 1;
+    }
+    if (token === '-p') {
+      i++;
+      continue;
+    }
+    if (token.startsWith('-')) {
+      return null;
+    }
+    return i;
   }
-  if (firstOperand === '--') {
-    return commandIndex + 2;
-  }
-  if (firstOperand.startsWith('-')) {
-    return null;
-  }
-  return commandIndex + 1;
+  return i;
 }
 
 interface TypesetOperandsInfo {
@@ -337,39 +412,73 @@ function getTypesetOperandsInfo(
       return { operandsStart: i + 1, exports: hasExportFlag };
     }
     if (token.startsWith('-')) {
-      hasExportFlag = hasExportFlag || token.slice(1).includes('x');
+      if (token.slice(1).includes('x')) {
+        hasExportFlag = true;
+      }
       i++;
       continue;
     }
     if (token.startsWith('+')) {
-      return null;
+      if (token.slice(1).includes('x')) {
+        hasExportFlag = false;
+      }
+      i++;
+      continue;
     }
     return { operandsStart: i, exports: hasExportFlag };
   }
   return { operandsStart: i, exports: hasExportFlag };
 }
 
-function getAllexportChange(tokens: readonly string[], commandIndex: number): boolean | null {
+interface SetOptionChanges {
+  allexport: boolean | null;
+  keywordExport: boolean | null;
+}
+
+function getSetOptionChanges(tokens: readonly string[], commandIndex: number): SetOptionChanges {
+  const changes: SetOptionChanges = { allexport: null, keywordExport: null };
   let i = commandIndex + 1;
   while (i < tokens.length) {
     const token = tokens[i];
     if (!token) {
-      return null;
+      return changes;
+    }
+    if (token === '--') {
+      return changes;
     }
     if (token === '-o' || token === '+o') {
       if (tokens[i + 1] === 'allexport') {
-        return token === '-o';
+        changes.allexport = token === '-o';
+      }
+      if (tokens[i + 1] === 'keyword') {
+        changes.keywordExport = token === '-o';
       }
       i += 2;
       continue;
     }
-    if (token.startsWith('-') && token.slice(1).includes('a')) {
-      return true;
+    if (token.startsWith('-') && token.length > 1) {
+      const flags = token.slice(1);
+      if (flags.includes('a')) {
+        changes.allexport = true;
+      }
+      if (flags.includes('k')) {
+        changes.keywordExport = true;
+      }
+      i++;
+      continue;
     }
-    if (token.startsWith('+') && token.slice(1).includes('a')) {
-      return false;
+    if (token.startsWith('+') && token.length > 1) {
+      const flags = token.slice(1);
+      if (flags.includes('a')) {
+        changes.allexport = false;
+      }
+      if (flags.includes('k')) {
+        changes.keywordExport = false;
+      }
+      i++;
+      continue;
     }
-    i++;
+    return changes;
   }
-  return null;
+  return changes;
 }

--- a/src/core/analyze/analyze-command.ts
+++ b/src/core/analyze/analyze-command.ts
@@ -1,7 +1,13 @@
 import { dangerousInText } from '@/core/analyze/dangerous-text';
 import { analyzeSegment, segmentChangesCwd } from '@/core/analyze/segment';
 import { splitShellCommands } from '@/core/shell';
-import { type AnalyzeOptions, type AnalyzeResult, type Config, MAX_RECURSION_DEPTH } from '@/types';
+import {
+  type AnalyzeNestedOverrides,
+  type AnalyzeOptions,
+  type AnalyzeResult,
+  type Config,
+  MAX_RECURSION_DEPTH,
+} from '@/types';
 
 const REASON_STRICT_UNPARSEABLE =
   'Command could not be safely analyzed (strict mode). Verify manually.';
@@ -58,11 +64,19 @@ export function analyzeCommandInternal(
       ...options,
       cwd: originalCwd,
       effectiveCwd,
-      analyzeNested: (nestedCommand: string): string | null => {
+      analyzeNested: (nestedCommand: string, overrides?: AnalyzeNestedOverrides): string | null => {
         // Pass current effectiveCwd so nested analysis sees CWD changes from prior segments
+        const nestedEffectiveCwd =
+          overrides && Object.hasOwn(overrides, 'effectiveCwd')
+            ? overrides.effectiveCwd
+            : effectiveCwd;
         return (
-          analyzeCommandInternal(nestedCommand, depth + 1, { ...options, effectiveCwd })?.reason ??
-          null
+          analyzeCommandInternal(nestedCommand, depth + 1, {
+            ...options,
+            effectiveCwd: nestedEffectiveCwd,
+            envAssignments: overrides?.envAssignments ?? options.envAssignments,
+            worktreeMode: overrides?.worktreeMode ?? options.worktreeMode,
+          })?.reason ?? null
         );
       },
     });

--- a/src/core/analyze/analyze-command.ts
+++ b/src/core/analyze/analyze-command.ts
@@ -121,7 +121,7 @@ export function createShellGitContextEnvState(
   return {
     effectiveEnvAssignments,
     shellAssignments: new Map(),
-    exportedNames: new Set(),
+    exportedNames: getInitiallyExportedGitContextNames(effectiveEnvAssignments),
     allexport: false,
     keywordExport: false,
   };
@@ -315,7 +315,7 @@ function parseGitContextEnvAssignment(token: string): GitContextAssignment | nul
 function parseGitContextAppendEnvAssignment(token: string): GitContextAssignment | null {
   const match = token.match(GIT_CONTEXT_APPEND_ASSIGNMENT_RE);
   const name = match?.[1];
-  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name)) {
+  if (!name || !isTrackedGitEnvName(name)) {
     return null;
   }
   const eqIdx = token.indexOf('=');
@@ -336,6 +336,23 @@ function isGitConfigEnvName(name: string): boolean {
     name === 'GIT_CONFIG_PARAMETERS' ||
     /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(name)
   );
+}
+
+function getInitiallyExportedGitContextNames(
+  effectiveEnvAssignments?: ReadonlyMap<string, string>,
+): Set<string> {
+  const exportedNames = new Set<string>();
+  for (const name of Object.keys(process.env)) {
+    if (isTrackedGitEnvName(name)) {
+      exportedNames.add(name);
+    }
+  }
+  for (const name of effectiveEnvAssignments?.keys() ?? []) {
+    if (isTrackedGitEnvName(name)) {
+      exportedNames.add(name);
+    }
+  }
+  return exportedNames;
 }
 
 function setShellGitContextAssignment(

--- a/src/core/analyze/analyze-command.ts
+++ b/src/core/analyze/analyze-command.ts
@@ -1,6 +1,7 @@
 import { dangerousInText } from '@/core/analyze/dangerous-text';
 import { analyzeSegment, segmentChangesCwd } from '@/core/analyze/segment';
-import { splitShellCommands } from '@/core/shell';
+import { parseEnvAssignment, splitShellCommands } from '@/core/shell';
+import { GIT_CONTEXT_ENV_OVERRIDES } from '@/core/worktree';
 import {
   type AnalyzeNestedOverrides,
   type AnalyzeOptions,
@@ -14,6 +15,7 @@ const REASON_STRICT_UNPARSEABLE =
 
 export const REASON_RECURSION_LIMIT =
   'Command exceeds maximum recursion depth and cannot be safely analyzed.';
+const GIT_CONTEXT_ENV_OVERRIDE_NAMES: ReadonlySet<string> = new Set(GIT_CONTEXT_ENV_OVERRIDES);
 
 export type InternalOptions = AnalyzeOptions & { config: Config };
 
@@ -45,9 +47,11 @@ export function analyzeCommandInternal(
   // undefined = use cwd, null = unknown (after cd/pushd)
   let effectiveCwd: string | null | undefined =
     options.effectiveCwd !== undefined ? options.effectiveCwd : options.cwd;
+  let effectiveEnvAssignments = options.envAssignments;
 
   for (const segment of segments) {
     const segmentStr = segment.join(' ');
+    const segmentEnvAssignments = effectiveEnvAssignments;
 
     if (segment.length === 1 && segment[0]?.includes(' ')) {
       const textReason = dangerousInText(segment[0]);
@@ -64,6 +68,7 @@ export function analyzeCommandInternal(
       ...options,
       cwd: originalCwd,
       effectiveCwd,
+      envAssignments: segmentEnvAssignments,
       analyzeNested: (nestedCommand: string, overrides?: AnalyzeNestedOverrides): string | null => {
         // Pass current effectiveCwd so nested analysis sees CWD changes from prior segments
         const nestedEffectiveCwd =
@@ -74,7 +79,7 @@ export function analyzeCommandInternal(
           analyzeCommandInternal(nestedCommand, depth + 1, {
             ...options,
             effectiveCwd: nestedEffectiveCwd,
-            envAssignments: overrides?.envAssignments ?? options.envAssignments,
+            envAssignments: overrides?.envAssignments ?? segmentEnvAssignments,
             worktreeMode: overrides?.worktreeMode ?? options.worktreeMode,
           })?.reason ?? null
         );
@@ -87,7 +92,35 @@ export function analyzeCommandInternal(
     if (segmentChangesCwd(segment)) {
       effectiveCwd = null;
     }
+
+    const exportedEnvAssignments = getExportedGitContextEnvAssignments(segment);
+    if (exportedEnvAssignments.size > 0) {
+      const nextEnvAssignments = new Map(effectiveEnvAssignments ?? []);
+      for (const [k, v] of exportedEnvAssignments) {
+        nextEnvAssignments.set(k, v);
+      }
+      effectiveEnvAssignments = nextEnvAssignments;
+    }
   }
 
   return null;
+}
+
+function getExportedGitContextEnvAssignments(tokens: readonly string[]): Map<string, string> {
+  const result = new Map<string, string>();
+  if (tokens[0] !== 'export') {
+    return result;
+  }
+
+  for (const token of tokens.slice(1)) {
+    if (token.startsWith('-')) {
+      return new Map();
+    }
+
+    const assignment = parseEnvAssignment(token);
+    if (assignment && GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
+      result.set(assignment.name, assignment.value);
+    }
+  }
+  return result;
 }

--- a/src/core/analyze/analyze-command.ts
+++ b/src/core/analyze/analyze-command.ts
@@ -16,6 +16,13 @@ const REASON_STRICT_UNPARSEABLE =
 export const REASON_RECURSION_LIMIT =
   'Command exceeds maximum recursion depth and cannot be safely analyzed.';
 const GIT_CONTEXT_ENV_OVERRIDE_NAMES: ReadonlySet<string> = new Set(GIT_CONTEXT_ENV_OVERRIDES);
+const GIT_CONFIG_AFFECTING_ENV_NAMES: ReadonlySet<string> = new Set([
+  'GIT_CONFIG_GLOBAL',
+  'GIT_CONFIG_NOSYSTEM',
+  'GIT_CONFIG_SYSTEM',
+  'HOME',
+  'XDG_CONFIG_HOME',
+]);
 const GIT_CONTEXT_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 
 export type InternalOptions = AnalyzeOptions & { config: Config };
@@ -177,11 +184,16 @@ export function applyShellGitContextEnvSegment(
     return;
   }
   for (const token of tokens.slice(operandsInfo.operandsStart)) {
-    addTypesetGitContextEnvAssignment(state, token, operandsInfo.exports);
+    addTypesetGitContextEnvAssignment(
+      state,
+      token,
+      operandsInfo.exports,
+      command === 'readonly' ? leadingAssignments : undefined,
+    );
   }
 }
 
-function getSegmentGitContextEnvAssignments(
+export function getSegmentGitContextEnvAssignments(
   tokens: readonly string[],
   state: ShellGitContextEnvState,
 ): ReadonlyMap<string, string> | undefined {
@@ -226,7 +238,7 @@ function getShellCommandInfo(tokens: readonly string[]): ShellCommandInfo | null
     if (!assignment) {
       break;
     }
-    if (GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
+    if (isTrackedGitEnvName(assignment.name)) {
       leadingAssignments.set(assignment.name, assignment);
     }
     i++;
@@ -240,6 +252,9 @@ function getShellCommandInfo(tokens: readonly string[]): ShellCommandInfo | null
   let command = tokens[commandIndex] ?? null;
   if (command === 'builtin') {
     commandIndex++;
+    if (tokens[commandIndex] === '--') {
+      commandIndex++;
+    }
     command = tokens[commandIndex] ?? null;
   }
   if (command === 'command') {
@@ -291,7 +306,7 @@ function parseShellAssignment(token: string): GitContextAssignment | null {
 
 function parseGitContextEnvAssignment(token: string): GitContextAssignment | null {
   const assignment = parseEnvAssignment(token) ?? parseGitContextAppendEnvAssignment(token);
-  if (!assignment || !GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(assignment.name)) {
+  if (!assignment || !isTrackedGitEnvName(assignment.name)) {
     return null;
   }
   return assignment;
@@ -305,6 +320,22 @@ function parseGitContextAppendEnvAssignment(token: string): GitContextAssignment
   }
   const eqIdx = token.indexOf('=');
   return { name, value: token.slice(eqIdx + 1) };
+}
+
+function isTrackedGitEnvName(name: string): boolean {
+  return (
+    GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name) ||
+    GIT_CONFIG_AFFECTING_ENV_NAMES.has(name) ||
+    isGitConfigEnvName(name)
+  );
+}
+
+function isGitConfigEnvName(name: string): boolean {
+  return (
+    name === 'GIT_CONFIG_COUNT' ||
+    name === 'GIT_CONFIG_PARAMETERS' ||
+    /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(name)
+  );
 }
 
 function setShellGitContextAssignment(
@@ -335,11 +366,13 @@ function addExportedGitContextEnvAssignment(state: ShellGitContextEnvState, toke
     return;
   }
 
-  if (GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(token)) {
+  if (isTrackedGitEnvName(token)) {
     state.exportedNames.add(token);
     const value = state.shellAssignments.get(token);
     if (value !== undefined) {
       setEffectiveGitContextAssignment(state, { name: token, value });
+    } else {
+      setEffectiveGitContextAssignment(state, { name: token, value: '' });
     }
   }
 }
@@ -348,6 +381,7 @@ function addTypesetGitContextEnvAssignment(
   state: ShellGitContextEnvState,
   token: string,
   exports: boolean,
+  readonlyLeadingAssignments?: ReadonlyMap<string, GitContextAssignment>,
 ): void {
   const assignment = parseGitContextEnvAssignment(token);
   if (assignment) {
@@ -361,11 +395,20 @@ function addTypesetGitContextEnvAssignment(
     return;
   }
 
-  if (exports && GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(token)) {
+  const readonlyAssignment = readonlyLeadingAssignments?.get(token);
+  if (readonlyAssignment) {
+    state.exportedNames.add(token);
+    setEffectiveGitContextAssignment(state, readonlyAssignment);
+    return;
+  }
+
+  if (exports && isTrackedGitEnvName(token)) {
     state.exportedNames.add(token);
     const value = state.shellAssignments.get(token);
     if (value !== undefined) {
       setEffectiveGitContextAssignment(state, { name: token, value });
+    } else {
+      setEffectiveGitContextAssignment(state, { name: token, value: '' });
     }
   }
 }

--- a/src/core/analyze/analyze-command.ts
+++ b/src/core/analyze/analyze-command.ts
@@ -1,7 +1,7 @@
 import { dangerousInText } from '@/core/analyze/dangerous-text';
 import { analyzeSegment, segmentChangesCwd } from '@/core/analyze/segment';
 import { parseEnvAssignment, splitShellCommands } from '@/core/shell';
-import { GIT_CONTEXT_ENV_OVERRIDES } from '@/core/worktree';
+import { GIT_CONFIG_AFFECTING_ENV_NAMES, GIT_CONTEXT_ENV_OVERRIDES } from '@/core/worktree';
 import {
   type AnalyzeNestedOverrides,
   type AnalyzeOptions,
@@ -16,13 +16,6 @@ const REASON_STRICT_UNPARSEABLE =
 export const REASON_RECURSION_LIMIT =
   'Command exceeds maximum recursion depth and cannot be safely analyzed.';
 const GIT_CONTEXT_ENV_OVERRIDE_NAMES: ReadonlySet<string> = new Set(GIT_CONTEXT_ENV_OVERRIDES);
-const GIT_CONFIG_AFFECTING_ENV_NAMES: ReadonlySet<string> = new Set([
-  'GIT_CONFIG_GLOBAL',
-  'GIT_CONFIG_NOSYSTEM',
-  'GIT_CONFIG_SYSTEM',
-  'HOME',
-  'XDG_CONFIG_HOME',
-]);
 const GIT_CONTEXT_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 
 export type InternalOptions = AnalyzeOptions & { config: Config };

--- a/src/core/analyze/parallel.ts
+++ b/src/core/analyze/parallel.ts
@@ -32,6 +32,7 @@ export function analyzeParallel(
   }
 
   const { template, args, hasPlaceholder, runsRemotely, usesStdin } = parseResult;
+  const hasDynamicStdinPlaceholder = usesStdin && hasPlaceholder;
 
   if (template.length === 0) {
     // parallel ::: 'cmd1' 'cmd2' - commands mode
@@ -57,7 +58,7 @@ export function analyzeParallel(
   const nestedOverrides = buildNestedOverrides(
     childEnvAssignments,
     childWrapperInfo.cwd,
-    runsRemotely,
+    runsRemotely || hasDynamicStdinPlaceholder,
   );
   let head = getBasename(childTokens[0] ?? '').toLowerCase();
 

--- a/src/core/analyze/parallel.ts
+++ b/src/core/analyze/parallel.ts
@@ -3,8 +3,8 @@ import { hasRecursiveForceFlags } from '@/core/analyze/rm-flags';
 import { extractDashCArg } from '@/core/analyze/shell-wrappers';
 import { analyzeGit } from '@/core/rules-git';
 import { analyzeRm } from '@/core/rules-rm';
-import { getBasename, stripWrappers } from '@/core/shell';
-import { SHELL_WRAPPERS } from '@/types';
+import { getBasename, stripWrappersWithInfo } from '@/core/shell';
+import { type AnalyzeNestedOverrides, SHELL_WRAPPERS } from '@/types';
 
 const REASON_PARALLEL_RM =
   'parallel rm -rf with dynamic input is dangerous. Use explicit file list instead.';
@@ -18,7 +18,7 @@ export interface ParallelAnalyzeContext {
   allowTmpdirVar: boolean;
   envAssignments?: ReadonlyMap<string, string>;
   worktreeMode?: boolean;
-  analyzeNested: (command: string) => string | null;
+  analyzeNested: (command: string, overrides?: AnalyzeNestedOverrides) => string | null;
 }
 
 export function analyzeParallel(
@@ -31,13 +31,14 @@ export function analyzeParallel(
     return null;
   }
 
-  const { template, args, hasPlaceholder } = parseResult;
+  const { template, args, hasPlaceholder, runsRemotely } = parseResult;
 
   if (template.length === 0) {
     // parallel ::: 'cmd1' 'cmd2' - commands mode
     // Analyze each arg as a command
+    const nestedOverrides = runsRemotely ? { worktreeMode: false } : undefined;
     for (const arg of args) {
-      const reason = context.analyzeNested(arg);
+      const reason = context.analyzeNested(arg, nestedOverrides);
       if (reason) {
         return reason;
       }
@@ -45,7 +46,19 @@ export function analyzeParallel(
     return null;
   }
 
-  let childTokens = stripWrappers([...template]);
+  const childWrapperInfo = stripWrappersWithInfo([...template], context.cwd);
+  let childTokens = childWrapperInfo.tokens;
+  const childEnvAssignments = new Map(context.envAssignments ?? []);
+  for (const [k, v] of childWrapperInfo.envAssignments) {
+    childEnvAssignments.set(k, v);
+  }
+  const childCwd =
+    childWrapperInfo.cwd === null ? undefined : (childWrapperInfo.cwd ?? context.cwd);
+  const nestedOverrides = buildNestedOverrides(
+    childEnvAssignments,
+    childWrapperInfo.cwd,
+    runsRemotely,
+  );
   let head = getBasename(childTokens[0] ?? '').toLowerCase();
 
   if (head === 'busybox' && childTokens.length > 1) {
@@ -67,7 +80,7 @@ export function analyzeParallel(
           // Expand with actual args and analyze
           for (const arg of args) {
             const expandedScript = dashCArg.replace(/{}/g, arg);
-            const reason = context.analyzeNested(expandedScript);
+            const reason = context.analyzeNested(expandedScript, nestedOverrides);
             if (reason) {
               return reason;
             }
@@ -76,14 +89,14 @@ export function analyzeParallel(
         }
         // Stdin mode with placeholder - analyze the script template
         // Check if the script pattern is dangerous (e.g., rm -rf {})
-        const reason = context.analyzeNested(dashCArg);
+        const reason = context.analyzeNested(dashCArg, nestedOverrides);
         if (reason) {
           return reason;
         }
         return null;
       }
       // Script doesn't have placeholder - analyze it directly
-      const reason = context.analyzeNested(dashCArg);
+      const reason = context.analyzeNested(dashCArg, nestedOverrides);
       if (reason) {
         return reason;
       }
@@ -152,9 +165,9 @@ export function analyzeParallel(
 
   if (head === 'git') {
     const gitResult = analyzeGit(childTokens, {
-      cwd: context.cwd,
-      envAssignments: context.envAssignments,
-      worktreeMode: context.worktreeMode,
+      cwd: childCwd,
+      envAssignments: childEnvAssignments,
+      worktreeMode: runsRemotely ? false : context.worktreeMode,
     });
     if (gitResult) {
       return gitResult;
@@ -164,10 +177,26 @@ export function analyzeParallel(
   return null;
 }
 
+function buildNestedOverrides(
+  envAssignments: ReadonlyMap<string, string>,
+  cwd: string | null | undefined,
+  runsRemotely: boolean,
+): AnalyzeNestedOverrides {
+  const overrides: AnalyzeNestedOverrides = { envAssignments };
+  if (cwd !== undefined) {
+    overrides.effectiveCwd = cwd;
+  }
+  if (runsRemotely) {
+    overrides.worktreeMode = false;
+  }
+  return overrides;
+}
+
 interface ParallelParseResult {
   template: string[];
   args: string[];
   hasPlaceholder: boolean;
+  runsRemotely: boolean;
 }
 
 function parseParallelCommand(tokens: readonly string[]): ParallelParseResult | null {
@@ -190,6 +219,7 @@ function parseParallelCommand(tokens: readonly string[]): ParallelParseResult | 
   let i = 1;
   const templateTokens: string[] = [];
   let markerIndex = -1;
+  let runsRemotely = false;
 
   // First pass: find the ::: marker and extract template
   while (i < tokens.length) {
@@ -217,6 +247,33 @@ function parseParallelCommand(tokens: readonly string[]): ParallelParseResult | 
     }
 
     if (token.startsWith('-')) {
+      if (
+        token === '-S' ||
+        token === '--sshlogin' ||
+        token === '--slf' ||
+        token === '--sshloginfile'
+      ) {
+        runsRemotely = true;
+        i += 2;
+        continue;
+      }
+
+      if (token.startsWith('-S') && token.length > 2) {
+        runsRemotely = true;
+        i++;
+        continue;
+      }
+
+      if (
+        token.startsWith('--sshlogin=') ||
+        token.startsWith('--slf=') ||
+        token.startsWith('--sshloginfile=')
+      ) {
+        runsRemotely = true;
+        i++;
+        continue;
+      }
+
       // Handle -jN attached option
       if (token.startsWith('-j') && token.length > 2 && /^\d+$/.test(token.slice(2))) {
         i++;
@@ -279,7 +336,7 @@ function parseParallelCommand(tokens: readonly string[]): ParallelParseResult | 
     return null;
   }
 
-  return { template: templateTokens, args, hasPlaceholder };
+  return { template: templateTokens, args, hasPlaceholder, runsRemotely };
 }
 
 export function extractParallelChildCommand(tokens: readonly string[]): string[] {

--- a/src/core/analyze/parallel.ts
+++ b/src/core/analyze/parallel.ts
@@ -10,6 +10,7 @@ const REASON_PARALLEL_RM =
   'parallel rm -rf with dynamic input is dangerous. Use explicit file list instead.';
 const REASON_PARALLEL_SHELL =
   'parallel with shell -c can execute arbitrary commands from dynamic input.';
+const PARALLEL_PLACEHOLDER_RE = /\{[^{}\s]*\}/;
 
 export interface ParallelAnalyzeContext {
   cwd: string | undefined;
@@ -72,15 +73,15 @@ export function analyzeParallel(
     const dashCArg = extractDashCArg(childTokens);
     if (dashCArg) {
       // If script IS just the placeholder, stdin provides entire script - dangerous
-      if (dashCArg === '{}' || dashCArg === '{1}') {
+      if (isOnlyParallelPlaceholder(dashCArg)) {
         return REASON_PARALLEL_SHELL;
       }
       // If script contains placeholder
-      if (dashCArg.includes('{}')) {
+      if (hasParallelPlaceholder(dashCArg)) {
         if (args.length > 0) {
           // Expand with actual args and analyze
           for (const arg of args) {
-            const expandedScript = dashCArg.replace(/{}/g, arg);
+            const expandedScript = replaceParallelPlaceholder(dashCArg, arg);
             const reason = context.analyzeNested(expandedScript, nestedOverrides);
             if (reason) {
               return reason;
@@ -171,7 +172,7 @@ export function analyzeParallel(
         : !hasPlaceholder && args.length > 0
           ? args.map((arg) => [...childTokens, arg])
           : [childTokens];
-    const dynamicGitArgs = usesStdin || (hasPlaceholder && args.length === 0);
+    const dynamicGitArgs = usesStdin || hasPlaceholder;
     for (const gitTokens of gitTokenSets) {
       const gitResult = analyzeGit(gitTokens, {
         cwd: childCwd,
@@ -228,10 +229,15 @@ interface ParallelParseResult {
 }
 
 function replaceParallelPlaceholder(token: string, arg: string): string {
-  return token
-    .replace(/\{\}/g, arg)
-    .replace(/\{1\}/g, arg)
-    .replace(/\{\.\}/g, arg);
+  return token.replace(/\{[^{}\s]*\}/g, arg);
+}
+
+function hasParallelPlaceholder(token: string): boolean {
+  return PARALLEL_PLACEHOLDER_RE.test(token);
+}
+
+function isOnlyParallelPlaceholder(token: string): boolean {
+  return /^\{[^{}\s]*\}$/.test(token);
 }
 
 function parseParallelCommand(tokens: readonly string[]): ParallelParseResult | null {
@@ -362,9 +368,7 @@ function parseParallelCommand(tokens: readonly string[]): ParallelParseResult | 
   }
 
   // Determine if template has placeholder
-  const hasPlaceholder = templateTokens.some(
-    (t) => t.includes('{}') || t.includes('{1}') || t.includes('{.}'),
-  );
+  const hasPlaceholder = templateTokens.some(hasParallelPlaceholder);
 
   // If no template and no marker, no valid parallel command
   if (templateTokens.length === 0 && markerIndex === -1) {

--- a/src/core/analyze/parallel.ts
+++ b/src/core/analyze/parallel.ts
@@ -129,7 +129,7 @@ export function analyzeParallel(
       for (const arg of args) {
         const expandedTokens = childTokens.map((t) => t.replace(/{}/g, arg));
         const rmResult = analyzeRm(expandedTokens, {
-          cwd: context.cwd,
+          cwd: childCwd,
           originalCwd: context.originalCwd,
           paranoid: context.paranoidRm,
           allowTmpdirVar: context.allowTmpdirVar,
@@ -145,7 +145,7 @@ export function analyzeParallel(
     if (args.length > 0) {
       const expandedTokens = [...childTokens, args[0] ?? ''];
       const rmResult = analyzeRm(expandedTokens, {
-        cwd: context.cwd,
+        cwd: childCwd,
         originalCwd: context.originalCwd,
         paranoid: context.paranoidRm,
         allowTmpdirVar: context.allowTmpdirVar,

--- a/src/core/analyze/parallel.ts
+++ b/src/core/analyze/parallel.ts
@@ -36,7 +36,7 @@ export function analyzeParallel(
   if (template.length === 0) {
     // parallel ::: 'cmd1' 'cmd2' - commands mode
     // Analyze each arg as a command
-    const nestedOverrides = runsRemotely ? { worktreeMode: false } : undefined;
+    const nestedOverrides = buildCommandsModeOverrides(context, runsRemotely);
     for (const arg of args) {
       const reason = context.analyzeNested(arg, nestedOverrides);
       if (reason) {
@@ -164,13 +164,17 @@ export function analyzeParallel(
   }
 
   if (head === 'git') {
-    const gitResult = analyzeGit(childTokens, {
-      cwd: childCwd,
-      envAssignments: childEnvAssignments,
-      worktreeMode: runsRemotely ? false : context.worktreeMode,
-    });
-    if (gitResult) {
-      return gitResult;
+    const gitTokenSets =
+      !hasPlaceholder && args.length > 0 ? args.map((arg) => [...childTokens, arg]) : [childTokens];
+    for (const gitTokens of gitTokenSets) {
+      const gitResult = analyzeGit(gitTokens, {
+        cwd: childCwd,
+        envAssignments: childEnvAssignments,
+        worktreeMode: runsRemotely ? false : context.worktreeMode,
+      });
+      if (gitResult) {
+        return gitResult;
+      }
     }
   }
 
@@ -190,6 +194,23 @@ function buildNestedOverrides(
     overrides.worktreeMode = false;
   }
   return overrides;
+}
+
+function buildCommandsModeOverrides(
+  context: ParallelAnalyzeContext,
+  runsRemotely: boolean,
+): AnalyzeNestedOverrides | undefined {
+  const overrides: AnalyzeNestedOverrides = {};
+  if (context.envAssignments) {
+    overrides.envAssignments = context.envAssignments;
+  }
+  if (context.cwd !== undefined) {
+    overrides.effectiveCwd = context.cwd;
+  }
+  if (runsRemotely) {
+    overrides.worktreeMode = false;
+  }
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 
 interface ParallelParseResult {

--- a/src/core/analyze/parallel.ts
+++ b/src/core/analyze/parallel.ts
@@ -31,7 +31,7 @@ export function analyzeParallel(
     return null;
   }
 
-  const { template, args, hasPlaceholder, runsRemotely } = parseResult;
+  const { template, args, hasPlaceholder, runsRemotely, usesStdin } = parseResult;
 
   if (template.length === 0) {
     // parallel ::: 'cmd1' 'cmd2' - commands mode
@@ -165,12 +165,17 @@ export function analyzeParallel(
 
   if (head === 'git') {
     const gitTokenSets =
-      !hasPlaceholder && args.length > 0 ? args.map((arg) => [...childTokens, arg]) : [childTokens];
+      hasPlaceholder && args.length > 0
+        ? args.map((arg) => childTokens.map((token) => replaceParallelPlaceholder(token, arg)))
+        : !hasPlaceholder && args.length > 0
+          ? args.map((arg) => [...childTokens, arg])
+          : [childTokens];
+    const dynamicGitArgs = usesStdin || (hasPlaceholder && args.length === 0);
     for (const gitTokens of gitTokenSets) {
       const gitResult = analyzeGit(gitTokens, {
         cwd: childCwd,
         envAssignments: childEnvAssignments,
-        worktreeMode: runsRemotely ? false : context.worktreeMode,
+        worktreeMode: runsRemotely || dynamicGitArgs ? false : context.worktreeMode,
       });
       if (gitResult) {
         return gitResult;
@@ -218,6 +223,14 @@ interface ParallelParseResult {
   args: string[];
   hasPlaceholder: boolean;
   runsRemotely: boolean;
+  usesStdin: boolean;
+}
+
+function replaceParallelPlaceholder(token: string, arg: string): string {
+  return token
+    .replace(/\{\}/g, arg)
+    .replace(/\{1\}/g, arg)
+    .replace(/\{\.\}/g, arg);
 }
 
 function parseParallelCommand(tokens: readonly string[]): ParallelParseResult | null {
@@ -357,7 +370,13 @@ function parseParallelCommand(tokens: readonly string[]): ParallelParseResult | 
     return null;
   }
 
-  return { template: templateTokens, args, hasPlaceholder, runsRemotely };
+  return {
+    template: templateTokens,
+    args,
+    hasPlaceholder,
+    runsRemotely,
+    usesStdin: markerIndex === -1,
+  };
 }
 
 export function extractParallelChildCommand(tokens: readonly string[]): string[] {

--- a/src/core/analyze/parallel.ts
+++ b/src/core/analyze/parallel.ts
@@ -16,6 +16,8 @@ export interface ParallelAnalyzeContext {
   originalCwd: string | undefined;
   paranoidRm: boolean | undefined;
   allowTmpdirVar: boolean;
+  envAssignments?: ReadonlyMap<string, string>;
+  worktreeMode?: boolean;
   analyzeNested: (command: string) => string | null;
 }
 
@@ -149,7 +151,11 @@ export function analyzeParallel(
   }
 
   if (head === 'git') {
-    const gitResult = analyzeGit(childTokens);
+    const gitResult = analyzeGit(childTokens, {
+      cwd: context.cwd,
+      envAssignments: context.envAssignments,
+      worktreeMode: context.worktreeMode,
+    });
     if (gitResult) {
       return gitResult;
     }

--- a/src/core/analyze/segment.ts
+++ b/src/core/analyze/segment.ts
@@ -113,7 +113,11 @@ export function analyzeSegment(
   const isParallel = basename === 'parallel';
 
   if (isGit) {
-    const gitResult = analyzeGit(stripped);
+    const gitResult = analyzeGit(stripped, {
+      cwd: cwdForRm,
+      envAssignments,
+      worktreeMode: options.worktreeMode,
+    });
     if (gitResult) {
       return gitResult;
     }
@@ -144,6 +148,8 @@ export function analyzeSegment(
       originalCwd,
       paranoidRm: options.paranoidRm,
       allowTmpdirVar,
+      envAssignments,
+      worktreeMode: options.worktreeMode,
     });
     if (xargsResult) {
       return xargsResult;
@@ -156,6 +162,8 @@ export function analyzeSegment(
       originalCwd,
       paranoidRm: options.paranoidRm,
       allowTmpdirVar,
+      envAssignments,
+      worktreeMode: options.worktreeMode,
       analyzeNested: options.analyzeNested,
     });
     if (parallelResult) {
@@ -190,7 +198,11 @@ export function analyzeSegment(
         }
         if (cmd === 'git') {
           const gitTokens = ['git', ...stripped.slice(i + 1)];
-          const reason = analyzeGit(gitTokens);
+          const reason = analyzeGit(gitTokens, {
+            cwd: cwdForRm,
+            envAssignments,
+            worktreeMode: options.worktreeMode,
+          });
           if (reason) {
             return reason;
           }

--- a/src/core/analyze/segment.ts
+++ b/src/core/analyze/segment.ts
@@ -103,7 +103,10 @@ export function analyzeSegment(
         return REASON_INTERPRETER_BLOCKED + PARANOID_INTERPRETERS_SUFFIX;
       }
 
-      const innerReason = options.analyzeNested(codeArg);
+      const innerReason = options.analyzeNested(codeArg, {
+        effectiveCwd: nestedEffectiveCwd,
+        envAssignments,
+      });
       if (innerReason) {
         return innerReason;
       }
@@ -115,7 +118,11 @@ export function analyzeSegment(
   }
 
   if (normalizedHead === 'busybox' && stripped.length > 1) {
-    return analyzeSegment(stripped.slice(1), depth, options);
+    return analyzeSegment(stripped.slice(1), depth, {
+      ...options,
+      effectiveCwd: nestedEffectiveCwd,
+      envAssignments,
+    });
   }
 
   const isGit = basename.toLowerCase() === 'git';

--- a/src/core/analyze/segment.ts
+++ b/src/core/analyze/segment.ts
@@ -16,6 +16,7 @@ import {
   stripWrappersWithInfo,
 } from '@/core/shell';
 import {
+  type AnalyzeNestedOverrides,
   type AnalyzeOptions,
   type Config,
   INTERPRETERS,
@@ -30,7 +31,7 @@ export const REASON_INTERPRETER_BLOCKED = 'Interpreter one-liners are blocked in
 export type InternalOptions = AnalyzeOptions & {
   config: Config;
   effectiveCwd: string | null | undefined;
-  analyzeNested: (command: string) => string | null;
+  analyzeNested: (command: string, overrides?: AnalyzeNestedOverrides) => string | null;
 };
 
 function deriveCwdContext(options: Pick<InternalOptions, 'cwd' | 'effectiveCwd'>): {
@@ -53,12 +54,19 @@ export function analyzeSegment(
     return null;
   }
 
+  const { cwdForRm: baseCwdForRm, originalCwd } = deriveCwdContext(options);
   const { tokens: strippedEnv, envAssignments: leadingEnvAssignments } =
     stripEnvAssignmentsWithInfo(tokens);
-  const { tokens: stripped, envAssignments: wrapperEnvAssignments } =
-    stripWrappersWithInfo(strippedEnv);
+  const {
+    tokens: stripped,
+    envAssignments: wrapperEnvAssignments,
+    cwd: wrapperCwd,
+  } = stripWrappersWithInfo(strippedEnv, baseCwdForRm);
 
-  const envAssignments = new Map(leadingEnvAssignments);
+  const envAssignments = new Map(options.envAssignments ?? []);
+  for (const [k, v] of leadingEnvAssignments) {
+    envAssignments.set(k, v);
+  }
   for (const [k, v] of wrapperEnvAssignments) {
     envAssignments.set(k, v);
   }
@@ -74,13 +82,17 @@ export function analyzeSegment(
 
   const normalizedHead = normalizeCommandToken(head);
   const basename = getBasename(head);
-  const { cwdForRm, originalCwd } = deriveCwdContext(options);
+  const cwdForRm = wrapperCwd === null ? undefined : (wrapperCwd ?? baseCwdForRm);
+  const nestedEffectiveCwd = wrapperCwd === undefined ? options.effectiveCwd : wrapperCwd;
   const allowTmpdirVar = !isTmpdirOverriddenToNonTemp(envAssignments);
 
   if (SHELL_WRAPPERS.has(normalizedHead)) {
     const dashCArg = extractDashCArg(stripped);
     if (dashCArg) {
-      return options.analyzeNested(dashCArg);
+      return options.analyzeNested(dashCArg, {
+        effectiveCwd: nestedEffectiveCwd,
+        envAssignments,
+      });
     }
   }
 
@@ -201,7 +213,7 @@ export function analyzeSegment(
           const reason = analyzeGit(gitTokens, {
             cwd: cwdForRm,
             envAssignments,
-            worktreeMode: options.worktreeMode,
+            worktreeMode: false,
           });
           if (reason) {
             return reason;

--- a/src/core/analyze/xargs.ts
+++ b/src/core/analyze/xargs.ts
@@ -78,10 +78,13 @@ export function analyzeXargs(
   if (head === 'git') {
     const gitTokens =
       replacementToken === null ? [...childTokens, XARGS_APPENDED_INPUT] : childTokens;
+    const hasDynamicReplacement =
+      replacementToken !== null && childTokens.some((token) => token.includes(replacementToken));
     const gitResult = analyzeGit(gitTokens, {
       cwd: childCwd,
       envAssignments: childEnvAssignments,
-      worktreeMode: replacementToken === null ? false : context.worktreeMode,
+      worktreeMode:
+        replacementToken === null || hasDynamicReplacement ? false : context.worktreeMode,
     });
     if (gitResult) {
       return gitResult;

--- a/src/core/analyze/xargs.ts
+++ b/src/core/analyze/xargs.ts
@@ -2,7 +2,7 @@ import { analyzeFind } from '@/core/analyze/find';
 import { hasRecursiveForceFlags } from '@/core/analyze/rm-flags';
 import { analyzeGit } from '@/core/rules-git';
 import { analyzeRm } from '@/core/rules-rm';
-import { getBasename, stripWrappers } from '@/core/shell';
+import { getBasename, stripWrappersWithInfo } from '@/core/shell';
 import { SHELL_WRAPPERS } from '@/types';
 
 const REASON_XARGS_RM =
@@ -24,7 +24,14 @@ export function analyzeXargs(
 ): string | null {
   const { childTokens: rawChildTokens } = extractXargsChildCommandWithInfo(tokens);
 
-  let childTokens = stripWrappers(rawChildTokens);
+  const childWrapperInfo = stripWrappersWithInfo(rawChildTokens, context.cwd);
+  let childTokens = childWrapperInfo.tokens;
+  const childEnvAssignments = new Map(context.envAssignments ?? []);
+  for (const [k, v] of childWrapperInfo.envAssignments) {
+    childEnvAssignments.set(k, v);
+  }
+  const childCwd =
+    childWrapperInfo.cwd === null ? undefined : (childWrapperInfo.cwd ?? context.cwd);
 
   if (childTokens.length === 0) {
     return null;
@@ -68,8 +75,8 @@ export function analyzeXargs(
 
   if (head === 'git') {
     const gitResult = analyzeGit(childTokens, {
-      cwd: context.cwd,
-      envAssignments: context.envAssignments,
+      cwd: childCwd,
+      envAssignments: childEnvAssignments,
       worktreeMode: context.worktreeMode,
     });
     if (gitResult) {

--- a/src/core/analyze/xargs.ts
+++ b/src/core/analyze/xargs.ts
@@ -14,6 +14,8 @@ export interface XargsAnalyzeContext {
   originalCwd: string | undefined;
   paranoidRm: boolean | undefined;
   allowTmpdirVar: boolean;
+  envAssignments?: ReadonlyMap<string, string>;
+  worktreeMode?: boolean;
 }
 
 export function analyzeXargs(
@@ -65,7 +67,11 @@ export function analyzeXargs(
   }
 
   if (head === 'git') {
-    const gitResult = analyzeGit(childTokens);
+    const gitResult = analyzeGit(childTokens, {
+      cwd: context.cwd,
+      envAssignments: context.envAssignments,
+      worktreeMode: context.worktreeMode,
+    });
     if (gitResult) {
       return gitResult;
     }

--- a/src/core/analyze/xargs.ts
+++ b/src/core/analyze/xargs.ts
@@ -81,7 +81,7 @@ export function analyzeXargs(
     const gitResult = analyzeGit(gitTokens, {
       cwd: childCwd,
       envAssignments: childEnvAssignments,
-      worktreeMode: context.worktreeMode,
+      worktreeMode: replacementToken === null ? false : context.worktreeMode,
     });
     if (gitResult) {
       return gitResult;

--- a/src/core/analyze/xargs.ts
+++ b/src/core/analyze/xargs.ts
@@ -55,7 +55,7 @@ export function analyzeXargs(
 
   if (head === 'rm' && hasRecursiveForceFlags(childTokens)) {
     const rmResult = analyzeRm(childTokens, {
-      cwd: context.cwd,
+      cwd: childCwd,
       originalCwd: context.originalCwd,
       paranoid: context.paranoidRm,
       allowTmpdirVar: context.allowTmpdirVar,

--- a/src/core/analyze/xargs.ts
+++ b/src/core/analyze/xargs.ts
@@ -8,6 +8,7 @@ import { SHELL_WRAPPERS } from '@/types';
 const REASON_XARGS_RM =
   'xargs rm -rf with dynamic input is dangerous. Use explicit file list instead.';
 const REASON_XARGS_SHELL = 'xargs with shell -c can execute arbitrary commands from dynamic input.';
+const XARGS_APPENDED_INPUT = '__CC_SAFETY_NET_XARGS_INPUT__';
 
 export interface XargsAnalyzeContext {
   cwd: string | undefined;
@@ -22,7 +23,8 @@ export function analyzeXargs(
   tokens: readonly string[],
   context: XargsAnalyzeContext,
 ): string | null {
-  const { childTokens: rawChildTokens } = extractXargsChildCommandWithInfo(tokens);
+  const { childTokens: rawChildTokens, replacementToken } =
+    extractXargsChildCommandWithInfo(tokens);
 
   const childWrapperInfo = stripWrappersWithInfo(rawChildTokens, context.cwd);
   let childTokens = childWrapperInfo.tokens;
@@ -74,7 +76,9 @@ export function analyzeXargs(
   }
 
   if (head === 'git') {
-    const gitResult = analyzeGit(childTokens, {
+    const gitTokens =
+      replacementToken === null ? [...childTokens, XARGS_APPENDED_INPUT] : childTokens;
+    const gitResult = analyzeGit(gitTokens, {
       cwd: childCwd,
       envAssignments: childEnvAssignments,
       worktreeMode: context.worktreeMode,

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -1,0 +1,33 @@
+import { lstatSync, realpathSync } from 'node:fs';
+import { dirname, isAbsolute, parse as parsePath, sep } from 'node:path';
+
+export function resolveChdirTarget(baseCwd: string, target: string): string {
+  const root = isAbsolute(target) ? getPathRoot(target) : '';
+  let current = root || baseCwd;
+  for (const component of getPathComponents(root ? target.slice(root.length) : target)) {
+    if (component === '' || component === '.') {
+      continue;
+    }
+    if (component === '..') {
+      current = dirname(current);
+      continue;
+    }
+
+    const candidate = appendPathWithoutNormalizing(current, component);
+    current = lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
+  }
+  return current;
+}
+
+function appendPathWithoutNormalizing(base: string, target: string): string {
+  return base.endsWith('/') || base.endsWith('\\') ? `${base}${target}` : `${base}${sep}${target}`;
+}
+
+function getPathRoot(target: string): string {
+  return parsePath(target).root;
+}
+
+function getPathComponents(target: string): string[] {
+  const separator = process.platform === 'win32' ? /[\\/]+/ : /\/+/;
+  return target.split(separator);
+}

--- a/src/core/rules-git.ts
+++ b/src/core/rules-git.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { extractShortOpts, getBasename } from '@/core/shell';
 import {
   GIT_GLOBAL_OPTS_WITH_VALUE,
@@ -608,9 +609,14 @@ function getEnvConfigValue(
 }
 
 function effectiveGitConfigEnablesRecursiveSubmodules(cwd: string): boolean {
+  const localConfigResult = localGitConfigEnablesRecursiveSubmodules(cwd);
+  if (localConfigResult === null || localConfigResult) {
+    return true;
+  }
+
   const gitBinary = getTrustedGitBinary();
   if (gitBinary === null) {
-    return true;
+    return false;
   }
 
   try {
@@ -624,6 +630,25 @@ function effectiveGitConfigEnablesRecursiveSubmodules(cwd: string): boolean {
   } catch (error) {
     return !isGitConfigUnsetError(error);
   }
+}
+
+function localGitConfigEnablesRecursiveSubmodules(cwd: string): boolean | null {
+  const configPaths = getLocalGitConfigPaths(cwd);
+  if (configPaths === null) {
+    return null;
+  }
+
+  for (const configPath of configPaths) {
+    if (!existsSync(configPath)) {
+      continue;
+    }
+    const result = gitConfigFileEnablesRecursiveSubmodules(configPath);
+    if (result) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function getTrustedGitBinary(): string | null {
@@ -656,6 +681,117 @@ function isGitConfigUnsetError(error: unknown): boolean {
     'status' in error &&
     (error as { status?: unknown }).status === 1
   );
+}
+
+function getLocalGitConfigPaths(cwd: string): string[] | null {
+  const dotGitPath = findDotGitPath(cwd);
+  if (dotGitPath === null) {
+    return null;
+  }
+
+  const gitDir = resolveGitDirFromDotGit(dotGitPath);
+  if (gitDir === null) {
+    return null;
+  }
+
+  const commonDir = resolveCommonGitDir(gitDir);
+  if (commonDir === null) {
+    return null;
+  }
+
+  return [join(commonDir, 'config'), join(gitDir, 'config.worktree')];
+}
+
+function findDotGitPath(cwd: string): string | null {
+  let current = cwd;
+  while (true) {
+    const dotGitPath = join(current, '.git');
+    if (existsSync(dotGitPath)) {
+      return dotGitPath;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function resolveGitDirFromDotGit(dotGitPath: string): string | null {
+  try {
+    const content = readFileSync(dotGitPath, 'utf-8');
+    const firstLine = content.split(/\r?\n/, 1)[0]?.trim() ?? '';
+    if (!firstLine.startsWith('gitdir:')) {
+      return dotGitPath;
+    }
+
+    const rawGitDir = firstLine.slice('gitdir:'.length).trim();
+    if (rawGitDir === '') {
+      return null;
+    }
+    return isAbsolute(rawGitDir) ? rawGitDir : resolve(dirname(dotGitPath), rawGitDir);
+  } catch {
+    return null;
+  }
+}
+
+function resolveCommonGitDir(gitDir: string): string | null {
+  const commonDirPath = join(gitDir, 'commondir');
+  if (!existsSync(commonDirPath)) {
+    return gitDir;
+  }
+
+  try {
+    const rawCommonDir = readFileSync(commonDirPath, 'utf-8').split(/\r?\n/, 1)[0]?.trim() ?? '';
+    if (rawCommonDir === '') {
+      return null;
+    }
+    return isAbsolute(rawCommonDir) ? rawCommonDir : resolve(gitDir, rawCommonDir);
+  } catch {
+    return null;
+  }
+}
+
+function gitConfigFileEnablesRecursiveSubmodules(configPath: string): boolean {
+  let content: string;
+  try {
+    content = readFileSync(configPath, 'utf-8');
+  } catch {
+    return true;
+  }
+
+  let section = '';
+  let recursiveSubmoduleConfig = false;
+
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith('#') || trimmed.startsWith(';')) {
+      continue;
+    }
+
+    const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+    if (sectionMatch) {
+      section = sectionMatch[1]?.trim().toLowerCase() ?? '';
+      continue;
+    }
+
+    const eqIdx = trimmed.indexOf('=');
+    const key = (eqIdx === -1 ? trimmed : trimmed.slice(0, eqIdx)).trim().toLowerCase();
+    const value = eqIdx === -1 ? 'true' : trimmed.slice(eqIdx + 1).trim();
+    if (isIncludeConfigSection(section) && key === 'path') {
+      return true;
+    }
+    if (section === 'submodule' && key === 'recurse') {
+      recursiveSubmoduleConfig = gitConfigValueEnablesRecursiveSubmodules(value);
+    }
+  }
+
+  return recursiveSubmoduleConfig;
+}
+
+function isIncludeConfigSection(section: string): boolean {
+  return section === 'include' || section.startsWith('includeif ');
 }
 
 function recursiveSubmoduleConfigValue(config: string | undefined): boolean | null {

--- a/src/core/rules-git.ts
+++ b/src/core/rules-git.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { extractShortOpts, getBasename } from '@/core/shell';
 import {
   GIT_GLOBAL_OPTS_WITH_VALUE,
@@ -196,8 +197,7 @@ function getGitWorktreeRelaxationForMatch(
   if (
     !match.localDiscard ||
     !options.worktreeMode ||
-    hasGitContextEnvOverride(options.envAssignments) ||
-    isNonRelaxableLocalDiscard(tokens)
+    hasGitContextEnvOverride(options.envAssignments)
   ) {
     return null;
   }
@@ -208,6 +208,10 @@ function getGitWorktreeRelaxationForMatch(
   }
 
   if (!isLinkedWorktree(context.gitCwd)) {
+    return null;
+  }
+
+  if (isNonRelaxableLocalDiscard(tokens, options, context.gitCwd)) {
     return null;
   }
 
@@ -440,12 +444,17 @@ function analyzeGitClean(tokens: readonly string[]): string | null {
   return null;
 }
 
-function isNonRelaxableLocalDiscard(tokens: readonly string[]): boolean {
+function isNonRelaxableLocalDiscard(
+  tokens: readonly string[],
+  options: GitAnalyzeOptions,
+  gitCwd: string,
+): boolean {
   const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
   const normalizedSubcommand = subcommand?.toLowerCase();
 
   if (
-    hasRecursiveSubmoduleConfig(tokens) ||
+    hasDynamicGitArgument(rest) ||
+    hasRecursiveSubmoduleConfig(tokens, options, gitCwd) ||
     hasRecurseSubmodulesOption(rest) ||
     isForcedBranchReset(normalizedSubcommand, rest)
   ) {
@@ -455,44 +464,75 @@ function isNonRelaxableLocalDiscard(tokens: readonly string[]): boolean {
   return normalizedSubcommand === 'clean' && countCleanForceFlags(rest) > 1;
 }
 
-function hasRecursiveSubmoduleConfig(tokens: readonly string[]): boolean {
+function hasDynamicGitArgument(tokens: readonly string[]): boolean {
+  return tokens.some((token) => token.includes('$'));
+}
+
+function hasRecursiveSubmoduleConfig(
+  tokens: readonly string[],
+  options: GitAnalyzeOptions,
+  gitCwd: string,
+): boolean {
+  const commandLineConfig = commandLineRecursiveSubmoduleConfig(tokens, options.envAssignments);
+  if (commandLineConfig !== null) {
+    return commandLineConfig;
+  }
+  const envConfig = envRecursiveSubmoduleConfig(options.envAssignments);
+  if (envConfig !== null) {
+    return envConfig;
+  }
+  return effectiveGitConfigEnablesRecursiveSubmodules(gitCwd);
+}
+
+function commandLineRecursiveSubmoduleConfig(
+  tokens: readonly string[],
+  envAssignments?: ReadonlyMap<string, string>,
+): boolean | null {
+  let recursiveSubmoduleConfig: boolean | null = null;
   let i = 1;
   while (i < tokens.length) {
     const token = tokens[i];
     if (!token || token === '--') {
-      return false;
+      return recursiveSubmoduleConfig;
     }
     if (!token.startsWith('-')) {
-      return false;
+      return recursiveSubmoduleConfig;
     }
 
     if (token === '-c') {
-      if (configEnablesRecursiveSubmodules(tokens[i + 1])) {
-        return true;
+      const configValue = recursiveSubmoduleConfigValue(tokens[i + 1]);
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i += 2;
       continue;
     }
 
     if (token.startsWith('-c') && token.length > 2) {
-      if (configEnablesRecursiveSubmodules(token.slice(2))) {
-        return true;
+      const configValue = recursiveSubmoduleConfigValue(token.slice(2));
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i++;
       continue;
     }
 
     if (token === '--config-env') {
-      if (configEnvTargetsRecursiveSubmodules(tokens[i + 1])) {
-        return true;
+      const configValue = recursiveSubmoduleConfigEnvValue(tokens[i + 1], envAssignments);
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i += 2;
       continue;
     }
 
     if (token.startsWith('--config-env=')) {
-      if (configEnvTargetsRecursiveSubmodules(token.slice('--config-env='.length))) {
-        return true;
+      const configValue = recursiveSubmoduleConfigEnvValue(
+        token.slice('--config-env='.length),
+        envAssignments,
+      );
+      if (configValue !== null) {
+        recursiveSubmoduleConfig = configValue;
       }
       i++;
       continue;
@@ -504,28 +544,110 @@ function hasRecursiveSubmoduleConfig(tokens: readonly string[]): boolean {
       i++;
     }
   }
-  return false;
+  return recursiveSubmoduleConfig;
 }
 
-function configEnablesRecursiveSubmodules(config: string | undefined): boolean {
+function envRecursiveSubmoduleConfig(envAssignments?: ReadonlyMap<string, string>): boolean | null {
+  const countValue = getEnvConfigValue('GIT_CONFIG_COUNT', envAssignments);
+  if (countValue === undefined) {
+    return null;
+  }
+
+  const count = Number.parseInt(countValue, 10);
+  if (!Number.isInteger(count) || count < 0) {
+    return true;
+  }
+
+  let recursiveSubmoduleConfig: boolean | null = null;
+  for (let i = 0; i < count; i++) {
+    const key = getEnvConfigValue(`GIT_CONFIG_KEY_${i}`, envAssignments);
+    if (key?.toLowerCase() !== 'submodule.recurse') {
+      continue;
+    }
+    const value = getEnvConfigValue(`GIT_CONFIG_VALUE_${i}`, envAssignments);
+    recursiveSubmoduleConfig =
+      value === undefined || gitConfigValueEnablesRecursiveSubmodules(value);
+  }
+
+  return recursiveSubmoduleConfig;
+}
+
+function getEnvConfigValue(
+  name: string,
+  envAssignments?: ReadonlyMap<string, string>,
+): string | undefined {
+  return envAssignments?.get(name) ?? process.env[name];
+}
+
+function effectiveGitConfigEnablesRecursiveSubmodules(cwd: string): boolean {
+  try {
+    const value = execFileSync('git', ['config', '--get', 'submodule.recurse'], {
+      cwd,
+      encoding: 'utf8',
+      env: withoutGitConfigEnv(process.env),
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return gitConfigValueEnablesRecursiveSubmodules(value);
+  } catch (error) {
+    return !isGitConfigUnsetError(error);
+  }
+}
+
+function withoutGitConfigEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const nextEnv = { ...env };
+  for (const key of Object.keys(nextEnv)) {
+    if (key === 'GIT_CONFIG_COUNT' || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(key)) {
+      delete nextEnv[key];
+    }
+  }
+  return nextEnv;
+}
+
+function isGitConfigUnsetError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    (error as { status?: unknown }).status === 1
+  );
+}
+
+function recursiveSubmoduleConfigValue(config: string | undefined): boolean | null {
   if (!config) {
-    return false;
+    return null;
   }
   const eqIdx = config.indexOf('=');
   const key = (eqIdx === -1 ? config : config.slice(0, eqIdx)).toLowerCase();
   if (key !== 'submodule.recurse') {
-    return false;
+    return null;
   }
   const value = eqIdx === -1 ? 'true' : config.slice(eqIdx + 1).toLowerCase();
-  return value !== 'false' && value !== 'no' && value !== 'off' && value !== '0';
+  return gitConfigValueEnablesRecursiveSubmodules(value);
 }
 
-function configEnvTargetsRecursiveSubmodules(configEnv: string | undefined): boolean {
+function gitConfigValueEnablesRecursiveSubmodules(value: string): boolean {
+  const normalizedValue = value.toLowerCase();
+  return (
+    normalizedValue !== 'false' &&
+    normalizedValue !== 'no' &&
+    normalizedValue !== 'off' &&
+    normalizedValue !== '0'
+  );
+}
+
+function recursiveSubmoduleConfigEnvValue(
+  configEnv: string | undefined,
+  envAssignments?: ReadonlyMap<string, string>,
+): boolean | null {
   const eqIdx = configEnv?.indexOf('=') ?? -1;
   if (!configEnv || eqIdx === -1) {
-    return false;
+    return null;
   }
-  return configEnv.slice(0, eqIdx).toLowerCase() === 'submodule.recurse';
+  if (configEnv.slice(0, eqIdx).toLowerCase() !== 'submodule.recurse') {
+    return null;
+  }
+  const value = getEnvConfigValue(configEnv.slice(eqIdx + 1), envAssignments);
+  return value === undefined || gitConfigValueEnablesRecursiveSubmodules(value);
 }
 
 function isForcedBranchReset(subcommand: string | undefined, rest: readonly string[]): boolean {
@@ -535,7 +657,9 @@ function isForcedBranchReset(subcommand: string | undefined, rest: readonly stri
       shortOptsWithValue: CHECKOUT_SHORT_OPTS_WITH_VALUE,
     });
     const hasForce = before.includes('--force') || shortOpts.has('-f');
-    return hasForce && before.some((token) => token === '-B' || token.startsWith('-B'));
+    const hasBranchReset =
+      shortOpts.has('-B') || before.some((token) => token === '-B' || token.startsWith('-B'));
+    return hasForce && hasBranchReset;
   }
 
   if (subcommand === 'switch') {
@@ -543,14 +667,16 @@ function isForcedBranchReset(subcommand: string | undefined, rest: readonly stri
     const shortOpts = extractShortOpts(before, {
       shortOptsWithValue: SWITCH_SHORT_OPTS_WITH_VALUE,
     });
-    const hasForce = before.includes('--force') || shortOpts.has('-f');
-    const hasForceCreate = before.some(
-      (token) =>
-        token === '-C' ||
-        token.startsWith('-C') ||
-        token === '--force-create' ||
-        token.startsWith('--force-create='),
-    );
+    const hasForce =
+      before.includes('--force') || before.includes('--discard-changes') || shortOpts.has('-f');
+    const hasForceCreate =
+      before.some(
+        (token) =>
+          token === '-C' ||
+          token.startsWith('-C') ||
+          token === '--force-create' ||
+          token.startsWith('--force-create='),
+      ) || shortOpts.has('-C');
     return hasForce && hasForceCreate;
   }
 

--- a/src/core/rules-git.ts
+++ b/src/core/rules-git.ts
@@ -164,7 +164,7 @@ function analyzeGitRule(tokens: readonly string[]): GitRuleMatch | null {
     case 'restore':
       return localDiscard(analyzeGitRestore(rest));
     case 'reset':
-      return localDiscard(analyzeGitReset(rest));
+      return analyzeGitReset(rest);
     case 'clean':
       return localDiscard(analyzeGitClean(rest));
     case 'push':
@@ -391,16 +391,37 @@ function analyzeGitRestore(tokens: readonly string[]): string | null {
   return hasStaged ? null : REASON_RESTORE;
 }
 
-function analyzeGitReset(tokens: readonly string[]): string | null {
+function analyzeGitReset(tokens: readonly string[]): GitRuleMatch | null {
+  let reason: string | null = null;
+
   for (const token of tokens) {
     if (token === '--hard') {
-      return REASON_RESET_HARD;
+      reason = REASON_RESET_HARD;
+      break;
     }
     if (token === '--merge') {
-      return REASON_RESET_MERGE;
+      reason = REASON_RESET_MERGE;
+      break;
     }
   }
-  return null;
+
+  if (!reason) {
+    return null;
+  }
+
+  return resetHasRef(tokens) ? sharedState(reason) : localDiscard(reason);
+}
+
+function resetHasRef(tokens: readonly string[]): boolean {
+  for (const token of tokens) {
+    if (token === '--') {
+      return false;
+    }
+    if (!token.startsWith('-')) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function analyzeGitClean(tokens: readonly string[]): string | null {

--- a/src/core/rules-git.ts
+++ b/src/core/rules-git.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { extractShortOpts, getBasename } from '@/core/shell';
 import {
+  GIT_CONFIG_AFFECTING_ENV_NAMES,
   GIT_GLOBAL_OPTS_WITH_VALUE,
   getGitExecutionContext,
   hasGitContextEnvOverride,
@@ -55,14 +56,11 @@ const CHECKOUT_OPTS_WITH_VALUE = new Set([
 const CHECKOUT_OPTS_WITH_OPTIONAL_VALUE = new Set(['--recurse-submodules', '--track', '-t']);
 const CHECKOUT_SHORT_OPTS_WITH_VALUE = new Set(['-b', '-B', '-U']);
 const SWITCH_SHORT_OPTS_WITH_VALUE = new Set(['-c', '-C']);
-const GIT_CONFIG_AFFECTING_ENV_NAMES: ReadonlySet<string> = new Set([
-  'GIT_CONFIG_GLOBAL',
-  'GIT_CONFIG_NOSYSTEM',
-  'GIT_CONFIG_SYSTEM',
-  'HOME',
-  'XDG_CONFIG_HOME',
-]);
-const TRUSTED_GIT_BINARIES = ['/usr/bin/git'] as const;
+const TRUSTED_GIT_BINARIES = [
+  '/usr/bin/git',
+  '/usr/local/bin/git',
+  '/opt/homebrew/bin/git',
+] as const;
 
 const CHECKOUT_KNOWN_OPTS_NO_VALUE = new Set([
   '-q',
@@ -960,4 +958,5 @@ function analyzeGitWorktree(tokens: readonly string[]): string | null {
 export {
   extractGitSubcommandAndRest as _extractGitSubcommandAndRest,
   getCheckoutPositionalArgs as _getCheckoutPositionalArgs,
+  TRUSTED_GIT_BINARIES as _TRUSTED_GIT_BINARIES,
 };

--- a/src/core/rules-git.ts
+++ b/src/core/rules-git.ts
@@ -60,6 +60,8 @@ const TRUSTED_GIT_BINARIES = [
   '/usr/bin/git',
   '/usr/local/bin/git',
   '/opt/homebrew/bin/git',
+  'C:\\Program Files\\Git\\cmd\\git.exe',
+  'C:\\Program Files\\Git\\bin\\git.exe',
 ] as const;
 
 const CHECKOUT_KNOWN_OPTS_NO_VALUE = new Set([

--- a/src/core/rules-git.ts
+++ b/src/core/rules-git.ts
@@ -196,7 +196,8 @@ function getGitWorktreeRelaxationForMatch(
   if (
     !match.localDiscard ||
     !options.worktreeMode ||
-    hasGitContextEnvOverride(options.envAssignments)
+    hasGitContextEnvOverride(options.envAssignments) ||
+    isNonRelaxableLocalDiscard(tokens)
   ) {
     return null;
   }
@@ -437,6 +438,43 @@ function analyzeGitClean(tokens: readonly string[]): string | null {
   }
 
   return null;
+}
+
+function isNonRelaxableLocalDiscard(tokens: readonly string[]): boolean {
+  const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
+  const normalizedSubcommand = subcommand?.toLowerCase();
+
+  if (hasRecurseSubmodulesOption(rest)) {
+    return true;
+  }
+
+  return normalizedSubcommand === 'clean' && countCleanForceFlags(rest) > 1;
+}
+
+function hasRecurseSubmodulesOption(tokens: readonly string[]): boolean {
+  return tokens.some(
+    (token) => token === '--recurse-submodules' || token.startsWith('--recurse-submodules='),
+  );
+}
+
+function countCleanForceFlags(tokens: readonly string[]): number {
+  let count = 0;
+
+  for (const token of tokens) {
+    if (token === '--force') {
+      count++;
+      continue;
+    }
+    if (token.startsWith('-') && !token.startsWith('--')) {
+      for (const opt of token.slice(1)) {
+        if (opt === 'f') {
+          count++;
+        }
+      }
+    }
+  }
+
+  return count;
 }
 
 function analyzeGitPush(tokens: readonly string[]): string | null {

--- a/src/core/rules-git.ts
+++ b/src/core/rules-git.ts
@@ -444,11 +444,117 @@ function isNonRelaxableLocalDiscard(tokens: readonly string[]): boolean {
   const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
   const normalizedSubcommand = subcommand?.toLowerCase();
 
-  if (hasRecurseSubmodulesOption(rest)) {
+  if (
+    hasRecursiveSubmoduleConfig(tokens) ||
+    hasRecurseSubmodulesOption(rest) ||
+    isForcedBranchReset(normalizedSubcommand, rest)
+  ) {
     return true;
   }
 
   return normalizedSubcommand === 'clean' && countCleanForceFlags(rest) > 1;
+}
+
+function hasRecursiveSubmoduleConfig(tokens: readonly string[]): boolean {
+  let i = 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token || token === '--') {
+      return false;
+    }
+    if (!token.startsWith('-')) {
+      return false;
+    }
+
+    if (token === '-c') {
+      if (configEnablesRecursiveSubmodules(tokens[i + 1])) {
+        return true;
+      }
+      i += 2;
+      continue;
+    }
+
+    if (token.startsWith('-c') && token.length > 2) {
+      if (configEnablesRecursiveSubmodules(token.slice(2))) {
+        return true;
+      }
+      i++;
+      continue;
+    }
+
+    if (token === '--config-env') {
+      if (configEnvTargetsRecursiveSubmodules(tokens[i + 1])) {
+        return true;
+      }
+      i += 2;
+      continue;
+    }
+
+    if (token.startsWith('--config-env=')) {
+      if (configEnvTargetsRecursiveSubmodules(token.slice('--config-env='.length))) {
+        return true;
+      }
+      i++;
+      continue;
+    }
+
+    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(token)) {
+      i += 2;
+    } else {
+      i++;
+    }
+  }
+  return false;
+}
+
+function configEnablesRecursiveSubmodules(config: string | undefined): boolean {
+  if (!config) {
+    return false;
+  }
+  const eqIdx = config.indexOf('=');
+  const key = (eqIdx === -1 ? config : config.slice(0, eqIdx)).toLowerCase();
+  if (key !== 'submodule.recurse') {
+    return false;
+  }
+  const value = eqIdx === -1 ? 'true' : config.slice(eqIdx + 1).toLowerCase();
+  return value !== 'false' && value !== 'no' && value !== 'off' && value !== '0';
+}
+
+function configEnvTargetsRecursiveSubmodules(configEnv: string | undefined): boolean {
+  const eqIdx = configEnv?.indexOf('=') ?? -1;
+  if (!configEnv || eqIdx === -1) {
+    return false;
+  }
+  return configEnv.slice(0, eqIdx).toLowerCase() === 'submodule.recurse';
+}
+
+function isForcedBranchReset(subcommand: string | undefined, rest: readonly string[]): boolean {
+  if (subcommand === 'checkout') {
+    const { before } = splitAtDoubleDash(rest);
+    const shortOpts = extractShortOpts(before, {
+      shortOptsWithValue: CHECKOUT_SHORT_OPTS_WITH_VALUE,
+    });
+    const hasForce = before.includes('--force') || shortOpts.has('-f');
+    return hasForce && before.some((token) => token === '-B' || token.startsWith('-B'));
+  }
+
+  if (subcommand === 'switch') {
+    const { before } = splitAtDoubleDash(rest);
+    const shortOpts = extractShortOpts(before, {
+      shortOptsWithValue: SWITCH_SHORT_OPTS_WITH_VALUE,
+    });
+    const hasForce = before.includes('--force') || shortOpts.has('-f');
+    const hasForceCreate = before.some(
+      (token) =>
+        token === '-C' ||
+        token.startsWith('-C') ||
+        token === '--force-create' ||
+        token.startsWith('--force-create='),
+    );
+    return hasForce && hasForceCreate;
+  }
+
+  return false;
 }
 
 function hasRecurseSubmodulesOption(tokens: readonly string[]): boolean {

--- a/src/core/rules-git.ts
+++ b/src/core/rules-git.ts
@@ -608,15 +608,17 @@ function getEnvConfigValue(
   return envAssignments?.get(name) ?? process.env[name];
 }
 
-function effectiveGitConfigEnablesRecursiveSubmodules(cwd: string): boolean {
+function effectiveGitConfigEnablesRecursiveSubmodules(
+  cwd: string,
+  gitBinary: string | null = getTrustedGitBinary(),
+): boolean {
   const localConfigResult = localGitConfigEnablesRecursiveSubmodules(cwd);
   if (localConfigResult === null || localConfigResult) {
     return true;
   }
 
-  const gitBinary = getTrustedGitBinary();
   if (gitBinary === null) {
-    return false;
+    return true;
   }
 
   try {
@@ -958,6 +960,7 @@ function analyzeGitWorktree(tokens: readonly string[]): string | null {
 
 /** @internal Exported for testing */
 export {
+  effectiveGitConfigEnablesRecursiveSubmodules as _effectiveGitConfigEnablesRecursiveSubmodules,
   extractGitSubcommandAndRest as _extractGitSubcommandAndRest,
   getCheckoutPositionalArgs as _getCheckoutPositionalArgs,
   TRUSTED_GIT_BINARIES as _TRUSTED_GIT_BINARIES,

--- a/src/core/rules-git.ts
+++ b/src/core/rules-git.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { extractShortOpts, getBasename } from '@/core/shell';
 import {
   GIT_GLOBAL_OPTS_WITH_VALUE,
@@ -53,6 +54,14 @@ const CHECKOUT_OPTS_WITH_VALUE = new Set([
 const CHECKOUT_OPTS_WITH_OPTIONAL_VALUE = new Set(['--recurse-submodules', '--track', '-t']);
 const CHECKOUT_SHORT_OPTS_WITH_VALUE = new Set(['-b', '-B', '-U']);
 const SWITCH_SHORT_OPTS_WITH_VALUE = new Set(['-c', '-C']);
+const GIT_CONFIG_AFFECTING_ENV_NAMES: ReadonlySet<string> = new Set([
+  'GIT_CONFIG_GLOBAL',
+  'GIT_CONFIG_NOSYSTEM',
+  'GIT_CONFIG_SYSTEM',
+  'HOME',
+  'XDG_CONFIG_HOME',
+]);
+const TRUSTED_GIT_BINARIES = ['/usr/bin/git'] as const;
 
 const CHECKOUT_KNOWN_OPTS_NO_VALUE = new Set([
   '-q',
@@ -465,7 +474,7 @@ function isNonRelaxableLocalDiscard(
 }
 
 function hasDynamicGitArgument(tokens: readonly string[]): boolean {
-  return tokens.some((token) => token.includes('$'));
+  return tokens.some((token) => /[$*?[]/.test(token));
 }
 
 function hasRecursiveSubmoduleConfig(
@@ -480,6 +489,9 @@ function hasRecursiveSubmoduleConfig(
   const envConfig = envRecursiveSubmoduleConfig(options.envAssignments);
   if (envConfig !== null) {
     return envConfig;
+  }
+  if (hasConfigAffectingEnvAssignment(options.envAssignments)) {
+    return true;
   }
   return effectiveGitConfigEnablesRecursiveSubmodules(gitCwd);
 }
@@ -548,6 +560,10 @@ function commandLineRecursiveSubmoduleConfig(
 }
 
 function envRecursiveSubmoduleConfig(envAssignments?: ReadonlyMap<string, string>): boolean | null {
+  if (getEnvConfigValue('GIT_CONFIG_PARAMETERS', envAssignments) !== undefined) {
+    return true;
+  }
+
   const countValue = getEnvConfigValue('GIT_CONFIG_COUNT', envAssignments);
   if (countValue === undefined) {
     return null;
@@ -572,6 +588,18 @@ function envRecursiveSubmoduleConfig(envAssignments?: ReadonlyMap<string, string
   return recursiveSubmoduleConfig;
 }
 
+function hasConfigAffectingEnvAssignment(envAssignments?: ReadonlyMap<string, string>): boolean {
+  if (!envAssignments) {
+    return false;
+  }
+  for (const key of envAssignments.keys()) {
+    if (GIT_CONFIG_AFFECTING_ENV_NAMES.has(key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function getEnvConfigValue(
   name: string,
   envAssignments?: ReadonlyMap<string, string>,
@@ -580,8 +608,13 @@ function getEnvConfigValue(
 }
 
 function effectiveGitConfigEnablesRecursiveSubmodules(cwd: string): boolean {
+  const gitBinary = getTrustedGitBinary();
+  if (gitBinary === null) {
+    return true;
+  }
+
   try {
-    const value = execFileSync('git', ['config', '--get', 'submodule.recurse'], {
+    const value = execFileSync(gitBinary, ['config', '--get', 'submodule.recurse'], {
       cwd,
       encoding: 'utf8',
       env: withoutGitConfigEnv(process.env),
@@ -593,10 +626,23 @@ function effectiveGitConfigEnablesRecursiveSubmodules(cwd: string): boolean {
   }
 }
 
+function getTrustedGitBinary(): string | null {
+  for (const gitBinary of TRUSTED_GIT_BINARIES) {
+    if (existsSync(gitBinary)) {
+      return gitBinary;
+    }
+  }
+  return null;
+}
+
 function withoutGitConfigEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const nextEnv = { ...env };
   for (const key of Object.keys(nextEnv)) {
-    if (key === 'GIT_CONFIG_COUNT' || /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(key)) {
+    if (
+      key === 'GIT_CONFIG_COUNT' ||
+      key === 'GIT_CONFIG_PARAMETERS' ||
+      /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(key)
+    ) {
       delete nextEnv[key];
     }
   }
@@ -618,6 +664,9 @@ function recursiveSubmoduleConfigValue(config: string | undefined): boolean | nu
   }
   const eqIdx = config.indexOf('=');
   const key = (eqIdx === -1 ? config : config.slice(0, eqIdx)).toLowerCase();
+  if (isIncludeConfigKey(key)) {
+    return true;
+  }
   if (key !== 'submodule.recurse') {
     return null;
   }
@@ -643,11 +692,19 @@ function recursiveSubmoduleConfigEnvValue(
   if (!configEnv || eqIdx === -1) {
     return null;
   }
-  if (configEnv.slice(0, eqIdx).toLowerCase() !== 'submodule.recurse') {
+  const key = configEnv.slice(0, eqIdx).toLowerCase();
+  if (isIncludeConfigKey(key)) {
+    return true;
+  }
+  if (key !== 'submodule.recurse') {
     return null;
   }
   const value = getEnvConfigValue(configEnv.slice(eqIdx + 1), envAssignments);
   return value === undefined || gitConfigValueEnablesRecursiveSubmodules(value);
+}
+
+function isIncludeConfigKey(key: string): boolean {
+  return key === 'include.path' || (key.startsWith('includeif.') && key.endsWith('.path'));
 }
 
 function isForcedBranchReset(subcommand: string | undefined, rest: readonly string[]): boolean {
@@ -671,11 +728,7 @@ function isForcedBranchReset(subcommand: string | undefined, rest: readonly stri
       before.includes('--force') || before.includes('--discard-changes') || shortOpts.has('-f');
     const hasForceCreate =
       before.some(
-        (token) =>
-          token === '-C' ||
-          token.startsWith('-C') ||
-          token === '--force-create' ||
-          token.startsWith('--force-create='),
+        (token) => token === '-C' || token.startsWith('-C') || isForceCreateOption(token),
       ) || shortOpts.has('-C');
     return hasForce && hasForceCreate;
   }
@@ -683,10 +736,16 @@ function isForcedBranchReset(subcommand: string | undefined, rest: readonly stri
   return false;
 }
 
-function hasRecurseSubmodulesOption(tokens: readonly string[]): boolean {
-  return tokens.some(
-    (token) => token === '--recurse-submodules' || token.startsWith('--recurse-submodules='),
+function isForceCreateOption(token: string): boolean {
+  const optionName = token.split('=', 1)[0] ?? token;
+  return (
+    optionName === '--force-create' ||
+    (optionName.length >= '--force-c'.length && '--force-create'.startsWith(optionName))
   );
+}
+
+function hasRecurseSubmodulesOption(tokens: readonly string[]): boolean {
+  return tokens.some((token) => token.startsWith('--recurse-sub'));
 }
 
 function countCleanForceFlags(tokens: readonly string[]): number {

--- a/src/core/rules-git.ts
+++ b/src/core/rules-git.ts
@@ -1,4 +1,10 @@
 import { extractShortOpts, getBasename } from '@/core/shell';
+import {
+  GIT_GLOBAL_OPTS_WITH_VALUE,
+  getGitExecutionContext,
+  hasGitContextEnvOverride,
+  isLinkedWorktree,
+} from '@/core/worktree';
 
 const REASON_CHECKOUT_DOUBLE_DASH =
   "git checkout -- discards uncommitted changes permanently. Use 'git stash' first.";
@@ -32,16 +38,6 @@ const REASON_STASH_DROP =
 const REASON_STASH_CLEAR = 'git stash clear deletes ALL stashed changes permanently.';
 const REASON_WORKTREE_REMOVE_FORCE =
   'git worktree remove --force can delete uncommitted changes. Remove --force flag.';
-
-const GIT_GLOBAL_OPTS_WITH_VALUE = new Set([
-  '-c',
-  '-C',
-  '--git-dir',
-  '--work-tree',
-  '--namespace',
-  '--super-prefix',
-  '--config-env',
-]);
 
 const CHECKOUT_OPTS_WITH_VALUE = new Set([
   '-b',
@@ -109,7 +105,51 @@ function splitAtDoubleDash(tokens: readonly string[]): {
   };
 }
 
-export function analyzeGit(tokens: readonly string[]): string | null {
+export interface GitAnalyzeOptions {
+  cwd?: string;
+  envAssignments?: ReadonlyMap<string, string>;
+  worktreeMode?: boolean;
+}
+
+export interface GitWorktreeRelaxation {
+  originalReason: string;
+  gitCwd: string;
+}
+
+interface GitRuleMatch {
+  reason: string;
+  localDiscard: boolean;
+}
+
+export function analyzeGit(
+  tokens: readonly string[],
+  options: GitAnalyzeOptions = {},
+): string | null {
+  const match = analyzeGitRule(tokens);
+
+  if (!match) {
+    return null;
+  }
+
+  if (getGitWorktreeRelaxationForMatch(tokens, match, options)) {
+    return null;
+  }
+
+  return match.reason;
+}
+
+export function getGitWorktreeRelaxation(
+  tokens: readonly string[],
+  options: GitAnalyzeOptions = {},
+): GitWorktreeRelaxation | null {
+  const match = analyzeGitRule(tokens);
+  if (!match) {
+    return null;
+  }
+  return getGitWorktreeRelaxationForMatch(tokens, match, options);
+}
+
+function analyzeGitRule(tokens: readonly string[]): GitRuleMatch | null {
   const { subcommand, rest } = extractGitSubcommandAndRest(tokens);
 
   if (!subcommand) {
@@ -118,26 +158,62 @@ export function analyzeGit(tokens: readonly string[]): string | null {
 
   switch (subcommand.toLowerCase()) {
     case 'checkout':
-      return analyzeGitCheckout(rest);
+      return localDiscard(analyzeGitCheckout(rest));
     case 'switch':
-      return analyzeGitSwitch(rest);
+      return localDiscard(analyzeGitSwitch(rest));
     case 'restore':
-      return analyzeGitRestore(rest);
+      return localDiscard(analyzeGitRestore(rest));
     case 'reset':
-      return analyzeGitReset(rest);
+      return localDiscard(analyzeGitReset(rest));
     case 'clean':
-      return analyzeGitClean(rest);
+      return localDiscard(analyzeGitClean(rest));
     case 'push':
-      return analyzeGitPush(rest);
+      return sharedState(analyzeGitPush(rest));
     case 'branch':
-      return analyzeGitBranch(rest);
+      return sharedState(analyzeGitBranch(rest));
     case 'stash':
-      return analyzeGitStash(rest);
+      return sharedState(analyzeGitStash(rest));
     case 'worktree':
-      return analyzeGitWorktree(rest);
+      return sharedState(analyzeGitWorktree(rest));
     default:
       return null;
   }
+}
+
+function localDiscard(reason: string | null): GitRuleMatch | null {
+  return reason ? { reason, localDiscard: true } : null;
+}
+
+function sharedState(reason: string | null): GitRuleMatch | null {
+  return reason ? { reason, localDiscard: false } : null;
+}
+
+function getGitWorktreeRelaxationForMatch(
+  tokens: readonly string[],
+  match: GitRuleMatch,
+  options: GitAnalyzeOptions,
+): GitWorktreeRelaxation | null {
+  if (
+    !match.localDiscard ||
+    !options.worktreeMode ||
+    hasGitContextEnvOverride(options.envAssignments)
+  ) {
+    return null;
+  }
+
+  const context = getGitExecutionContext(tokens, options.cwd);
+  if (!context.gitCwd || context.hasExplicitGitContext) {
+    return null;
+  }
+
+  if (!isLinkedWorktree(context.gitCwd)) {
+    return null;
+  }
+
+  return {
+    originalReason: match.reason,
+    gitCwd: context.gitCwd,
+  };
 }
 
 function extractGitSubcommandAndRest(tokens: readonly string[]): {

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -572,7 +572,7 @@ function _stripAttachedIoNumbers(command: string): string {
 
 const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
 
-function parseEnvAssignment(token: string): { name: string; value: string } | null {
+export function parseEnvAssignment(token: string): { name: string; value: string } | null {
   if (!ENV_ASSIGNMENT_RE.test(token)) {
     return null;
   }
@@ -652,7 +652,11 @@ export function stripWrappersWithInfo(
     }
 
     if (head === 'sudo') {
-      result = stripSudo(result);
+      const sudoResult = stripSudoWithInfo(result, currentCwd);
+      result = sudoResult.tokens;
+      if (sudoResult.cwd !== undefined) {
+        currentCwd = sudoResult.cwd;
+      }
     }
     if (head === 'env') {
       const envResult = stripEnvWithInfo(result, currentCwd);
@@ -682,19 +686,30 @@ export function stripWrappersWithInfo(
 
 const SUDO_OPTS_WITH_VALUE = new Set(['-u', '-g', '-C', '-D', '-h', '-p', '-r', '-t', '-T', '-U']);
 
-function stripSudo(tokens: string[]): string[] {
+function stripSudoWithInfo(
+  tokens: string[],
+  cwd?: string | null,
+): { tokens: string[]; cwd?: string | null } {
   let i = 1;
+  let currentCwd = cwd;
   while (i < tokens.length) {
     const token = tokens[i];
     if (!token) break;
 
     if (token === '--') {
-      return tokens.slice(i + 1);
+      return { tokens: tokens.slice(i + 1), cwd: currentCwd };
     }
 
     // Guard: not an option, exit loop
     if (!token.startsWith('-')) {
       break;
+    }
+
+    if (token === '-D') {
+      const target = tokens[i + 1];
+      currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
+      i += 2;
+      continue;
     }
 
     if (SUDO_OPTS_WITH_VALUE.has(token)) {
@@ -704,7 +719,7 @@ function stripSudo(tokens: string[]): string[] {
 
     i++;
   }
-  return tokens.slice(i);
+  return { tokens: tokens.slice(i), cwd: currentCwd };
 }
 
 const ENV_OPTS_NO_VALUE = new Set(['-i', '-0', '--null']);
@@ -721,13 +736,14 @@ const ENV_OPTS_WITH_VALUE = new Set([
 function stripEnvWithInfo(tokens: string[], cwd?: string | null): EnvStrippingResult {
   const envAssignments = new Map<string, string>();
   let currentCwd = cwd;
+  let expandedTokens = tokens;
   let i = 1;
-  while (i < tokens.length) {
-    const token = tokens[i];
+  while (i < expandedTokens.length) {
+    const token = expandedTokens[i];
     if (!token) break;
 
     if (token === '--') {
-      return { tokens: tokens.slice(i + 1), envAssignments };
+      return { tokens: expandedTokens.slice(i + 1), envAssignments, cwd: currentCwd };
     }
 
     if (ENV_OPTS_NO_VALUE.has(token)) {
@@ -735,9 +751,55 @@ function stripEnvWithInfo(tokens: string[], cwd?: string | null): EnvStrippingRe
       continue;
     }
 
+    if (token === '-S' || token === '--split-string') {
+      const splitValue = expandedTokens[i + 1];
+      const splitTokens = splitValue !== undefined ? parseEnvSplitString(splitValue) : null;
+      if (!splitTokens) {
+        currentCwd = null;
+        i += 2;
+        continue;
+      }
+      expandedTokens = [
+        ...expandedTokens.slice(0, i),
+        ...splitTokens,
+        ...expandedTokens.slice(i + 2),
+      ];
+      continue;
+    }
+
+    if (token.startsWith('-S') && token.length > 2) {
+      const splitTokens = parseEnvSplitString(token.slice('-S'.length));
+      if (!splitTokens) {
+        currentCwd = null;
+        i++;
+        continue;
+      }
+      expandedTokens = [
+        ...expandedTokens.slice(0, i),
+        ...splitTokens,
+        ...expandedTokens.slice(i + 1),
+      ];
+      continue;
+    }
+
+    if (token.startsWith('--split-string=')) {
+      const splitTokens = parseEnvSplitString(token.slice('--split-string='.length));
+      if (!splitTokens) {
+        currentCwd = null;
+        i++;
+        continue;
+      }
+      expandedTokens = [
+        ...expandedTokens.slice(0, i),
+        ...splitTokens,
+        ...expandedTokens.slice(i + 1),
+      ];
+      continue;
+    }
+
     if (ENV_OPTS_WITH_VALUE.has(token)) {
       if (token === '-C' || token === '--chdir') {
-        const target = tokens[i + 1];
+        const target = expandedTokens[i + 1];
         currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
       }
       i += 2;
@@ -749,10 +811,12 @@ function stripEnvWithInfo(tokens: string[], cwd?: string | null): EnvStrippingRe
       continue;
     }
 
-    if (token.startsWith('-C=') || token.startsWith('--chdir=')) {
-      const target = token.startsWith('-C=')
-        ? token.slice('-C='.length)
-        : token.slice('--chdir='.length);
+    if ((token.startsWith('-C') && token.length > 2) || token.startsWith('--chdir=')) {
+      const target = token.startsWith('--chdir=')
+        ? token.slice('--chdir='.length)
+        : token.startsWith('-C=')
+          ? token.slice('-C='.length)
+          : token.slice('-C'.length);
       currentCwd = resolveWrapperCwd(currentCwd, target);
       i++;
       continue;
@@ -776,7 +840,24 @@ function stripEnvWithInfo(tokens: string[], cwd?: string | null): EnvStrippingRe
     envAssignments.set(assignment.name, assignment.value);
     i++;
   }
-  return { tokens: tokens.slice(i), envAssignments, cwd: currentCwd };
+  return { tokens: expandedTokens.slice(i), envAssignments, cwd: currentCwd };
+}
+
+function parseEnvSplitString(value: string): string[] | null {
+  if (hasUnclosedQuotes(value)) {
+    return null;
+  }
+
+  const parsed = parse(value, ENV_PROXY);
+  const result: string[] = [];
+  for (const entry of parsed) {
+    const token = _getCommandTokenText(entry as ParseEntry);
+    if (token === null) {
+      return null;
+    }
+    result.push(token);
+  }
+  return result;
 }
 
 function resolveWrapperCwd(cwd: string | null | undefined, target: string): string | null {

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -1,6 +1,7 @@
 import { isAbsolute, resolve } from 'node:path';
 import { type ParseEntry, parse } from 'shell-quote';
 import { MAX_STRIP_ITERATIONS, SHELL_OPERATORS } from '@/types';
+import { GIT_CONTEXT_ENV_OVERRIDES } from './worktree';
 
 // Proxy that preserves variable references as $VAR strings instead of expanding them
 const ENV_PROXY = new Proxy(
@@ -571,6 +572,8 @@ function _stripAttachedIoNumbers(command: string): string {
 }
 
 const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
+const ENV_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
+const GIT_CONTEXT_ENV_OVERRIDE_NAMES: ReadonlySet<string> = new Set(GIT_CONTEXT_ENV_OVERRIDES);
 
 export function parseEnvAssignment(token: string): { name: string; value: string } | null {
   if (!ENV_ASSIGNMENT_RE.test(token)) {
@@ -578,6 +581,16 @@ export function parseEnvAssignment(token: string): { name: string; value: string
   }
   const eqIdx = token.indexOf('=');
   return { name: token.slice(0, eqIdx), value: token.slice(eqIdx + 1) };
+}
+
+function parseGitContextAppendEnvAssignment(token: string): { name: string; value: string } | null {
+  const match = token.match(ENV_APPEND_ASSIGNMENT_RE);
+  const name = match?.[1];
+  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name)) {
+    return null;
+  }
+  const eqIdx = token.indexOf('=');
+  return { name, value: token.slice(eqIdx + 1) };
 }
 
 export interface EnvStrippingResult {
@@ -637,9 +650,12 @@ export function stripWrappersWithInfo(
       result[0]?.includes('=') &&
       !ENV_ASSIGNMENT_RE.test(result[0] ?? '')
     ) {
-      // Conservative parsing: only strict NAME=value is treated as an env assignment.
-      // Other leading tokens that contain '=' (e.g. NAME+=value) are dropped to reach
-      // the actual executable token.
+      const appendAssignment = parseGitContextAppendEnvAssignment(result[0] ?? '');
+      if (appendAssignment) {
+        allEnvAssignments.set(appendAssignment.name, appendAssignment.value);
+      }
+      // Other non-strict leading assignments are dropped to reach the executable token.
+      // Git context append assignments are preserved above so worktree relaxation fails closed.
       result = result.slice(1);
     }
     if (result.length === 0) break;
@@ -705,10 +721,16 @@ function stripSudoWithInfo(
       break;
     }
 
-    if (token === '-D') {
+    if (token === '-D' || token === '--chdir') {
       const target = tokens[i + 1];
       currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
       i += 2;
+      continue;
+    }
+
+    if (token.startsWith('--chdir=')) {
+      currentCwd = resolveWrapperCwd(currentCwd, token.slice('--chdir='.length));
+      i++;
       continue;
     }
 

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -1,5 +1,5 @@
 import { lstatSync, realpathSync } from 'node:fs';
-import { dirname, isAbsolute } from 'node:path';
+import { dirname, isAbsolute, parse as parsePath, sep } from 'node:path';
 import { type ParseEntry, parse } from 'shell-quote';
 import { MAX_STRIP_ITERATIONS, SHELL_OPERATORS } from '@/types';
 import { GIT_CONTEXT_ENV_OVERRIDES } from './worktree';
@@ -588,6 +588,13 @@ function _stripAttachedIoNumbers(command: string): string {
 const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
 const ENV_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 const GIT_CONTEXT_ENV_OVERRIDE_NAMES: ReadonlySet<string> = new Set(GIT_CONTEXT_ENV_OVERRIDES);
+const GIT_CONFIG_AFFECTING_ENV_NAMES: ReadonlySet<string> = new Set([
+  'GIT_CONFIG_GLOBAL',
+  'GIT_CONFIG_NOSYSTEM',
+  'GIT_CONFIG_SYSTEM',
+  'HOME',
+  'XDG_CONFIG_HOME',
+]);
 
 export function parseEnvAssignment(token: string): { name: string; value: string } | null {
   if (!ENV_ASSIGNMENT_RE.test(token)) {
@@ -600,11 +607,27 @@ export function parseEnvAssignment(token: string): { name: string; value: string
 function parseGitContextAppendEnvAssignment(token: string): { name: string; value: string } | null {
   const match = token.match(ENV_APPEND_ASSIGNMENT_RE);
   const name = match?.[1];
-  if (!name || !GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name)) {
+  if (!name || !isTrackedGitEnvName(name)) {
     return null;
   }
   const eqIdx = token.indexOf('=');
   return { name, value: token.slice(eqIdx + 1) };
+}
+
+function isTrackedGitEnvName(name: string): boolean {
+  return (
+    GIT_CONTEXT_ENV_OVERRIDE_NAMES.has(name) ||
+    GIT_CONFIG_AFFECTING_ENV_NAMES.has(name) ||
+    isGitConfigEnvName(name)
+  );
+}
+
+function isGitConfigEnvName(name: string): boolean {
+  return (
+    name === 'GIT_CONFIG_COUNT' ||
+    name === 'GIT_CONFIG_PARAMETERS' ||
+    /^GIT_CONFIG_(KEY|VALUE)_\d+$/.test(name)
+  );
 }
 
 export interface EnvStrippingResult {
@@ -916,7 +939,7 @@ function resolveWrapperCwd(cwd: string | null | undefined, target: string): stri
     if (!cwd && !isAbsolute(target)) {
       return null;
     }
-    const baseCwd = isAbsolute(target) ? '/' : realpathSync(cwd ?? '/');
+    const baseCwd = isAbsolute(target) ? getPathRoot(target) : realpathSync(cwd ?? '/');
     return resolveChdirTarget(baseCwd, target);
   } catch {
     return null;
@@ -924,8 +947,9 @@ function resolveWrapperCwd(cwd: string | null | undefined, target: string): stri
 }
 
 function resolveChdirTarget(baseCwd: string, target: string): string {
-  let current = isAbsolute(target) ? '/' : baseCwd;
-  for (const component of target.split('/')) {
+  const root = isAbsolute(target) ? getPathRoot(target) : '';
+  let current = root || baseCwd;
+  for (const component of getPathComponents(root ? target.slice(root.length) : target)) {
     if (component === '' || component === '.') {
       continue;
     }
@@ -941,7 +965,16 @@ function resolveChdirTarget(baseCwd: string, target: string): string {
 }
 
 function appendPathWithoutNormalizing(base: string, target: string): string {
-  return base.endsWith('/') ? `${base}${target}` : `${base}/${target}`;
+  return base.endsWith('/') || base.endsWith('\\') ? `${base}${target}` : `${base}${sep}${target}`;
+}
+
+function getPathRoot(target: string): string {
+  return parsePath(target).root;
+}
+
+function getPathComponents(target: string): string[] {
+  const separator = process.platform === 'win32' ? /[\\/]+/ : /\/+/;
+  return target.split(separator);
 }
 
 function stripCommand(tokens: string[]): string[] {

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -1,8 +1,9 @@
-import { lstatSync, realpathSync } from 'node:fs';
-import { dirname, isAbsolute, parse as parsePath, sep } from 'node:path';
+import { realpathSync } from 'node:fs';
+import { isAbsolute, parse as parsePath } from 'node:path';
 import { type ParseEntry, parse } from 'shell-quote';
+import { resolveChdirTarget } from '@/core/path';
 import { MAX_STRIP_ITERATIONS, SHELL_OPERATORS } from '@/types';
-import { GIT_CONTEXT_ENV_OVERRIDES } from './worktree';
+import { GIT_CONFIG_AFFECTING_ENV_NAMES, GIT_CONTEXT_ENV_OVERRIDES } from './worktree';
 
 // Proxy that preserves variable references as $VAR strings instead of expanding them
 const ENV_PROXY = new Proxy(
@@ -588,14 +589,6 @@ function _stripAttachedIoNumbers(command: string): string {
 const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
 const ENV_APPEND_ASSIGNMENT_RE = /^([A-Za-z_][A-Za-z0-9_]*)\+=/;
 const GIT_CONTEXT_ENV_OVERRIDE_NAMES: ReadonlySet<string> = new Set(GIT_CONTEXT_ENV_OVERRIDES);
-const GIT_CONFIG_AFFECTING_ENV_NAMES: ReadonlySet<string> = new Set([
-  'GIT_CONFIG_GLOBAL',
-  'GIT_CONFIG_NOSYSTEM',
-  'GIT_CONFIG_SYSTEM',
-  'HOME',
-  'XDG_CONFIG_HOME',
-]);
-
 export function parseEnvAssignment(token: string): { name: string; value: string } | null {
   if (!ENV_ASSIGNMENT_RE.test(token)) {
     return null;
@@ -946,35 +939,8 @@ function resolveWrapperCwd(cwd: string | null | undefined, target: string): stri
   }
 }
 
-function resolveChdirTarget(baseCwd: string, target: string): string {
-  const root = isAbsolute(target) ? getPathRoot(target) : '';
-  let current = root || baseCwd;
-  for (const component of getPathComponents(root ? target.slice(root.length) : target)) {
-    if (component === '' || component === '.') {
-      continue;
-    }
-    if (component === '..') {
-      current = dirname(current);
-      continue;
-    }
-
-    const candidate = appendPathWithoutNormalizing(current, component);
-    current = lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
-  }
-  return current;
-}
-
-function appendPathWithoutNormalizing(base: string, target: string): string {
-  return base.endsWith('/') || base.endsWith('\\') ? `${base}${target}` : `${base}${sep}${target}`;
-}
-
 function getPathRoot(target: string): string {
   return parsePath(target).root;
-}
-
-function getPathComponents(target: string): string[] {
-  const separator = process.platform === 'win32' ? /[\\/]+/ : /\/+/;
-  return target.split(separator);
 }
 
 function stripCommand(tokens: string[]): string[] {

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, resolve } from 'node:path';
+import { lstatSync, realpathSync } from 'node:fs';
+import { dirname, isAbsolute } from 'node:path';
 import { type ParseEntry, parse } from 'shell-quote';
 import { MAX_STRIP_ITERATIONS, SHELL_OPERATORS } from '@/types';
 import { GIT_CONTEXT_ENV_OVERRIDES } from './worktree';
@@ -734,6 +735,18 @@ function stripSudoWithInfo(
       continue;
     }
 
+    if (token.startsWith('-D') && token.length > 2) {
+      currentCwd = resolveWrapperCwd(currentCwd, token.slice(2));
+      i++;
+      continue;
+    }
+
+    if (token === '-i' || token === '--login') {
+      currentCwd = null;
+      i++;
+      continue;
+    }
+
     if (SUDO_OPTS_WITH_VALUE.has(token)) {
       i += 2;
       continue;
@@ -886,13 +899,35 @@ function resolveWrapperCwd(cwd: string | null | undefined, target: string): stri
   if (target === '') {
     return null;
   }
-  if (isAbsolute(target)) {
-    return resolve(target);
-  }
-  if (!cwd) {
+  try {
+    if (!cwd && !isAbsolute(target)) {
+      return null;
+    }
+    return resolveChdirTarget(cwd ?? '/', target);
+  } catch {
     return null;
   }
-  return resolve(cwd, target);
+}
+
+function resolveChdirTarget(baseCwd: string, target: string): string {
+  let current = isAbsolute(target) ? '/' : baseCwd;
+  for (const component of target.split('/')) {
+    if (component === '' || component === '.') {
+      continue;
+    }
+    if (component === '..') {
+      current = dirname(current);
+      continue;
+    }
+
+    const candidate = appendPathWithoutNormalizing(current, component);
+    current = lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
+  }
+  return current;
+}
+
+function appendPathWithoutNormalizing(base: string, target: string): string {
+  return base.endsWith('/') ? `${base}${target}` : `${base}/${target}`;
 }
 
 function stripCommand(tokens: string[]): string[] {

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, resolve } from 'node:path';
 import { type ParseEntry, parse } from 'shell-quote';
 import { MAX_STRIP_ITERATIONS, SHELL_OPERATORS } from '@/types';
 
@@ -582,6 +583,7 @@ function parseEnvAssignment(token: string): { name: string; value: string } | nu
 export interface EnvStrippingResult {
   tokens: string[];
   envAssignments: Map<string, string>;
+  cwd?: string | null;
 }
 
 export function stripEnvAssignmentsWithInfo(tokens: string[]): EnvStrippingResult {
@@ -605,15 +607,20 @@ export function stripEnvAssignmentsWithInfo(tokens: string[]): EnvStrippingResul
 export interface WrapperStrippingResult {
   tokens: string[];
   envAssignments: Map<string, string>;
+  cwd?: string | null;
 }
 
-export function stripWrappers(tokens: string[]): string[] {
-  return stripWrappersWithInfo(tokens).tokens;
+export function stripWrappers(tokens: string[], cwd?: string | null): string[] {
+  return stripWrappersWithInfo(tokens, cwd).tokens;
 }
 
-export function stripWrappersWithInfo(tokens: string[]): WrapperStrippingResult {
+export function stripWrappersWithInfo(
+  tokens: string[],
+  cwd?: string | null,
+): WrapperStrippingResult {
   let result = [...tokens];
   const allEnvAssignments = new Map<string, string>();
+  let currentCwd = cwd;
 
   for (let iteration = 0; iteration < MAX_STRIP_ITERATIONS; iteration++) {
     const before = result.join(' ');
@@ -648,8 +655,11 @@ export function stripWrappersWithInfo(tokens: string[]): WrapperStrippingResult 
       result = stripSudo(result);
     }
     if (head === 'env') {
-      const envResult = stripEnvWithInfo(result);
+      const envResult = stripEnvWithInfo(result, currentCwd);
       result = envResult.tokens;
+      if (envResult.cwd !== undefined) {
+        currentCwd = envResult.cwd;
+      }
       for (const [k, v] of envResult.envAssignments) {
         allEnvAssignments.set(k, v);
       }
@@ -667,7 +677,7 @@ export function stripWrappersWithInfo(tokens: string[]): WrapperStrippingResult 
     allEnvAssignments.set(k, v);
   }
 
-  return { tokens: finalTokens, envAssignments: allEnvAssignments };
+  return { tokens: finalTokens, envAssignments: allEnvAssignments, cwd: currentCwd };
 }
 
 const SUDO_OPTS_WITH_VALUE = new Set(['-u', '-g', '-C', '-D', '-h', '-p', '-r', '-t', '-T', '-U']);
@@ -708,8 +718,9 @@ const ENV_OPTS_WITH_VALUE = new Set([
   '-P',
 ]);
 
-function stripEnvWithInfo(tokens: string[]): EnvStrippingResult {
+function stripEnvWithInfo(tokens: string[], cwd?: string | null): EnvStrippingResult {
   const envAssignments = new Map<string, string>();
+  let currentCwd = cwd;
   let i = 1;
   while (i < tokens.length) {
     const token = tokens[i];
@@ -725,6 +736,10 @@ function stripEnvWithInfo(tokens: string[]): EnvStrippingResult {
     }
 
     if (ENV_OPTS_WITH_VALUE.has(token)) {
+      if (token === '-C' || token === '--chdir') {
+        const target = tokens[i + 1];
+        currentCwd = target ? resolveWrapperCwd(currentCwd, target) : null;
+      }
       i += 2;
       continue;
     }
@@ -735,6 +750,10 @@ function stripEnvWithInfo(tokens: string[]): EnvStrippingResult {
     }
 
     if (token.startsWith('-C=') || token.startsWith('--chdir=')) {
+      const target = token.startsWith('-C=')
+        ? token.slice('-C='.length)
+        : token.slice('--chdir='.length);
+      currentCwd = resolveWrapperCwd(currentCwd, target);
       i++;
       continue;
     }
@@ -757,7 +776,20 @@ function stripEnvWithInfo(tokens: string[]): EnvStrippingResult {
     envAssignments.set(assignment.name, assignment.value);
     i++;
   }
-  return { tokens: tokens.slice(i), envAssignments };
+  return { tokens: tokens.slice(i), envAssignments, cwd: currentCwd };
+}
+
+function resolveWrapperCwd(cwd: string | null | undefined, target: string): string | null {
+  if (target === '') {
+    return null;
+  }
+  if (isAbsolute(target)) {
+    return resolve(target);
+  }
+  if (!cwd) {
+    return null;
+  }
+  return resolve(cwd, target);
 }
 
 function stripCommand(tokens: string[]): string[] {

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -14,6 +14,7 @@ const ENV_PROXY = new Proxy(
 
 const ARITHMETIC_SENTINEL = '__CC_SAFETY_NET_ARITH_SENTINEL__';
 const BACKTICK_ATTACHED_SUFFIX_SENTINEL = '__CC_SAFETY_NET_BACKTICK_SUFFIX__';
+const DYNAMIC_SUBSTITUTION_TOKEN = '$__CC_SAFETY_NET_DYNAMIC_SUBSTITUTION__';
 
 export function splitShellCommands(command: string): string[][] {
   if (hasUnclosedQuotes(command)) {
@@ -64,9 +65,14 @@ export function splitShellCommands(command: string): string[][] {
       const shouldKeepCurrent =
         attachedSuffix !== null && !_isRedirectOp(tokens[i - 1]) && !isOperatorToken(tokens[i - 1]);
 
-      if (!shouldKeepCurrent && current.length > 0) {
-        segments.push(current);
-        current = [];
+      if (current.length > 0) {
+        if (_containsGitCommandToken(current)) {
+          current.push(DYNAMIC_SUBSTITUTION_TOKEN);
+        }
+        if (!shouldKeepCurrent) {
+          segments.push(current);
+          current = [];
+        }
       }
       for (const seg of innerSegments) {
         segments.push(seg);
@@ -85,6 +91,9 @@ export function splitShellCommands(command: string): string[][] {
         if (prefix) {
           current.push(prefix);
         }
+      }
+      if (_containsGitCommandToken(current)) {
+        current.push(DYNAMIC_SUBSTITUTION_TOKEN);
       }
       const { innerSegments, endIndex } = extractCommandSubstitution(tokens, i + 2);
       for (const seg of innerSegments) {
@@ -195,6 +204,10 @@ function _getCommandTokenText(token: ParseEntry | undefined): string | null {
   }
 
   return null;
+}
+
+function _containsGitCommandToken(tokens: readonly string[]): boolean {
+  return tokens.some((token) => (token.split('/').pop() ?? token).toLowerCase() === 'git');
 }
 
 function extractCommandSubstitution(
@@ -903,7 +916,8 @@ function resolveWrapperCwd(cwd: string | null | undefined, target: string): stri
     if (!cwd && !isAbsolute(target)) {
       return null;
     }
-    return resolveChdirTarget(cwd ?? '/', target);
+    const baseCwd = isAbsolute(target) ? '/' : realpathSync(cwd ?? '/');
+    return resolveChdirTarget(baseCwd, target);
   } catch {
     return null;
   }

--- a/src/core/worktree.ts
+++ b/src/core/worktree.ts
@@ -1,5 +1,5 @@
 import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from 'node:fs';
-import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, parse as parsePath, resolve, sep } from 'node:path';
 
 export const GIT_GLOBAL_OPTS_WITH_VALUE: ReadonlySet<string> = new Set([
   '-c',
@@ -241,8 +241,9 @@ function resolveGitCwd(baseCwd: string, target: string): string | null {
 }
 
 function resolveChdirTarget(baseCwd: string, target: string): string {
-  let current = isAbsolute(target) ? '/' : baseCwd;
-  for (const component of target.split('/')) {
+  const root = isAbsolute(target) ? getPathRoot(target) : '';
+  let current = root || baseCwd;
+  for (const component of getPathComponents(root ? target.slice(root.length) : target)) {
     if (component === '' || component === '.') {
       continue;
     }
@@ -258,7 +259,16 @@ function resolveChdirTarget(baseCwd: string, target: string): string {
 }
 
 function appendPathWithoutNormalizing(base: string, target: string): string {
-  return base.endsWith('/') ? `${base}${target}` : `${base}/${target}`;
+  return base.endsWith('/') || base.endsWith('\\') ? `${base}${target}` : `${base}${sep}${target}`;
+}
+
+function getPathRoot(target: string): string {
+  return parsePath(target).root;
+}
+
+function getPathComponents(target: string): string[] {
+  const separator = process.platform === 'win32' ? /[\\/]+/ : /\/+/;
+  return target.split(separator);
 }
 
 function isDirectory(path: string): boolean {

--- a/src/core/worktree.ts
+++ b/src/core/worktree.ts
@@ -11,7 +11,7 @@ export const GIT_GLOBAL_OPTS_WITH_VALUE: ReadonlySet<string> = new Set([
   '--config-env',
 ]);
 
-const GIT_CONTEXT_ENV_OVERRIDES = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_COMMON_DIR'] as const;
+export const GIT_CONTEXT_ENV_OVERRIDES = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_COMMON_DIR'] as const;
 
 export interface GitExecutionContext {
   gitCwd: string | null;

--- a/src/core/worktree.ts
+++ b/src/core/worktree.ts
@@ -1,5 +1,6 @@
 import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from 'node:fs';
-import { dirname, isAbsolute, join, parse as parsePath, resolve, sep } from 'node:path';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { resolveChdirTarget } from '@/core/path';
 
 export const GIT_GLOBAL_OPTS_WITH_VALUE: ReadonlySet<string> = new Set([
   '-c',
@@ -17,6 +18,14 @@ export const GIT_CONTEXT_ENV_OVERRIDES = [
   'GIT_COMMON_DIR',
   'GIT_INDEX_FILE',
 ] as const;
+
+export const GIT_CONFIG_AFFECTING_ENV_NAMES: ReadonlySet<string> = new Set([
+  'GIT_CONFIG_GLOBAL',
+  'GIT_CONFIG_NOSYSTEM',
+  'GIT_CONFIG_SYSTEM',
+  'HOME',
+  'XDG_CONFIG_HOME',
+]);
 
 export interface GitExecutionContext {
   gitCwd: string | null;
@@ -246,22 +255,57 @@ function readCoreWorktree(configPath: string): string | null {
 
     const match = trimmed.match(/^worktree\s*=\s*(.*)$/i);
     if (match) {
-      configuredWorktree = unquoteGitConfigValue(match[1] ?? '');
+      configuredWorktree = parseGitConfigValue(match[1] ?? '');
     }
   }
 
   return configuredWorktree;
 }
 
-function unquoteGitConfigValue(value: string): string {
+function parseGitConfigValue(value: string): string {
   const trimmed = value.trim();
-  if (
-    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-    (trimmed.startsWith("'") && trimmed.endsWith("'"))
-  ) {
-    return trimmed.slice(1, -1);
+  if (!trimmed.startsWith('"') || !trimmed.endsWith('"')) {
+    return trimmed;
   }
-  return trimmed;
+  return unescapeDoubleQuotedGitConfigValue(trimmed.slice(1, -1));
+}
+
+function unescapeDoubleQuotedGitConfigValue(value: string): string {
+  let result = '';
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (char !== '\\') {
+      result += char;
+      continue;
+    }
+
+    const next = value[i + 1];
+    if (next === undefined) {
+      result += char;
+      continue;
+    }
+
+    switch (next) {
+      case '\\':
+      case '"':
+        result += next;
+        break;
+      case 'n':
+        result += '\n';
+        break;
+      case 't':
+        result += '\t';
+        break;
+      case 'b':
+        result += '\b';
+        break;
+      default:
+        result += `\\${next}`;
+        break;
+    }
+    i++;
+  }
+  return result;
 }
 
 function resolveGitCwd(baseCwd: string, target: string): string | null {
@@ -271,37 +315,6 @@ function resolveGitCwd(baseCwd: string, target: string): string | null {
   } catch {
     return null;
   }
-}
-
-function resolveChdirTarget(baseCwd: string, target: string): string {
-  const root = isAbsolute(target) ? getPathRoot(target) : '';
-  let current = root || baseCwd;
-  for (const component of getPathComponents(root ? target.slice(root.length) : target)) {
-    if (component === '' || component === '.') {
-      continue;
-    }
-    if (component === '..') {
-      current = dirname(current);
-      continue;
-    }
-
-    const candidate = appendPathWithoutNormalizing(current, component);
-    current = lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
-  }
-  return current;
-}
-
-function appendPathWithoutNormalizing(base: string, target: string): string {
-  return base.endsWith('/') || base.endsWith('\\') ? `${base}${target}` : `${base}${sep}${target}`;
-}
-
-function getPathRoot(target: string): string {
-  return parsePath(target).root;
-}
-
-function getPathComponents(target: string): string[] {
-  const separator = process.platform === 'win32' ? /[\\/]+/ : /\/+/;
-  return target.split(separator);
 }
 
 function isDirectory(path: string): boolean {
@@ -333,3 +346,6 @@ function findDotGit(cwd: string): string | null {
     current = parent;
   }
 }
+
+/** @internal Exported for testing */
+export { parseGitConfigValue as _parseGitConfigValue };

--- a/src/core/worktree.ts
+++ b/src/core/worktree.ts
@@ -165,7 +165,7 @@ function worktreeGitdirBacklinkMatches(gitDir: string, dotGitPath: string): bool
   const linkedDotGitPath = isAbsolute(rawBacklink) ? rawBacklink : resolve(gitDir, rawBacklink);
 
   try {
-    return realpathSync(linkedDotGitPath) === realpathSync(dotGitPath);
+    return sameFilesystemPath(linkedDotGitPath, dotGitPath);
   } catch {
     return false;
   }
@@ -187,10 +187,40 @@ function worktreeConfigMatchesRoot(gitDir: string, worktreeRoot: string): boolea
     : resolve(gitDir, configuredWorktree);
 
   try {
-    return realpathSync(resolvedConfiguredWorktree) === realpathSync(worktreeRoot);
+    return sameFilesystemPath(resolvedConfiguredWorktree, worktreeRoot);
   } catch {
     return false;
   }
+}
+
+function sameFilesystemPath(left: string, right: string): boolean {
+  try {
+    const leftStat = statSync(left);
+    const rightStat = statSync(right);
+    if (
+      leftStat.ino !== 0 &&
+      rightStat.ino !== 0 &&
+      leftStat.dev === rightStat.dev &&
+      leftStat.ino === rightStat.ino
+    ) {
+      return true;
+    }
+  } catch {
+    // Fall through to realpath comparison for platforms where stat identity is unavailable.
+  }
+
+  return (
+    normalizePathForComparison(realpathSync(left)) ===
+    normalizePathForComparison(realpathSync(right))
+  );
+}
+
+function normalizePathForComparison(path: string): string {
+  let normalized = path.replace(/\\/g, '/');
+  if (normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
 }
 
 function readCoreWorktree(configPath: string): string | null {

--- a/src/core/worktree.ts
+++ b/src/core/worktree.ts
@@ -209,14 +209,17 @@ function sameFilesystemPath(left: string, right: string): boolean {
     // Fall through to realpath comparison for platforms where stat identity is unavailable.
   }
 
-  return (
-    normalizePathForComparison(realpathSync(left)) ===
-    normalizePathForComparison(realpathSync(right))
-  );
+  return getCanonicalPathForComparison(left) === getCanonicalPathForComparison(right);
 }
 
-function normalizePathForComparison(path: string): string {
-  let normalized = path.replace(/\\/g, '/');
+function getCanonicalPathForComparison(path: string): string {
+  return normalizePathForComparison(realpathSync.native(path));
+}
+
+/** @internal Exported for testing */
+export function normalizePathForComparison(path: string): string {
+  let normalized = path.replace(/^\\\\\?\\UNC\\/i, '//').replace(/^\\\\\?\\/i, '');
+  normalized = normalized.replace(/\\/g, '/');
   if (normalized.length > 1 && normalized.endsWith('/')) {
     normalized = normalized.slice(0, -1);
   }

--- a/src/core/worktree.ts
+++ b/src/core/worktree.ts
@@ -127,10 +127,73 @@ export function isLinkedWorktree(cwd: string): boolean {
     }
 
     const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve(dirname(dotGitPath), rawGitDir);
-    return existsSync(join(gitDir, 'commondir'));
+    if (!existsSync(join(gitDir, 'commondir'))) {
+      return false;
+    }
+
+    return worktreeConfigMatchesRoot(gitDir, dirname(dotGitPath));
   } catch {
     return false;
   }
+}
+
+function worktreeConfigMatchesRoot(gitDir: string, worktreeRoot: string): boolean {
+  const configWorktreePath = join(gitDir, 'config.worktree');
+  if (!existsSync(configWorktreePath)) {
+    return true;
+  }
+
+  const configuredWorktree = readCoreWorktree(configWorktreePath);
+  if (configuredWorktree === null) {
+    return true;
+  }
+
+  const resolvedConfiguredWorktree = isAbsolute(configuredWorktree)
+    ? configuredWorktree
+    : resolve(gitDir, configuredWorktree);
+
+  try {
+    return realpathSync(resolvedConfiguredWorktree) === realpathSync(worktreeRoot);
+  } catch {
+    return false;
+  }
+}
+
+function readCoreWorktree(configPath: string): string | null {
+  const content = readFileSync(configPath, 'utf-8');
+  let inCore = false;
+
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith('#') || trimmed.startsWith(';')) {
+      continue;
+    }
+    if (trimmed.startsWith('[')) {
+      inCore = /^\[core\]$/i.test(trimmed);
+      continue;
+    }
+    if (!inCore) {
+      continue;
+    }
+
+    const match = trimmed.match(/^worktree\s*=\s*(.*)$/i);
+    if (match) {
+      return unquoteGitConfigValue(match[1] ?? '');
+    }
+  }
+
+  return null;
+}
+
+function unquoteGitConfigValue(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
 }
 
 function resolveGitCwd(baseCwd: string, target: string): string | null {

--- a/src/core/worktree.ts
+++ b/src/core/worktree.ts
@@ -40,7 +40,12 @@ export function getGitExecutionContext(
     return { gitCwd: null, hasExplicitGitContext: false };
   }
 
-  let gitCwd = resolve(cwd);
+  let gitCwd: string;
+  try {
+    gitCwd = realpathSync(resolve(cwd));
+  } catch {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
   if (!isDirectory(gitCwd)) {
     return { gitCwd: null, hasExplicitGitContext: false };
   }
@@ -115,8 +120,8 @@ export function isLinkedWorktree(cwd: string): boolean {
   }
 
   try {
-    const stat = statSync(dotGitPath);
-    if (!stat.isFile()) {
+    const stat = lstatSync(dotGitPath);
+    if (stat.isSymbolicLink() || !stat.isFile()) {
       return false;
     }
 

--- a/src/core/worktree.ts
+++ b/src/core/worktree.ts
@@ -1,0 +1,169 @@
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+
+export const GIT_GLOBAL_OPTS_WITH_VALUE: ReadonlySet<string> = new Set([
+  '-c',
+  '-C',
+  '--git-dir',
+  '--work-tree',
+  '--namespace',
+  '--super-prefix',
+  '--config-env',
+]);
+
+const GIT_CONTEXT_ENV_OVERRIDES = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_COMMON_DIR'] as const;
+
+export interface GitExecutionContext {
+  gitCwd: string | null;
+  hasExplicitGitContext: boolean;
+}
+
+export function hasGitContextEnvOverride(envAssignments?: ReadonlyMap<string, string>): boolean {
+  for (const name of GIT_CONTEXT_ENV_OVERRIDES) {
+    if (envAssignments?.has(name) || Object.hasOwn(process.env, name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function getGitExecutionContext(
+  tokens: readonly string[],
+  cwd: string | undefined,
+): GitExecutionContext {
+  if (!cwd) {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
+
+  let gitCwd = resolve(cwd);
+  if (!isDirectory(gitCwd)) {
+    return { gitCwd: null, hasExplicitGitContext: false };
+  }
+
+  let hasExplicitGitContext = false;
+  let i = 1;
+
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (!token) break;
+
+    if (token === '--') {
+      break;
+    }
+
+    if (!token.startsWith('-')) {
+      break;
+    }
+
+    if (token === '-C') {
+      const target = tokens[i + 1];
+      if (!target) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      const resolvedCwd = resolveGitCwd(gitCwd, target);
+      if (!resolvedCwd) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      gitCwd = resolvedCwd;
+      i += 2;
+      continue;
+    }
+
+    if (token.startsWith('-C') && token.length > 2) {
+      const resolvedCwd = resolveGitCwd(gitCwd, token.slice(2));
+      if (!resolvedCwd) {
+        return { gitCwd: null, hasExplicitGitContext };
+      }
+      gitCwd = resolvedCwd;
+      i++;
+      continue;
+    }
+
+    if (token === '--git-dir' || token === '--work-tree') {
+      hasExplicitGitContext = true;
+      i += 2;
+      continue;
+    }
+
+    if (token.startsWith('--git-dir=') || token.startsWith('--work-tree=')) {
+      hasExplicitGitContext = true;
+      i++;
+      continue;
+    }
+
+    if (GIT_GLOBAL_OPTS_WITH_VALUE.has(token)) {
+      i += 2;
+    } else if (token.startsWith('-c') && token.length > 2) {
+      i++;
+    } else {
+      i++;
+    }
+  }
+
+  return { gitCwd, hasExplicitGitContext };
+}
+
+export function isLinkedWorktree(cwd: string): boolean {
+  const dotGitPath = findDotGit(cwd);
+  if (!dotGitPath) {
+    return false;
+  }
+
+  try {
+    const stat = statSync(dotGitPath);
+    if (!stat.isFile()) {
+      return false;
+    }
+
+    const content = readFileSync(dotGitPath, 'utf-8');
+    const firstLine = content.split(/\r?\n/, 1)[0]?.trim() ?? '';
+    if (!firstLine.startsWith('gitdir:')) {
+      return false;
+    }
+
+    const rawGitDir = firstLine.slice('gitdir:'.length).trim();
+    if (rawGitDir === '') {
+      return false;
+    }
+
+    const gitDir = isAbsolute(rawGitDir) ? rawGitDir : resolve(dirname(dotGitPath), rawGitDir);
+    return existsSync(join(gitDir, 'commondir'));
+  } catch {
+    return false;
+  }
+}
+
+function resolveGitCwd(baseCwd: string, target: string): string | null {
+  const resolved = isAbsolute(target) ? target : resolve(baseCwd, target);
+  return isDirectory(resolved) ? resolved : null;
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function findDotGit(cwd: string): string | null {
+  let current: string;
+  try {
+    current = realpathSync(cwd);
+  } catch {
+    return null;
+  }
+
+  while (true) {
+    const dotGitPath = join(current, '.git');
+    if (existsSync(dotGitPath)) {
+      return dotGitPath;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}

--- a/src/core/worktree.ts
+++ b/src/core/worktree.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 
 export const GIT_GLOBAL_OPTS_WITH_VALUE: ReadonlySet<string> = new Set([
@@ -11,7 +11,12 @@ export const GIT_GLOBAL_OPTS_WITH_VALUE: ReadonlySet<string> = new Set([
   '--config-env',
 ]);
 
-export const GIT_CONTEXT_ENV_OVERRIDES = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_COMMON_DIR'] as const;
+export const GIT_CONTEXT_ENV_OVERRIDES = [
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_COMMON_DIR',
+  'GIT_INDEX_FILE',
+] as const;
 
 export interface GitExecutionContext {
   gitCwd: string | null;
@@ -131,7 +136,31 @@ export function isLinkedWorktree(cwd: string): boolean {
       return false;
     }
 
+    if (!worktreeGitdirBacklinkMatches(gitDir, dotGitPath)) {
+      return false;
+    }
+
     return worktreeConfigMatchesRoot(gitDir, dirname(dotGitPath));
+  } catch {
+    return false;
+  }
+}
+
+function worktreeGitdirBacklinkMatches(gitDir: string, dotGitPath: string): boolean {
+  const backlinkPath = join(gitDir, 'gitdir');
+  if (!existsSync(backlinkPath)) {
+    return false;
+  }
+
+  const rawBacklink = readFileSync(backlinkPath, 'utf-8').split(/\r?\n/, 1)[0]?.trim() ?? '';
+  if (rawBacklink === '') {
+    return false;
+  }
+
+  const linkedDotGitPath = isAbsolute(rawBacklink) ? rawBacklink : resolve(gitDir, rawBacklink);
+
+  try {
+    return realpathSync(linkedDotGitPath) === realpathSync(dotGitPath);
   } catch {
     return false;
   }
@@ -162,6 +191,7 @@ function worktreeConfigMatchesRoot(gitDir: string, worktreeRoot: string): boolea
 function readCoreWorktree(configPath: string): string | null {
   const content = readFileSync(configPath, 'utf-8');
   let inCore = false;
+  let configuredWorktree: string | null = null;
 
   for (const line of content.split(/\r?\n/)) {
     const trimmed = line.trim();
@@ -178,11 +208,11 @@ function readCoreWorktree(configPath: string): string | null {
 
     const match = trimmed.match(/^worktree\s*=\s*(.*)$/i);
     if (match) {
-      return unquoteGitConfigValue(match[1] ?? '');
+      configuredWorktree = unquoteGitConfigValue(match[1] ?? '');
     }
   }
 
-  return null;
+  return configuredWorktree;
 }
 
 function unquoteGitConfigValue(value: string): string {
@@ -197,8 +227,33 @@ function unquoteGitConfigValue(value: string): string {
 }
 
 function resolveGitCwd(baseCwd: string, target: string): string | null {
-  const resolved = isAbsolute(target) ? target : resolve(baseCwd, target);
-  return isDirectory(resolved) ? resolved : null;
+  try {
+    const resolved = resolveChdirTarget(baseCwd, target);
+    return isDirectory(resolved) ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveChdirTarget(baseCwd: string, target: string): string {
+  let current = isAbsolute(target) ? '/' : baseCwd;
+  for (const component of target.split('/')) {
+    if (component === '' || component === '.') {
+      continue;
+    }
+    if (component === '..') {
+      current = dirname(current);
+      continue;
+    }
+
+    const candidate = appendPathWithoutNormalizing(current, component);
+    current = lstatSync(candidate).isSymbolicLink() ? realpathSync(candidate) : candidate;
+  }
+  return current;
+}
+
+function appendPathWithoutNormalizing(base: string, target: string): string {
+  return base.endsWith('/') ? `${base}${target}` : `${base}/${target}`;
 }
 
 function isDirectory(path: string): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export const SafetyNetPlugin: Plugin = async ({ directory }) => {
   const paranoidAll = envTruthy('SAFETY_NET_PARANOID');
   const paranoidRm = paranoidAll || envTruthy('SAFETY_NET_PARANOID_RM');
   const paranoidInterpreters = paranoidAll || envTruthy('SAFETY_NET_PARANOID_INTERPRETERS');
+  const worktreeMode = envTruthy('SAFETY_NET_WORKTREE');
 
   return {
     config: async (opencodeConfig: Record<string, unknown>) => {
@@ -31,6 +32,7 @@ export const SafetyNetPlugin: Plugin = async ({ directory }) => {
           strict,
           paranoidRm,
           paranoidInterpreters,
+          worktreeMode,
         });
         if (result) {
           const message = formatBlockedMessage({

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,8 @@ export interface AnalyzeOptions {
   paranoidRm?: boolean;
   /** Block interpreter one-liners */
   paranoidInterpreters?: boolean;
+  /** Allow local Git discard commands in linked worktrees */
+  worktreeMode?: boolean;
   /** Allow $TMPDIR paths (false when TMPDIR is overridden to non-temp) */
   allowTmpdirVar?: boolean;
 }
@@ -182,6 +184,7 @@ export type TraceStep =
       matched: boolean;
       reason?: string;
     }
+  | { type: 'worktree-relaxation'; originalReason: string; gitCwd: string }
   | {
       type: 'tmpdir-check';
       tmpdirValue: string | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,8 @@ export interface AnalyzeOptions {
   cwd?: string;
   /** Effective cwd after cd commands (null = unknown, undefined = use cwd) */
   effectiveCwd?: string | null;
+  /** Environment assignments inherited by nested command analysis */
+  envAssignments?: ReadonlyMap<string, string>;
   /** Loaded configuration */
   config?: Config;
   /** Fail-closed on unparseable commands */
@@ -120,6 +122,12 @@ export interface AnalyzeOptions {
   worktreeMode?: boolean;
   /** Allow $TMPDIR paths (false when TMPDIR is overridden to non-temp) */
   allowTmpdirVar?: boolean;
+}
+
+export interface AnalyzeNestedOverrides {
+  effectiveCwd?: string | null;
+  envAssignments?: ReadonlyMap<string, string>;
+  worktreeMode?: boolean;
 }
 
 /** Audit log entry */

--- a/tests/bin/cli-statusline.test.ts
+++ b/tests/bin/cli-statusline.test.ts
@@ -8,6 +8,7 @@ function clearEnv(): void {
   delete process.env.SAFETY_NET_PARANOID;
   delete process.env.SAFETY_NET_PARANOID_RM;
   delete process.env.SAFETY_NET_PARANOID_INTERPRETERS;
+  delete process.env.SAFETY_NET_WORKTREE;
   delete process.env.CLAUDE_SETTINGS_PATH;
 }
 
@@ -77,6 +78,20 @@ describe('--statusline flag', () => {
     const exitCode = await proc.exited;
 
     expect(output.trim()).toBe('🛡️ Safety Net 👁️');
+    expect(exitCode).toBe(0);
+  });
+
+  test('shows worktree emoji when SAFETY_NET_WORKTREE=1', async () => {
+    const proc = Bun.spawn(['bun', 'src/bin/cc-safety-net.ts', '--statusline'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env, CLAUDE_SETTINGS_PATH: enabledSettingsPath, SAFETY_NET_WORKTREE: '1' },
+    });
+
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    expect(output.trim()).toBe('🛡️ Safety Net 🌳');
     expect(exitCode).toBe(0);
   });
 

--- a/tests/bin/doctor/environment.test.ts
+++ b/tests/bin/doctor/environment.test.ts
@@ -14,6 +14,7 @@ describe('getEnvironmentInfo', () => {
     expect(names).toContain('SAFETY_NET_PARANOID');
     expect(names).toContain('SAFETY_NET_PARANOID_RM');
     expect(names).toContain('SAFETY_NET_PARANOID_INTERPRETERS');
+    expect(names).toContain('SAFETY_NET_WORKTREE');
   });
 
   test('each env var has required fields', () => {

--- a/tests/bin/explain/cli.test.ts
+++ b/tests/bin/explain/cli.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { createLinkedWorktreeFixture } from '../../helpers.ts';
 
 describe('explain CLI flag parsing', () => {
   test('explain preserves --debug in command when it appears after first positional arg', async () => {
@@ -122,6 +123,41 @@ describe('explain CLI flag parsing', () => {
       expect(exitCode).toBe(0);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('explain --json reports worktree relaxation', async () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      const proc = Bun.spawn(
+        [
+          'bun',
+          'src/bin/cc-safety-net.ts',
+          'explain',
+          '--json',
+          '--cwd',
+          fixture.linkedWorktree,
+          'git reset --hard',
+        ],
+        {
+          stdout: 'pipe',
+          stderr: 'pipe',
+          env: { ...process.env, SAFETY_NET_WORKTREE: '1' },
+        },
+      );
+
+      const output = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+
+      const parsed = JSON.parse(output);
+      const worktreeStep = parsed.trace.segments
+        .flatMap((s: { steps: Array<{ type: string }> }) => s.steps)
+        .find((s: { type: string }) => s.type === 'worktree-relaxation');
+      expect(parsed.result).toBe('allowed');
+      expect(worktreeStep).toBeDefined();
+      expect(exitCode).toBe(0);
+    } finally {
+      fixture.cleanup();
     }
   });
 

--- a/tests/bin/explain/command.test.ts
+++ b/tests/bin/explain/command.test.ts
@@ -654,6 +654,23 @@ describe('explainCommand worktree parity', () => {
     }
   });
 
+  test('carries nested exported git context overrides across inner segments', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const result = explainCommand(
+          `sh -c "export GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}; git reset --hard"`,
+          { cwd: fixture.linkedWorktree },
+        );
+
+        expect(result.result).toBe('blocked');
+        expect(result.reason).toContain('git reset --hard');
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('honors parallel nested overrides when explaining remote commands', () => {
     const fixture = createLinkedWorktreeFixture();
     try {

--- a/tests/bin/explain/command.test.ts
+++ b/tests/bin/explain/command.test.ts
@@ -11,6 +11,7 @@ import { explainSegment } from '@/bin/explain/segment';
 import { REASON_RECURSION_LIMIT } from '@/core/analyze/analyze-command';
 import type { TraceStep } from '@/types';
 import { MAX_RECURSION_DEPTH } from '@/types';
+import { createLinkedWorktreeFixture, toShellPath, withEnv } from '../../helpers.ts';
 
 describe('explainCommand', () => {
   test('git status returns allowed', () => {
@@ -581,6 +582,43 @@ describe('explainCommand fallback scan with find', () => {
     const allSteps = result.trace.segments.flatMap((s) => s.steps);
     const fallbackStep = allSteps.find((s) => s.type === 'fallback-scan');
     expect(fallbackStep).toBeDefined();
+  });
+});
+
+describe('explainCommand worktree parity', () => {
+  test('uses wrapper cwd when explaining worktree relaxation', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const result = explainCommand(
+          `env -C ${toShellPath(fixture.mainWorktree)} git reset --hard`,
+          { cwd: fixture.linkedWorktree },
+        );
+
+        expect(result.result).toBe('blocked');
+        expect(result.reason).toContain('git reset --hard');
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('does not report worktree relaxation for fallback embedded git', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const result = explainCommand('ssh host git clean -f', { cwd: fixture.linkedWorktree });
+        const worktreeStep = result.trace.segments
+          .flatMap((segment) => segment.steps)
+          .find((step) => step.type === 'worktree-relaxation');
+
+        expect(result.result).toBe('blocked');
+        expect(result.reason).toContain('git clean -f');
+        expect(worktreeStep).toBeUndefined();
+      });
+    } finally {
+      fixture.cleanup();
+    }
   });
 });
 

--- a/tests/bin/explain/command.test.ts
+++ b/tests/bin/explain/command.test.ts
@@ -603,6 +603,73 @@ describe('explainCommand worktree parity', () => {
     }
   });
 
+  test('carries exported git context overrides into later segments', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const result = explainCommand(
+          `export GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}; git reset --hard`,
+          { cwd: fixture.linkedWorktree },
+        );
+
+        expect(result.result).toBe('blocked');
+        expect(result.reason).toContain('git reset --hard');
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('passes wrapper cwd into recursive explain analysis', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const result = explainCommand(
+          `env -C ${toShellPath(fixture.mainWorktree)} sh -c "git reset --hard"`,
+          { cwd: fixture.linkedWorktree },
+        );
+
+        expect(result.result).toBe('blocked');
+        expect(result.reason).toContain('git reset --hard');
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('passes stripped env into recursive explain analysis', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const result = explainCommand(
+          `GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)} sh -c "git reset --hard"`,
+          { cwd: fixture.linkedWorktree },
+        );
+
+        expect(result.result).toBe('blocked');
+        expect(result.reason).toContain('git reset --hard');
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('honors parallel nested overrides when explaining remote commands', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const result = explainCommand('parallel -S host sh -c "git reset --hard" ::: x', {
+          cwd: fixture.linkedWorktree,
+        });
+
+        expect(result.result).toBe('blocked');
+        expect(result.reason).toContain('git reset --hard');
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('does not report worktree relaxation for fallback embedded git', () => {
     const fixture = createLinkedWorktreeFixture();
     try {

--- a/tests/bin/explain/command.test.ts
+++ b/tests/bin/explain/command.test.ts
@@ -671,6 +671,40 @@ describe('explainCommand worktree parity', () => {
     }
   });
 
+  test('includes keyword-export git context overrides in current segment', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const result = explainCommand(
+          `set -k; git restore file.txt GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}`,
+          { cwd: fixture.linkedWorktree },
+        );
+
+        expect(result.result).toBe('blocked');
+        expect(result.reason).toContain('git restore');
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('includes nested keyword-export git context overrides in current segment', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const result = explainCommand(
+          `sh -c "set -k; git restore file.txt GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}"`,
+          { cwd: fixture.linkedWorktree },
+        );
+
+        expect(result.result).toBe('blocked');
+        expect(result.reason).toContain('git restore');
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('honors parallel nested overrides when explaining remote commands', () => {
     const fixture = createLinkedWorktreeFixture();
     try {

--- a/tests/bin/explain/format.test.ts
+++ b/tests/bin/explain/format.test.ts
@@ -152,6 +152,28 @@ describe('formatTraceHuman step formatting', () => {
     expect(output).toContain('MATCHED');
   });
 
+  test('formats worktree relaxation step', () => {
+    const worktreeStep: TraceStep = {
+      type: 'worktree-relaxation',
+      originalReason: 'git reset --hard destroys uncommitted changes',
+      gitCwd: '/tmp/linked-worktree',
+    };
+    const mockResult: ExplainResult = {
+      trace: {
+        steps: [
+          { type: 'parse', input: 'git reset --hard', segments: [['git', 'reset', '--hard']] },
+        ],
+        segments: [{ index: 0, steps: [worktreeStep] }],
+      },
+      result: 'allowed',
+      configSource: null,
+      configValid: true,
+    };
+    const output = formatTraceHuman(mockResult);
+    expect(output).toContain('Worktree relaxation');
+    expect(output).toContain('SAFETY_NET_WORKTREE');
+  });
+
   test('tmpdir-check is an internal detail not shown in human output', () => {
     const result = explainCommand('rm -rf /tmp/test');
     const allSteps = result.trace.segments.flatMap((s) => s.steps);

--- a/tests/bin/explain/types.test.ts
+++ b/tests/bin/explain/types.test.ts
@@ -82,6 +82,15 @@ describe('TraceStep discriminated union', () => {
     expect(step.type).toBe('rule-check');
   });
 
+  test('worktree-relaxation step type compiles', () => {
+    const step: TraceStep = {
+      type: 'worktree-relaxation',
+      originalReason: 'git reset --hard destroys uncommitted changes',
+      gitCwd: '/tmp/repo-linked-worktree',
+    };
+    expect(step.type).toBe('worktree-relaxation');
+  });
+
   test('tmpdir-check step type compiles', () => {
     const step: TraceStep = {
       type: 'tmpdir-check',

--- a/tests/bin/help.test.ts
+++ b/tests/bin/help.test.ts
@@ -63,6 +63,7 @@ describe('help output', () => {
       expect(output).toContain('ENVIRONMENT VARIABLES:');
       expect(output).toContain('SAFETY_NET_STRICT');
       expect(output).toContain('SAFETY_NET_PARANOID');
+      expect(output).toContain('SAFETY_NET_WORKTREE');
     });
 
     test('contains CONFIG FILES section', () => {

--- a/tests/core/analyze/analyze-coverage.test.ts
+++ b/tests/core/analyze/analyze-coverage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { homedir } from 'node:os';
 import { analyzeCommand } from '@/core/analyze';
 import type { Config } from '@/types';
+import { createLinkedWorktreeFixture, toShellPath, withEnv } from '../../helpers.ts';
 
 const EMPTY_CONFIG: Config = { version: 1, rules: [] };
 
@@ -159,6 +160,175 @@ describe('analyzeCommand (coverage)', () => {
         config: EMPTY_CONFIG,
       }),
     ).toBeNull();
+  });
+
+  describe('shell git context env state branches', () => {
+    test('command -- export target is tracked across segments', () => {
+      const fixture = createLinkedWorktreeFixture();
+      try {
+        withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+          const result = analyzeCommand(
+            `command -- export GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}; git reset --hard`,
+            {
+              cwd: fixture.linkedWorktree,
+              config: EMPTY_CONFIG,
+              worktreeMode: true,
+            },
+          );
+          expect(result?.reason).toContain('git reset --hard');
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    test('command inspection with no executable target leaves later git context unchanged', () => {
+      const fixture = createLinkedWorktreeFixture();
+      try {
+        withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+          expect(
+            analyzeCommand(
+              `command -v export; GIT_WORK_TREE=${toShellPath(
+                fixture.mainWorktree,
+              )}; git reset --hard`,
+              {
+                cwd: fixture.linkedWorktree,
+                config: EMPTY_CONFIG,
+                worktreeMode: true,
+              },
+            ),
+          ).toBeNull();
+          expect(
+            analyzeCommand('command; git reset --hard', {
+              cwd: fixture.linkedWorktree,
+              config: EMPTY_CONFIG,
+              worktreeMode: true,
+            }),
+          ).toBeNull();
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    test('export option parsing tracks only valid export operands', () => {
+      const fixture = createLinkedWorktreeFixture();
+      try {
+        withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+          expect(
+            analyzeCommand(
+              `export -z GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}; git reset --hard`,
+              {
+                cwd: fixture.linkedWorktree,
+                config: EMPTY_CONFIG,
+                worktreeMode: true,
+              },
+            ),
+          ).toBeNull();
+
+          const result = analyzeCommand(
+            `export -- GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}; git reset --hard`,
+            {
+              cwd: fixture.linkedWorktree,
+              config: EMPTY_CONFIG,
+              worktreeMode: true,
+            },
+          );
+          expect(result?.reason).toContain('git reset --hard');
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    test('exporting an unset tracked name uses an empty effective value', () => {
+      const fixture = createLinkedWorktreeFixture();
+      try {
+        withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+          const result = analyzeCommand('export GIT_WORK_TREE; git reset --hard', {
+            cwd: fixture.linkedWorktree,
+            config: EMPTY_CONFIG,
+            worktreeMode: true,
+          });
+          expect(result?.reason).toContain('git reset --hard');
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    test('typeset and readonly forms update tracked env state only when exported', () => {
+      const fixture = createLinkedWorktreeFixture();
+      try {
+        withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+          const mainWorktree = toShellPath(fixture.mainWorktree);
+          const blockedCommands = [
+            `typeset -x GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            `declare -x GIT_WORK_TREE; GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            `export GIT_WORK_TREE; typeset GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            `GIT_WORK_TREE=${mainWorktree} readonly GIT_WORK_TREE; git reset --hard`,
+          ];
+
+          for (const command of blockedCommands) {
+            const result = analyzeCommand(command, {
+              cwd: fixture.linkedWorktree,
+              config: EMPTY_CONFIG,
+              worktreeMode: true,
+            });
+            expect(result?.reason).toContain('git reset --hard');
+          }
+
+          for (const command of [
+            `typeset -- -x GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            `declare -x; GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+          ]) {
+            expect(
+              analyzeCommand(command, {
+                cwd: fixture.linkedWorktree,
+                config: EMPTY_CONFIG,
+                worktreeMode: true,
+              }),
+            ).toBeNull();
+          }
+
+          expect(
+            analyzeCommand(`typeset +x GIT_WORK_TREE=${mainWorktree}; git reset --hard`, {
+              cwd: fixture.linkedWorktree,
+              config: EMPTY_CONFIG,
+              worktreeMode: true,
+            }),
+          ).toBeNull();
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    test('set option parsing toggles exported assignment behavior', () => {
+      const fixture = createLinkedWorktreeFixture();
+      try {
+        withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+          const mainWorktree = toShellPath(fixture.mainWorktree);
+          const allowedCommands = [
+            `set -k; set +k; git restore file.txt GIT_WORK_TREE=${mainWorktree}`,
+            `set positional; GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            `set --; GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+          ];
+
+          for (const command of allowedCommands) {
+            expect(
+              analyzeCommand(command, {
+                cwd: fixture.linkedWorktree,
+                config: EMPTY_CONFIG,
+                worktreeMode: true,
+              }),
+            ).toBeNull();
+          }
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    });
   });
 
   describe('parallel parsing/analysis branches', () => {

--- a/tests/core/analyze/edge-cases.test.ts
+++ b/tests/core/analyze/edge-cases.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { assertAllowed, assertBlocked, runGuard, withEnv } from '../../helpers.ts';
@@ -419,6 +419,19 @@ describe('edge cases', () => {
       assertAllowed('echo ok | xargs rm -- -rf', tempDir);
     });
 
+    test('xargs rm uses wrapper cwd when checking relative targets', () => {
+      const projectDir = join(tempDir, 'project');
+      const otherDir = join(tempDir, 'other');
+      mkdirSync(projectDir);
+      mkdirSync(otherDir);
+
+      assertBlocked(
+        `echo ok | xargs env -C ${otherDir} rm -rf build`,
+        'rm -rf outside cwd',
+        projectDir,
+      );
+    });
+
     test('xargs bash c dynamic denied', () => {
       assertBlocked("echo 'rm -rf /' | xargs bash -c", 'xargs');
     });
@@ -523,6 +536,19 @@ describe('edge cases', () => {
 
     test('parallel rm rf with safe replacement allowed', () => {
       assertAllowed('parallel rm -rf {} ::: build', tempDir);
+    });
+
+    test('parallel rm uses wrapper cwd when checking relative replacements', () => {
+      const projectDir = join(tempDir, 'project');
+      const otherDir = join(tempDir, 'other');
+      mkdirSync(projectDir);
+      mkdirSync(otherDir);
+
+      assertBlocked(
+        `parallel env -C ${otherDir} rm -rf {} ::: build`,
+        'rm -rf outside cwd',
+        projectDir,
+      );
     });
 
     test('parallel bash c rm rf with safe replacement allowed', () => {

--- a/tests/core/analyze/edge-cases.test.ts
+++ b/tests/core/analyze/edge-cases.test.ts
@@ -2,7 +2,14 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { assertAllowed, assertBlocked, runGuard, toShellPath, withEnv } from '../../helpers.ts';
+import {
+  assertAllowed,
+  assertBlocked,
+  createLinkedWorktreeFixture,
+  runGuard,
+  toShellPath,
+  withEnv,
+} from '../../helpers.ts';
 
 describe('edge cases', () => {
   let tempDir: string;
@@ -569,6 +576,55 @@ describe('edge cases', () => {
 
     test('parallel busybox rm rf args after marker without placeholder blocked', () => {
       assertBlocked('parallel busybox rm -rf ::: /', 'root or home');
+    });
+
+    test('parallel attached sshlogin disables worktree relaxation', () => {
+      const fixture = createLinkedWorktreeFixture();
+      try {
+        withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+          assertBlocked(
+            'parallel -Shost git reset --hard ::: x',
+            'git reset --hard',
+            fixture.linkedWorktree,
+          );
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    test('parallel long remote options disable worktree relaxation', () => {
+      const fixture = createLinkedWorktreeFixture();
+      try {
+        withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+          const commands = [
+            'parallel --sshlogin=host git clean -f ::: .',
+            'parallel --slf=hosts.txt git clean -f ::: .',
+            'parallel --sshloginfile=hosts.txt git clean -f ::: .',
+          ];
+
+          for (const command of commands) {
+            assertBlocked(command, 'git clean -f', fixture.linkedWorktree);
+          }
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    });
+
+    test('parallel placeholder git arguments disable worktree relaxation', () => {
+      const fixture = createLinkedWorktreeFixture();
+      try {
+        withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+          assertBlocked(
+            'parallel git reset --hard {} ::: HEAD~1',
+            'git reset --hard',
+            fixture.linkedWorktree,
+          );
+        });
+      } finally {
+        fixture.cleanup();
+      }
     });
   });
 

--- a/tests/core/analyze/edge-cases.test.ts
+++ b/tests/core/analyze/edge-cases.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { assertAllowed, assertBlocked, runGuard, withEnv } from '../../helpers.ts';
+import { assertAllowed, assertBlocked, runGuard, toShellPath, withEnv } from '../../helpers.ts';
 
 describe('edge cases', () => {
   let tempDir: string;
@@ -426,7 +426,7 @@ describe('edge cases', () => {
       mkdirSync(otherDir);
 
       assertBlocked(
-        `echo ok | xargs env -C ${otherDir} rm -rf build`,
+        `echo ok | xargs env -C ${toShellPath(otherDir)} rm -rf build`,
         'rm -rf outside cwd',
         projectDir,
       );
@@ -545,7 +545,7 @@ describe('edge cases', () => {
       mkdirSync(otherDir);
 
       assertBlocked(
-        `parallel env -C ${otherDir} rm -rf {} ::: build`,
+        `parallel env -C ${toShellPath(otherDir)} rm -rf {} ::: build`,
         'rm -rf outside cwd',
         projectDir,
       );

--- a/tests/core/analyze/parsing-helpers.test.ts
+++ b/tests/core/analyze/parsing-helpers.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import { realpathSync } from 'node:fs';
 import {
   _extractParallelChildCommand,
   _extractXargsChildCommand,
@@ -17,6 +18,7 @@ import { extractDashCArg } from '@/core/analyze/shell-wrappers';
 import { _extractGitSubcommandAndRest, _getCheckoutPositionalArgs } from '@/core/rules-git';
 import { extractShortOpts, splitShellCommands, stripWrappersWithInfo } from '@/core/shell';
 import { MAX_STRIP_ITERATIONS } from '@/types';
+import { createLinkedWorktreeFixture } from '../../helpers.ts';
 
 describe('shell parsing helpers', () => {
   describe('extractDashCArg', () => {
@@ -471,6 +473,23 @@ describe('shell parsing helpers', () => {
       const result = stripWrappersWithInfo(['env', '-C=/tmp', 'rm', '-rf']);
       expect(result.tokens).toEqual(['rm', '-rf']);
     });
+
+    test.skipIf(process.platform !== 'win32')(
+      'resolves wrapper cwd with Windows separators',
+      () => {
+        const fixture = createLinkedWorktreeFixture();
+        try {
+          const result = stripWrappersWithInfo(
+            ['env', '-C', fixture.mainWorktree, '-C', '..\\linked', 'git', 'status'],
+            fixture.rootDir,
+          );
+          expect(result.tokens).toEqual(['git', 'status']);
+          expect(result.cwd).toBe(realpathSync(fixture.linkedWorktree));
+        } finally {
+          fixture.cleanup();
+        }
+      },
+    );
 
     test('strips command -pv and -- separator', () => {
       const result = stripWrappersWithInfo(['command', '-pv', '--', 'git', 'status']);

--- a/tests/core/analyze/parsing-helpers.test.ts
+++ b/tests/core/analyze/parsing-helpers.test.ts
@@ -212,6 +212,13 @@ describe('shell parsing helpers', () => {
       ]);
     });
 
+    test('marks attached command substitution after git as dynamic', () => {
+      expect(splitShellCommands('git reset --hard$(printf HEAD~1)')).toEqual([
+        ['printf', 'HEAD~1'],
+        ['git', 'reset', '--hard', '$__CC_SAFETY_NET_DYNAMIC_SUBSTITUTION__'],
+      ]);
+    });
+
     test('drops glob redirect targets instead of treating them as args', () => {
       expect(splitShellCommands('echo > *.log')).toEqual([['echo']]);
     });
@@ -472,6 +479,24 @@ describe('shell parsing helpers', () => {
     test('strips env -C=...', () => {
       const result = stripWrappersWithInfo(['env', '-C=/tmp', 'rm', '-rf']);
       expect(result.tokens).toEqual(['rm', '-rf']);
+    });
+
+    test('invalid env -S split string makes cwd unknown', () => {
+      const result = stripWrappersWithInfo(['env', '-S', '"unterminated', 'git', 'status'], '/tmp');
+      expect(result.tokens).toEqual(['git', 'status']);
+      expect(result.cwd).toBeNull();
+    });
+
+    test('empty env chdir target makes cwd unknown', () => {
+      const result = stripWrappersWithInfo(['env', '-C', '', 'git', 'status'], '/tmp');
+      expect(result.tokens).toEqual(['git', 'status']);
+      expect(result.cwd).toBeNull();
+    });
+
+    test('relative env chdir target with unknown cwd remains unknown', () => {
+      const result = stripWrappersWithInfo(['env', '-C', 'relative', 'git', 'status'], null);
+      expect(result.tokens).toEqual(['git', 'status']);
+      expect(result.cwd).toBeNull();
     });
 
     test.skipIf(process.platform !== 'win32')(

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { execFileSync } from 'node:child_process';
 import { chmodSync, existsSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { analyzeGit } from '@/core/rules-git';
+import { _TRUSTED_GIT_BINARIES, analyzeGit } from '@/core/rules-git';
 import {
   assertAllowed,
   assertBlocked,
@@ -16,6 +16,12 @@ import {
 describe('analyzeGit direct', () => {
   test('empty tokens returns null', () => {
     expect(analyzeGit([])).toBeNull();
+  });
+
+  test('trusted git binaries cover common absolute install paths', () => {
+    expect(_TRUSTED_GIT_BINARIES).toContain('/usr/bin/git');
+    expect(_TRUSTED_GIT_BINARIES).toContain('/usr/local/bin/git');
+    expect(_TRUSTED_GIT_BINARIES).toContain('/opt/homebrew/bin/git');
   });
 });
 

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -1311,7 +1311,7 @@ describe('git linked worktree mode', () => {
     chmodSync(fakeGit, 0o755);
     try {
       withEnv({ SAFETY_NET_WORKTREE: '1', PATH: fakeBin }, () => {
-        runGuard('git reset --hard', fixture.linkedWorktree);
+        expect(runGuard('git reset --hard', fixture.linkedWorktree)).toBeNull();
       });
       expect(existsSync(marker)).toBe(false);
     } finally {

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, symlinkSync } from 'node:fs';
+import { join } from 'node:path';
 import { analyzeGit } from '@/core/rules-git';
-import { assertAllowed, assertBlocked } from '../helpers.ts';
+import {
+  assertAllowed,
+  assertBlocked,
+  createLinkedWorktreeFixture,
+  createSubmoduleLikeGitFileFixture,
+  runGuard,
+  toShellPath,
+  withEnv,
+} from '../helpers.ts';
 
 describe('analyzeGit direct', () => {
   test('empty tokens returns null', () => {
@@ -421,6 +432,209 @@ describe('git clean', () => {
 
   test('git clean -nd allowed', () => {
     assertAllowed('git clean -nd');
+  });
+});
+
+describe('git linked worktree mode', () => {
+  test('default mode still blocks local discard commands in linked worktrees', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      assertBlocked('git reset --hard', 'git reset --hard', fixture.linkedWorktree);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE allows local discard commands in linked worktrees', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const commands = [
+          'git restore file.txt',
+          'git restore --worktree file.txt',
+          'git checkout -- file.txt',
+          'git checkout HEAD -- file.txt',
+          'git checkout --force main',
+          'git checkout --pathspec-from-file paths.txt',
+          'git checkout main file.txt',
+          'git switch --discard-changes main',
+          'git switch -f main',
+          'git reset --hard',
+          'git reset --merge',
+          'git clean -f',
+          'git clean -fd',
+        ];
+
+        for (const command of commands) {
+          expect(runGuard(command, fixture.linkedWorktree)).toBeNull();
+        }
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax main worktree commands', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('git reset --hard', 'git reset --hard', fixture.mainWorktree);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax main worktree subdirectories', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const subdir = join(fixture.mainWorktree, 'nested');
+    mkdirSync(subdir);
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('git clean -f', 'git clean -f', subdir);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax submodule-like git file directories', () => {
+    const fixture = createSubmoduleLikeGitFileFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('git reset --hard', 'git reset --hard', fixture.cwd);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE allows symlinked cwd inside linked worktree', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const nested = join(fixture.linkedWorktree, 'nested');
+    const symlinkedCwd = join(fixture.rootDir, 'nested-link');
+    mkdirSync(nested);
+    symlinkSync(nested, symlinkedCwd, 'dir');
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertAllowed('git reset --hard', symlinkedCwd);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE allows nested linked worktrees', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const nestedWorktree = join(fixture.linkedWorktree, 'inner-worktree');
+    execFileSync('git', ['worktree', 'add', '-b', 'feature/nested-worktree-test', nestedWorktree], {
+      cwd: fixture.mainWorktree,
+      stdio: 'ignore',
+    });
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertAllowed('git reset --hard', nestedWorktree);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE honors git -C linked worktree directories', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertAllowed(
+          `git -C ${toShellPath(fixture.linkedWorktree)} reset --hard`,
+          fixture.mainWorktree,
+        );
+        assertAllowed(
+          `git -C${toShellPath(fixture.linkedWorktree)} clean -f`,
+          fixture.mainWorktree,
+        );
+        assertAllowed(
+          `git -C ${toShellPath(fixture.mainWorktree)} -C ../linked reset --merge`,
+          fixture.rootDir,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax unresolved git -C directories', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `git -C ${toShellPath(join(fixture.rootDir, 'missing'))} reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax after cwd becomes unknown', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('cd /tmp && git reset --hard', 'git reset --hard', fixture.linkedWorktree);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax explicit git context overrides', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          'git --git-dir=.git reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked('git --work-tree=. reset --hard', 'git reset --hard', fixture.linkedWorktree);
+        assertBlocked('GIT_DIR=.git git reset --hard', 'git reset --hard', fixture.linkedWorktree);
+        assertBlocked(
+          'GIT_WORK_TREE=. git reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          'GIT_COMMON_DIR=.git git reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE keeps shared and remote destructive rules blocked', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('git push -f', 'push --force', fixture.linkedWorktree);
+        assertBlocked(
+          'git branch -D feature/worktree-test',
+          'git branch -D',
+          fixture.linkedWorktree,
+        );
+        assertBlocked('git stash clear', 'git stash clear', fixture.linkedWorktree);
+        assertBlocked(
+          'git worktree remove --force ../other-worktree',
+          'git worktree remove --force',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
   });
 });
 

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -615,6 +615,104 @@ describe('git linked worktree mode', () => {
     }
   });
 
+  test('SAFETY_NET_WORKTREE does not relax cwd-changing wrappers into main worktree', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `env -C ${toShellPath(fixture.mainWorktree)} git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax xargs child git env overrides', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `echo HEAD | xargs env GIT_DIR=${toShellPath(join(fixture.mainWorktree, '.git'))} GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)} git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax parallel child git env overrides', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `parallel env GIT_DIR=${toShellPath(join(fixture.mainWorktree, '.git'))} GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)} git reset --hard ::: x`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax shell wrapper git env overrides', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `GIT_DIR=${toShellPath(join(fixture.mainWorktree, '.git'))} GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)} sh -c 'git reset --hard'`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax fallback embedded git commands', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('ssh host git clean -f', 'git clean -f', fixture.linkedWorktree);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax remote parallel git commands', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          'parallel -S host git clean -f ::: .',
+          'git clean -f',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE keeps ref-moving resets blocked', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('git reset --hard HEAD~1', 'git reset --hard', fixture.linkedWorktree);
+        assertBlocked('git reset --merge HEAD~1', 'git reset --merge', fixture.linkedWorktree);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('SAFETY_NET_WORKTREE keeps shared and remote destructive rules blocked', () => {
     const fixture = createLinkedWorktreeFixture();
     try {

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -1176,6 +1176,51 @@ describe('git linked worktree mode', () => {
     }
   });
 
+  test('SAFETY_NET_WORKTREE allows disabled recursive submodule config', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        expect(runGuard('git -c submodule.recurse=false clean -f', fixture.linkedWorktree)).toBe(
+          null,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE fails closed on malformed recursive config env', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          'GIT_CONFIG_COUNT=not-a-number git reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          'GIT_CONFIG_SYSTEM=/tmp/missing-gitconfig git reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE fails closed on local include config', () => {
+    const fixture = createLinkedWorktreeFixture();
+    writeFileSync(join(fixture.mainWorktree, '.git', 'config'), '[include]\n\tpath = extra.conf\n');
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('git reset --hard', 'git reset --hard', fixture.linkedWorktree);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('SAFETY_NET_WORKTREE honors recursive submodule config-env values', () => {
     const fixture = createLinkedWorktreeFixture();
     try {

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -630,6 +630,61 @@ describe('git linked worktree mode', () => {
     }
   });
 
+  test('SAFETY_NET_WORKTREE keeps env chdir context through terminators and attached args', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `env -C ${toShellPath(fixture.mainWorktree)} -- git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          `env -C${toShellPath(fixture.mainWorktree)} git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE parses env split strings before relaxing', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `env -S '-C ${toShellPath(fixture.mainWorktree)}' git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          `env -S 'GIT_DIR=${toShellPath(join(fixture.mainWorktree, '.git'))} GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}' git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE tracks sudo chdir before relaxing', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `sudo -D ${toShellPath(fixture.mainWorktree)} git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('SAFETY_NET_WORKTREE does not relax xargs child git env overrides', () => {
     const fixture = createLinkedWorktreeFixture();
     try {
@@ -651,6 +706,61 @@ describe('git linked worktree mode', () => {
       withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
         assertBlocked(
           `parallel env GIT_DIR=${toShellPath(join(fixture.mainWorktree, '.git'))} GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)} git reset --hard ::: x`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE propagates wrapper context through parallel commands mode', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `env -C ${toShellPath(fixture.mainWorktree)} parallel ::: 'git reset --hard'`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          `GIT_DIR=${toShellPath(join(fixture.mainWorktree, '.git'))} GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)} parallel ::: 'git reset --hard'`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE propagates wrapper context through BusyBox', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `env -C ${toShellPath(fixture.mainWorktree)} busybox sh -c 'git reset --hard'`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          `GIT_DIR=${toShellPath(join(fixture.mainWorktree, '.git'))} GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)} busybox sh -c 'git reset --hard'`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax exported git context overrides', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `export GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}; git reset --hard`,
           'git reset --hard',
           fixture.linkedWorktree,
         );
@@ -707,6 +817,41 @@ describe('git linked worktree mode', () => {
       withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
         assertBlocked('git reset --hard HEAD~1', 'git reset --hard', fixture.linkedWorktree);
         assertBlocked('git reset --merge HEAD~1', 'git reset --merge', fixture.linkedWorktree);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE keeps xargs and parallel appended reset refs blocked', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          'echo HEAD~1 | xargs git reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          'parallel git reset --hard ::: HEAD~1',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE propagates interpreter wrapper context', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)} ruby -e '\`git restore file.txt\`'`,
+          'git restore',
+          fixture.linkedWorktree,
+        );
       });
     } finally {
       fixture.cleanup();

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -1091,6 +1091,21 @@ describe('git linked worktree mode', () => {
             fixture.linkedWorktree,
           );
           assertBlocked(
+            `HOME=${toShellPath(recurseHome)}; git reset --hard`,
+            'git reset --hard',
+            fixture.linkedWorktree,
+          );
+          assertBlocked(
+            `HOME+=${toShellPath(recurseHome)} git reset --hard`,
+            'git reset --hard',
+            fixture.linkedWorktree,
+          );
+          assertBlocked(
+            `export HOME+=${toShellPath(recurseHome)}; git reset --hard`,
+            'git reset --hard',
+            fixture.linkedWorktree,
+          );
+          assertBlocked(
             `GIT_CONFIG_PARAMETERS="'submodule.recurse=true'" git reset --hard`,
             'git reset --hard',
             fixture.linkedWorktree,

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -1091,6 +1091,107 @@ describe('git linked worktree mode', () => {
     }
   });
 
+  test('SAFETY_NET_WORKTREE fails closed on dynamic worktree relaxation bypasses', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const mainWorktree = toShellPath(fixture.mainWorktree);
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const commands = [
+          {
+            command: 'echo -ffdx | xargs -I{} git clean -f {}',
+            reason: 'git clean -f',
+          },
+          {
+            command: 'EXTRA=-ffdx; git clean -f $EXTRA',
+            reason: 'git clean -f',
+          },
+          {
+            command: "printf -- '-ffdx\\n' | parallel sh -c 'git clean -f {}'",
+            reason: 'git clean -f',
+          },
+          {
+            command:
+              'GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=submodule.recurse GIT_CONFIG_VALUE_0=true git reset --hard',
+            reason: 'git reset --hard',
+          },
+          {
+            command: `export -p GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            reason: 'git reset --hard',
+          },
+          {
+            command: `readonly -x GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            reason: 'git reset --hard',
+          },
+          {
+            command: `command -p export GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            reason: 'git reset --hard',
+          },
+          {
+            command: 'git checkout -fB feature HEAD~1',
+            reason: 'git checkout --force',
+          },
+          {
+            command: 'git switch --discard-changes -C feature HEAD~1',
+            reason: 'git switch --discard-changes',
+          },
+          {
+            command: 'git switch --discard-changes --force-create feature HEAD~1',
+            reason: 'git switch --discard-changes',
+          },
+          {
+            command: 'git switch -fC feature HEAD~1',
+            reason: 'git switch --force',
+          },
+          {
+            command: `set -k; git restore file.txt GIT_WORK_TREE=${mainWorktree}`,
+            reason: 'git restore',
+          },
+          {
+            command: `set -o keyword; git restore file.txt GIT_WORK_TREE=${mainWorktree}`,
+            reason: 'git restore',
+          },
+          {
+            command: `set -a; set -- +a; GIT_WORK_TREE=${mainWorktree}; git restore file.txt`,
+            reason: 'git restore',
+          },
+          {
+            command: `set +a -a; GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            reason: 'git reset --hard',
+          },
+          {
+            command: `typeset +x -x GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            reason: 'git reset --hard',
+          },
+        ];
+
+        const failures = commands.flatMap(({ command, reason }) => {
+          const result = runGuard(command, fixture.linkedWorktree);
+          return result?.includes(reason) ? [] : [{ command, result }];
+        });
+
+        expect(failures).toEqual([]);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE keeps configured recursive submodule discards blocked', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      execFileSync('git', ['config', 'submodule.recurse', 'true'], {
+        cwd: fixture.linkedWorktree,
+        stdio: 'ignore',
+      });
+
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('git reset --hard', 'git reset --hard', fixture.linkedWorktree);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('SAFETY_NET_WORKTREE verifies worktree config before relaxing', () => {
     const fixture = createLinkedWorktreeFixture();
     try {

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -7,6 +7,7 @@ import {
   _extractGitSubcommandAndRest,
   _TRUSTED_GIT_BINARIES,
   analyzeGit,
+  getGitWorktreeRelaxation,
 } from '@/core/rules-git';
 import {
   assertAllowed,
@@ -44,6 +45,23 @@ describe('analyzeGit direct', () => {
       subcommand: 'reset',
       rest: ['--hard'],
     });
+  });
+
+  test('classifies reset --hard before -- as local discard', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      expect(
+        getGitWorktreeRelaxation(['git', 'reset', '--hard', '--'], {
+          cwd: fixture.linkedWorktree,
+          worktreeMode: true,
+        }),
+      ).toEqual({
+        originalReason: expect.stringContaining('git reset --hard'),
+        gitCwd: expect.any(String),
+      });
+    } finally {
+      fixture.cleanup();
+    }
   });
 });
 

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -679,6 +679,11 @@ describe('git linked worktree mode', () => {
           'git reset --hard',
           fixture.linkedWorktree,
         );
+        assertBlocked(
+          `sudo --chdir=${toShellPath(fixture.mainWorktree)} git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
       });
     } finally {
       fixture.cleanup();
@@ -764,6 +769,21 @@ describe('git linked worktree mode', () => {
           'git reset --hard',
           fixture.linkedWorktree,
         );
+        assertBlocked(
+          `GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}; export GIT_WORK_TREE; git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          `export -- GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}; git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          `typeset -x GIT_WORK_TREE=${toShellPath(fixture.mainWorktree)}; git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
       });
     } finally {
       fixture.cleanup();
@@ -837,6 +857,73 @@ describe('git linked worktree mode', () => {
           'git reset --hard',
           fixture.linkedWorktree,
         );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not relax git context append assignments', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `GIT_WORK_TREE+=${toShellPath(fixture.mainWorktree)} git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE keeps recursive submodule discards blocked', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          'git reset --hard --recurse-submodules',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          'git checkout --force --recurse-submodules main',
+          'git checkout --force',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE keeps double-force clean blocked', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('git clean -ffdx', 'git clean -f', fixture.linkedWorktree);
+        assertBlocked('git clean -f --force', 'git clean -f', fixture.linkedWorktree);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE verifies worktree config before relaxing', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      execFileSync('git', ['config', 'extensions.worktreeConfig', 'true'], {
+        cwd: fixture.mainWorktree,
+        stdio: 'ignore',
+      });
+      execFileSync('git', ['config', '--worktree', 'core.worktree', fixture.mainWorktree], {
+        cwd: fixture.linkedWorktree,
+        stdio: 'ignore',
+      });
+
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('git reset --hard', 'git reset --hard', fixture.linkedWorktree);
       });
     } finally {
       fixture.cleanup();

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from 'bun:test';
 import { execFileSync } from 'node:child_process';
 import { chmodSync, existsSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { _TRUSTED_GIT_BINARIES, analyzeGit } from '@/core/rules-git';
+import {
+  _effectiveGitConfigEnablesRecursiveSubmodules,
+  _TRUSTED_GIT_BINARIES,
+  analyzeGit,
+} from '@/core/rules-git';
 import {
   assertAllowed,
   assertBlocked,
@@ -22,6 +26,8 @@ describe('analyzeGit direct', () => {
     expect(_TRUSTED_GIT_BINARIES).toContain('/usr/bin/git');
     expect(_TRUSTED_GIT_BINARIES).toContain('/usr/local/bin/git');
     expect(_TRUSTED_GIT_BINARIES).toContain('/opt/homebrew/bin/git');
+    expect(_TRUSTED_GIT_BINARIES).toContain('C:\\Program Files\\Git\\cmd\\git.exe');
+    expect(_TRUSTED_GIT_BINARIES).toContain('C:\\Program Files\\Git\\bin\\git.exe');
   });
 });
 
@@ -1320,6 +1326,17 @@ describe('git linked worktree mode', () => {
         expect(runGuard('git reset --hard', fixture.linkedWorktree)).toBeNull();
       });
       expect(existsSync(marker)).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE treats missing trusted git binary as recursive submodule config', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      expect(_effectiveGitConfigEnablesRecursiveSubmodules(fixture.linkedWorktree, null)).toBe(
+        true,
+      );
     } finally {
       fixture.cleanup();
     }

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -615,6 +615,75 @@ describe('git linked worktree mode', () => {
     }
   });
 
+  test('SAFETY_NET_WORKTREE treats GIT_INDEX_FILE as a git context override', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `GIT_INDEX_FILE=${toShellPath(join(fixture.mainWorktree, '.git', 'index'))} git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE tracks shell-exported git context overrides', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const mainWorktree = toShellPath(fixture.mainWorktree);
+    const mainGitDir = toShellPath(join(fixture.mainWorktree, '.git'));
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        const commands = [
+          `declare GIT_WORK_TREE=${mainWorktree}; export GIT_WORK_TREE; git reset --hard`,
+          `typeset GIT_WORK_TREE=${mainWorktree}; export GIT_WORK_TREE; git reset --hard`,
+          `declare -- GIT_WORK_TREE=${mainWorktree}; export GIT_WORK_TREE; git reset --hard`,
+          `declare GIT_WORK_TREE=${mainWorktree}; declare -x GIT_WORK_TREE; git reset --hard`,
+          `declare -x GIT_WORK_TREE; GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+          `export GIT_WORK_TREE; GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+          `builtin export GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+          `command export GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+          `set -a; GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+          `set -o allexport; GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+          `export GIT_WORK_TREE+=${mainWorktree}; git reset --hard`,
+          `declare -x GIT_WORK_TREE+=${mainWorktree}; git reset --hard`,
+          `GIT_DIR=${mainGitDir} GIT_WORK_TREE=${mainWorktree} export GIT_DIR GIT_WORK_TREE; git reset --hard`,
+        ];
+
+        for (const command of commands) {
+          assertBlocked(command, 'git reset --hard', fixture.linkedWorktree);
+        }
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE honors disabled allexport before later assignments', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const mainWorktree = toShellPath(fixture.mainWorktree);
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        expect(
+          runGuard(
+            `set -a; set +a; GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            fixture.linkedWorktree,
+          ),
+        ).toBeNull();
+        expect(
+          runGuard(
+            `set -o allexport; set +o allexport; GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            fixture.linkedWorktree,
+          ),
+        ).toBeNull();
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('SAFETY_NET_WORKTREE does not relax cwd-changing wrappers into main worktree', () => {
     const fixture = createLinkedWorktreeFixture();
     try {
@@ -641,6 +710,30 @@ describe('git linked worktree mode', () => {
         );
         assertBlocked(
           `env -C${toShellPath(fixture.mainWorktree)} git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE resolves wrapper chdir targets physically', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const mainSubdir = join(fixture.mainWorktree, 'subdir');
+    const symlinkedMainSubdir = join(fixture.linkedWorktree, 'link');
+    mkdirSync(mainSubdir);
+    symlinkSync(mainSubdir, symlinkedMainSubdir, 'dir');
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          'env -C link/.. git reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          'sudo -D link/.. git reset --hard',
           'git reset --hard',
           fixture.linkedWorktree,
         );
@@ -684,6 +777,22 @@ describe('git linked worktree mode', () => {
           'git reset --hard',
           fixture.linkedWorktree,
         );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE tracks attached sudo chdir and sudo login cwd', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          `sudo -D${toShellPath(fixture.mainWorktree)} git reset --hard`,
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked('sudo -i git reset --hard', 'git reset --hard', fixture.linkedWorktree);
       });
     } finally {
       fixture.cleanup();
@@ -863,6 +972,38 @@ describe('git linked worktree mode', () => {
     }
   });
 
+  test('SAFETY_NET_WORKTREE fails closed on dynamic xargs git arguments', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('echo --force | xargs git clean -f', 'git clean -f', fixture.linkedWorktree);
+        assertBlocked(
+          'echo --recurse-submodules | xargs git checkout --force main',
+          'git checkout --force',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE fails closed on dynamic parallel git arguments', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          "printf 'HEAD~1\\n' | parallel git reset --hard",
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked('parallel git clean -f {} ::: -ffdx', 'git clean -f', fixture.linkedWorktree);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('SAFETY_NET_WORKTREE does not relax git context append assignments', () => {
     const fixture = createLinkedWorktreeFixture();
     try {
@@ -890,6 +1031,46 @@ describe('git linked worktree mode', () => {
         assertBlocked(
           'git checkout --force --recurse-submodules main',
           'git checkout --force',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE keeps recursive submodule config discards blocked', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          'git -c submodule.recurse=true reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          'git -csubmodule.recurse=true checkout --force main',
+          'git checkout --force',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE keeps forced branch resets blocked', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          'git checkout -f -B feature HEAD~1',
+          'git checkout --force',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          'git switch -f -C feature HEAD~1',
+          'git switch --force',
           fixture.linkedWorktree,
         );
       });

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, symlinkSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { analyzeGit } from '@/core/rules-git';
 import {
@@ -524,6 +524,22 @@ describe('git linked worktree mode', () => {
     }
   });
 
+  test('SAFETY_NET_WORKTREE uses physical cwd for wrapper chdir targets', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const mainSubdir = join(fixture.mainWorktree, 'subdir');
+    const symlinkedMainSubdir = join(fixture.linkedWorktree, 'main-subdir-link');
+    mkdirSync(mainSubdir);
+    symlinkSync(mainSubdir, symlinkedMainSubdir, 'dir');
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked('env -C .. git reset --hard', 'git reset --hard', symlinkedMainSubdir);
+        assertBlocked('sudo -D .. git reset --hard', 'git reset --hard', symlinkedMainSubdir);
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('SAFETY_NET_WORKTREE allows nested linked worktrees', () => {
     const fixture = createLinkedWorktreeFixture();
     const nestedWorktree = join(fixture.linkedWorktree, 'inner-worktree');
@@ -1033,6 +1049,11 @@ describe('git linked worktree mode', () => {
           'git checkout --force',
           fixture.linkedWorktree,
         );
+        assertBlocked(
+          'git reset --hard --recurse-submodule',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
       });
     } finally {
       fixture.cleanup();
@@ -1041,7 +1062,42 @@ describe('git linked worktree mode', () => {
 
   test('SAFETY_NET_WORKTREE keeps recursive submodule config discards blocked', () => {
     const fixture = createLinkedWorktreeFixture();
+    const safeHome = join(fixture.rootDir, 'safe-home');
+    const safeXdg = join(fixture.rootDir, 'safe-xdg');
+    const recurseHome = join(fixture.rootDir, 'recurse-home');
+    const recurseConfig = join(fixture.rootDir, 'recurse.conf');
+    mkdirSync(safeHome);
+    mkdirSync(safeXdg);
+    mkdirSync(recurseHome);
+    writeFileSync(join(recurseHome, '.gitconfig'), '[submodule]\n\trecurse = true\n');
+    writeFileSync(recurseConfig, '[submodule]\n\trecurse = true\n');
     try {
+      withEnv(
+        {
+          SAFETY_NET_WORKTREE: '1',
+          GIT_CONFIG_NOSYSTEM: '1',
+          HOME: safeHome,
+          XDG_CONFIG_HOME: safeXdg,
+        },
+        () => {
+          assertBlocked(
+            `git -c include.path=${toShellPath(recurseConfig)} reset --hard`,
+            'git reset --hard',
+            fixture.linkedWorktree,
+          );
+          assertBlocked(
+            `HOME=${toShellPath(recurseHome)} git reset --hard`,
+            'git reset --hard',
+            fixture.linkedWorktree,
+          );
+          assertBlocked(
+            `GIT_CONFIG_PARAMETERS="'submodule.recurse=true'" git reset --hard`,
+            'git reset --hard',
+            fixture.linkedWorktree,
+          );
+        },
+      );
+
       withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
         assertBlocked(
           'git -c submodule.recurse=true reset --hard',
@@ -1071,6 +1127,11 @@ describe('git linked worktree mode', () => {
         assertBlocked(
           'git switch -f -C feature HEAD~1',
           'git switch --force',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          'git switch --discard-changes --force-creat feature HEAD~1',
+          'git switch --discard-changes',
           fixture.linkedWorktree,
         );
       });
@@ -1106,6 +1167,18 @@ describe('git linked worktree mode', () => {
             reason: 'git clean -f',
           },
           {
+            command: 'git clean -f *',
+            reason: 'git clean -f',
+          },
+          {
+            command: 'git reset --hard $(printf HEAD~1)',
+            reason: 'git reset --hard',
+          },
+          {
+            command: 'git clean -f `printf -- -ffdx`',
+            reason: 'git clean -f',
+          },
+          {
             command: "printf -- '-ffdx\\n' | parallel sh -c 'git clean -f {}'",
             reason: 'git clean -f',
           },
@@ -1115,7 +1188,24 @@ describe('git linked worktree mode', () => {
             reason: 'git reset --hard',
           },
           {
+            command:
+              'export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=submodule.recurse GIT_CONFIG_VALUE_0=true; git reset --hard',
+            reason: 'git reset --hard',
+          },
+          {
+            command: `GIT_WORK_TREE=${mainWorktree} readonly GIT_WORK_TREE; git reset --hard`,
+            reason: 'git reset --hard',
+          },
+          {
             command: `export -p GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            reason: 'git reset --hard',
+          },
+          {
+            command: `builtin -- export GIT_WORK_TREE=${mainWorktree}; git reset --hard`,
+            reason: 'git reset --hard',
+          },
+          {
+            command: `read GIT_WORK_TREE <<< ${mainWorktree}; export GIT_WORK_TREE; git reset --hard`,
             reason: 'git reset --hard',
           },
           {
@@ -1171,6 +1261,44 @@ describe('git linked worktree mode', () => {
 
         expect(failures).toEqual([]);
       });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE disables relaxation for numbered parallel placeholders', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          "parallel sh -c 'git clean -f {2}' ::: x ::: -ffdx",
+          'git clean -f',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          'parallel git clean -f {2} ::: x ::: -ffdx',
+          'git clean -f',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE does not execute git from PATH while checking config', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const fakeBin = join(fixture.rootDir, 'fake-bin');
+    const fakeGit = join(fakeBin, 'git');
+    const marker = join(fixture.rootDir, 'fake-git-executed');
+    mkdirSync(fakeBin);
+    writeFileSync(fakeGit, `#!/bin/sh\nprintf executed > "${marker}"\nexit 1\n`);
+    chmodSync(fakeGit, 0o755);
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1', PATH: fakeBin }, () => {
+        runGuard('git reset --hard', fixture.linkedWorktree);
+      });
+      expect(existsSync(marker)).toBe(false);
     } finally {
       fixture.cleanup();
     }

--- a/tests/core/rules-git.test.ts
+++ b/tests/core/rules-git.test.ts
@@ -4,6 +4,7 @@ import { chmodSync, existsSync, mkdirSync, symlinkSync, writeFileSync } from 'no
 import { join } from 'node:path';
 import {
   _effectiveGitConfigEnablesRecursiveSubmodules,
+  _extractGitSubcommandAndRest,
   _TRUSTED_GIT_BINARIES,
   analyzeGit,
 } from '@/core/rules-git';
@@ -28,6 +29,21 @@ describe('analyzeGit direct', () => {
     expect(_TRUSTED_GIT_BINARIES).toContain('/opt/homebrew/bin/git');
     expect(_TRUSTED_GIT_BINARIES).toContain('C:\\Program Files\\Git\\cmd\\git.exe');
     expect(_TRUSTED_GIT_BINARIES).toContain('C:\\Program Files\\Git\\bin\\git.exe');
+  });
+
+  test('extracts subcommand after global config-env option', () => {
+    expect(
+      _extractGitSubcommandAndRest([
+        'git',
+        '--config-env',
+        'submodule.recurse=RECURSE_SUBMODULES',
+        'reset',
+        '--hard',
+      ]),
+    ).toEqual({
+      subcommand: 'reset',
+      rest: ['--hard'],
+    });
   });
 });
 
@@ -1134,6 +1150,68 @@ describe('git linked worktree mode', () => {
         assertBlocked(
           'git -csubmodule.recurse=true checkout --force main',
           'git checkout --force',
+          fixture.linkedWorktree,
+        );
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE honors recursive submodule config-env values', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1', RECURSE_SUBMODULES: 'true' }, () => {
+        assertBlocked(
+          'git --config-env submodule.recurse=RECURSE_SUBMODULES reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+
+      withEnv({ SAFETY_NET_WORKTREE: '1', RECURSE_SUBMODULES: '1' }, () => {
+        assertBlocked(
+          'git --config-env=submodule.recurse=RECURSE_SUBMODULES reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+
+      withEnv({ SAFETY_NET_WORKTREE: '1' }, () => {
+        assertBlocked(
+          'git --config-env submodule.recurse=MISSING_RECURSE_SUBMODULES reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+      });
+
+      for (const value of ['false', 'no', 'off', '0']) {
+        withEnv({ SAFETY_NET_WORKTREE: '1', RECURSE_SUBMODULES: value }, () => {
+          expect(
+            runGuard(
+              'git --config-env submodule.recurse=RECURSE_SUBMODULES reset --hard',
+              fixture.linkedWorktree,
+            ),
+          ).toBeNull();
+        });
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('SAFETY_NET_WORKTREE fails closed on include config-env values', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      withEnv({ SAFETY_NET_WORKTREE: '1', INCLUDE_PATH: '.gitconfig-extra' }, () => {
+        assertBlocked(
+          'git --config-env include.path=INCLUDE_PATH reset --hard',
+          'git reset --hard',
+          fixture.linkedWorktree,
+        );
+        assertBlocked(
+          'git --config-env=includeIf.gitdir:./.path=INCLUDE_PATH reset --hard',
+          'git reset --hard',
           fixture.linkedWorktree,
         );
       });

--- a/tests/core/worktree.test.ts
+++ b/tests/core/worktree.test.ts
@@ -67,6 +67,26 @@ describe('worktree git execution context', () => {
     }
   });
 
+  test.skipIf(process.platform !== 'win32')(
+    'resolves git -C targets with Windows separators',
+    () => {
+      const fixture = createLinkedWorktreeFixture();
+      try {
+        expect(
+          getGitExecutionContext(
+            ['git', '-C', fixture.mainWorktree, '-C', '..\\linked', 'status'],
+            fixture.rootDir,
+          ),
+        ).toEqual({
+          gitCwd: realpathSync(fixture.linkedWorktree),
+          hasExplicitGitContext: false,
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
   test('resolves git -C targets with physical chdir semantics', () => {
     const fixture = createLinkedWorktreeFixture();
     const mainSubdir = join(fixture.mainWorktree, 'subdir');

--- a/tests/core/worktree.test.ts
+++ b/tests/core/worktree.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  getGitExecutionContext,
+  hasGitContextEnvOverride,
+  isLinkedWorktree,
+} from '@/core/worktree';
+import {
+  createLinkedWorktreeFixture,
+  createSubmoduleLikeGitFileFixture,
+  withEnv,
+} from '../helpers.ts';
+
+describe('worktree git execution context', () => {
+  test('handles missing and invalid cwd', () => {
+    expect(getGitExecutionContext(['git', 'status'], undefined)).toEqual({
+      gitCwd: null,
+      hasExplicitGitContext: false,
+    });
+    expect(getGitExecutionContext(['git', 'status'], '/path/that/does/not/exist')).toEqual({
+      gitCwd: null,
+      hasExplicitGitContext: false,
+    });
+  });
+
+  test('resolves separate and attached git -C options in order', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      expect(
+        getGitExecutionContext(
+          ['git', '-C', fixture.mainWorktree, '-C', '../linked', 'status'],
+          fixture.rootDir,
+        ),
+      ).toEqual({
+        gitCwd: fixture.linkedWorktree,
+        hasExplicitGitContext: false,
+      });
+
+      expect(
+        getGitExecutionContext(
+          ['git', `-C${fixture.mainWorktree}`, '-C../linked', 'status'],
+          fixture.rootDir,
+        ),
+      ).toEqual({
+        gitCwd: fixture.linkedWorktree,
+        hasExplicitGitContext: false,
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('fails closed for missing or unresolved git -C targets', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      expect(getGitExecutionContext(['git', '-C'], fixture.rootDir).gitCwd).toBeNull();
+      expect(
+        getGitExecutionContext(['git', `-C${join(fixture.rootDir, 'missing')}`], fixture.rootDir)
+          .gitCwd,
+      ).toBeNull();
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('detects explicit git context overrides in arguments', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      expect(
+        getGitExecutionContext(['git', '--git-dir', '.git', 'status'], fixture.linkedWorktree)
+          .hasExplicitGitContext,
+      ).toBe(true);
+      expect(
+        getGitExecutionContext(['git', '--work-tree=.', 'status'], fixture.linkedWorktree)
+          .hasExplicitGitContext,
+      ).toBe(true);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('skips other git global options before the subcommand', () => {
+    const fixture = createLinkedWorktreeFixture();
+    try {
+      expect(
+        getGitExecutionContext(
+          ['git', '-c', 'foo=bar', '--namespace', 'ns', '-cfoo=baz', '--no-pager', 'status'],
+          fixture.linkedWorktree,
+        ),
+      ).toEqual({
+        gitCwd: fixture.linkedWorktree,
+        hasExplicitGitContext: false,
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe('worktree env context overrides', () => {
+  test('detects command scoped and process scoped git env overrides', () => {
+    expect(hasGitContextEnvOverride(new Map([['GIT_DIR', '.git']]))).toBe(true);
+    expect(hasGitContextEnvOverride(new Map([['OTHER', '1']]))).toBe(false);
+
+    withEnv({ GIT_WORK_TREE: '.' }, () => {
+      expect(hasGitContextEnvOverride()).toBe(true);
+    });
+  });
+});
+
+describe('linked worktree detection', () => {
+  test('detects linked worktrees and symlinked directories inside them', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const nested = join(fixture.linkedWorktree, 'nested');
+    const symlinkedCwd = join(fixture.rootDir, 'nested-link');
+    mkdirSync(nested);
+    symlinkSync(nested, symlinkedCwd, 'dir');
+    try {
+      expect(isLinkedWorktree(fixture.linkedWorktree)).toBe(true);
+      expect(isLinkedWorktree(symlinkedCwd)).toBe(true);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('rejects main worktrees, non-repos, and submodule-like git files', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const fakeSubmodule = createSubmoduleLikeGitFileFixture();
+    const tempDir = mkdtempSync(join(tmpdir(), 'safety-net-worktree-unit-'));
+    try {
+      expect(isLinkedWorktree(fixture.mainWorktree)).toBe(false);
+      expect(isLinkedWorktree(tempDir)).toBe(false);
+      expect(isLinkedWorktree(fakeSubmodule.cwd)).toBe(false);
+      expect(isLinkedWorktree(join(tempDir, 'missing'))).toBe(false);
+    } finally {
+      fixture.cleanup();
+      fakeSubmodule.cleanup();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects malformed git files', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'safety-net-worktree-malformed-'));
+    const badGitdir = join(tempDir, 'bad-gitdir');
+    const emptyGitdir = join(tempDir, 'empty-gitdir');
+    mkdirSync(badGitdir);
+    mkdirSync(emptyGitdir);
+    writeFileSync(join(badGitdir, '.git'), 'not a gitdir file\n');
+    writeFileSync(join(emptyGitdir, '.git'), 'gitdir:\n');
+    try {
+      expect(isLinkedWorktree(badGitdir)).toBe(false);
+      expect(isLinkedWorktree(emptyGitdir)).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/core/worktree.test.ts
+++ b/tests/core/worktree.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
 import {
   mkdirSync,
   mkdtempSync,
@@ -11,6 +12,7 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import {
+  _parseGitConfigValue,
   getGitExecutionContext,
   hasGitContextEnvOverride,
   isLinkedWorktree,
@@ -181,6 +183,16 @@ describe('worktree env context overrides', () => {
 });
 
 describe('linked worktree detection', () => {
+  test('parses double-quoted git config escapes', () => {
+    expect(_parseGitConfigValue('"/tmp/with \\"quotes\\""')).toBe('/tmp/with "quotes"');
+    expect(_parseGitConfigValue('"/tmp/backslash\\\\path"')).toBe('/tmp/backslash\\path');
+    expect(_parseGitConfigValue('"line\\nfeed\\ttab\\bbackspace"')).toBe(
+      'line\nfeed\ttab\bbackspace',
+    );
+    expect(_parseGitConfigValue('"unknown\\xpath"')).toBe('unknown\\xpath');
+    expect(_parseGitConfigValue("'/tmp/single'")).toBe("'/tmp/single'");
+  });
+
   test('normalizes Windows native realpath prefixes for comparison', () => {
     expect(normalizePathForComparison('\\\\?\\C:\\Temp\\Linked\\.git\\')).toBe(
       process.platform === 'win32' ? 'c:/temp/linked/.git' : 'C:/Temp/Linked/.git',
@@ -266,6 +278,44 @@ describe('linked worktree detection', () => {
     writeFileSync(
       join(gitDir, 'config.worktree'),
       `[core]\n\tworktree = ${fixture.linkedWorktree}\n\tworktree = ${fixture.mainWorktree}\n`,
+    );
+    try {
+      expect(isLinkedWorktree(fixture.linkedWorktree)).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test.skipIf(process.platform === 'win32')(
+    'accepts double-quoted escaped core.worktree values',
+    () => {
+      const fixture = createLinkedWorktreeFixture();
+      const quotedWorktree = join(fixture.rootDir, 'linked"quoted');
+      execFileSync(
+        'git',
+        ['worktree', 'add', '-b', 'feature/quoted-worktree-test', quotedWorktree],
+        {
+          cwd: fixture.mainWorktree,
+          stdio: 'ignore',
+        },
+      );
+      const gitDir = getLinkedGitDir(quotedWorktree);
+      const escapedWorktree = quotedWorktree.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      writeFileSync(join(gitDir, 'config.worktree'), `[core]\n\tworktree = "${escapedWorktree}"\n`);
+      try {
+        expect(isLinkedWorktree(quotedWorktree)).toBe(true);
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  test('treats single-quoted core.worktree values as literal paths', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const gitDir = getLinkedGitDir(fixture.linkedWorktree);
+    writeFileSync(
+      join(gitDir, 'config.worktree'),
+      `[core]\n\tworktree = '${fixture.linkedWorktree}'\n`,
     );
     try {
       expect(isLinkedWorktree(fixture.linkedWorktree)).toBe(false);

--- a/tests/core/worktree.test.ts
+++ b/tests/core/worktree.test.ts
@@ -266,6 +266,40 @@ describe('linked worktree detection', () => {
     }
   });
 
+  test('rejects worktree gitdirs with missing or empty backlinks', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const missingBacklinkRoot = join(fixture.rootDir, 'missing-backlink-root');
+    const emptyBacklinkRoot = join(fixture.rootDir, 'empty-backlink-root');
+    const missingBacklinkGitDir = join(fixture.rootDir, 'missing-backlink-gitdir');
+    const emptyBacklinkGitDir = join(fixture.rootDir, 'empty-backlink-gitdir');
+    mkdirSync(missingBacklinkRoot);
+    mkdirSync(emptyBacklinkRoot);
+    mkdirSync(missingBacklinkGitDir);
+    mkdirSync(emptyBacklinkGitDir);
+    writeFileSync(join(missingBacklinkRoot, '.git'), `gitdir: ${missingBacklinkGitDir}\n`);
+    writeFileSync(join(emptyBacklinkRoot, '.git'), `gitdir: ${emptyBacklinkGitDir}\n`);
+    writeFileSync(join(missingBacklinkGitDir, 'commondir'), '../main/.git\n');
+    writeFileSync(join(emptyBacklinkGitDir, 'commondir'), '../main/.git\n');
+    writeFileSync(join(emptyBacklinkGitDir, 'gitdir'), '\n');
+    try {
+      expect(isLinkedWorktree(missingBacklinkRoot)).toBe(false);
+      expect(isLinkedWorktree(emptyBacklinkRoot)).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('accepts unparsable core.worktree config as conservative fallback', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const gitDir = getLinkedGitDir(fixture.linkedWorktree);
+    writeFileSync(join(gitDir, 'config.worktree'), '[core\n\tworktree =');
+    try {
+      expect(isLinkedWorktree(fixture.linkedWorktree)).toBe(true);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('rejects symlinked gitdir files', () => {
     const fixture = createLinkedWorktreeFixture();
     const symlinkedRoot = join(fixture.rootDir, 'symlinked-root');

--- a/tests/core/worktree.test.ts
+++ b/tests/core/worktree.test.ts
@@ -85,6 +85,22 @@ describe('worktree git execution context', () => {
     }
   });
 
+  test('resolves git -C targets from a physical starting cwd', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const mainSubdir = join(fixture.mainWorktree, 'subdir');
+    const symlinkedMainSubdir = join(fixture.linkedWorktree, 'main-subdir-link');
+    mkdirSync(mainSubdir);
+    symlinkSync(mainSubdir, symlinkedMainSubdir, 'dir');
+    try {
+      expect(getGitExecutionContext(['git', '-C', '..', 'status'], symlinkedMainSubdir)).toEqual({
+        gitCwd: realpathSync(fixture.mainWorktree),
+        hasExplicitGitContext: false,
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   test('fails closed for missing or unresolved git -C targets', () => {
     const fixture = createLinkedWorktreeFixture();
     try {
@@ -123,7 +139,7 @@ describe('worktree git execution context', () => {
           fixture.linkedWorktree,
         ),
       ).toEqual({
-        gitCwd: fixture.linkedWorktree,
+        gitCwd: realpathSync(fixture.linkedWorktree),
         hasExplicitGitContext: false,
       });
     } finally {
@@ -197,6 +213,18 @@ describe('linked worktree detection', () => {
     writeFileSync(join(copiedRoot, '.git'), readFileSync(join(fixture.linkedWorktree, '.git')));
     try {
       expect(isLinkedWorktree(copiedRoot)).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('rejects symlinked gitdir files', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const symlinkedRoot = join(fixture.rootDir, 'symlinked-root');
+    mkdirSync(symlinkedRoot);
+    symlinkSync(join(fixture.linkedWorktree, '.git'), join(symlinkedRoot, '.git'));
+    try {
+      expect(isLinkedWorktree(symlinkedRoot)).toBe(false);
     } finally {
       fixture.cleanup();
     }

--- a/tests/core/worktree.test.ts
+++ b/tests/core/worktree.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import {
   getGitExecutionContext,
   hasGitContextEnvOverride,
@@ -12,6 +20,13 @@ import {
   createSubmoduleLikeGitFileFixture,
   withEnv,
 } from '../helpers.ts';
+
+function getLinkedGitDir(worktree: string): string {
+  const dotGitPath = join(worktree, '.git');
+  const firstLine = readFileSync(dotGitPath, 'utf-8').split(/\r?\n/, 1)[0] ?? '';
+  const rawGitDir = firstLine.slice('gitdir:'.length).trim();
+  return isAbsolute(rawGitDir) ? rawGitDir : resolve(dirname(dotGitPath), rawGitDir);
+}
 
 describe('worktree git execution context', () => {
   test('handles missing and invalid cwd', () => {
@@ -34,7 +49,7 @@ describe('worktree git execution context', () => {
           fixture.rootDir,
         ),
       ).toEqual({
-        gitCwd: fixture.linkedWorktree,
+        gitCwd: realpathSync(fixture.linkedWorktree),
         hasExplicitGitContext: false,
       });
 
@@ -44,7 +59,25 @@ describe('worktree git execution context', () => {
           fixture.rootDir,
         ),
       ).toEqual({
-        gitCwd: fixture.linkedWorktree,
+        gitCwd: realpathSync(fixture.linkedWorktree),
+        hasExplicitGitContext: false,
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('resolves git -C targets with physical chdir semantics', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const mainSubdir = join(fixture.mainWorktree, 'subdir');
+    const symlinkedMainSubdir = join(fixture.linkedWorktree, 'link');
+    mkdirSync(mainSubdir);
+    symlinkSync(mainSubdir, symlinkedMainSubdir, 'dir');
+    try {
+      expect(
+        getGitExecutionContext(['git', '-C', 'link/..', 'status'], fixture.linkedWorktree),
+      ).toEqual({
+        gitCwd: realpathSync(fixture.mainWorktree),
         hasExplicitGitContext: false,
       });
     } finally {
@@ -154,6 +187,32 @@ describe('linked worktree detection', () => {
       expect(isLinkedWorktree(emptyGitdir)).toBe(false);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects copied gitdir files whose backlink points at another worktree', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const copiedRoot = join(fixture.rootDir, 'copied-root');
+    mkdirSync(copiedRoot);
+    writeFileSync(join(copiedRoot, '.git'), readFileSync(join(fixture.linkedWorktree, '.git')));
+    try {
+      expect(isLinkedWorktree(copiedRoot)).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('uses the last core.worktree value from worktree config', () => {
+    const fixture = createLinkedWorktreeFixture();
+    const gitDir = getLinkedGitDir(fixture.linkedWorktree);
+    writeFileSync(
+      join(gitDir, 'config.worktree'),
+      `[core]\n\tworktree = ${fixture.linkedWorktree}\n\tworktree = ${fixture.mainWorktree}\n`,
+    );
+    try {
+      expect(isLinkedWorktree(fixture.linkedWorktree)).toBe(false);
+    } finally {
+      fixture.cleanup();
     }
   });
 });

--- a/tests/core/worktree.test.ts
+++ b/tests/core/worktree.test.ts
@@ -126,12 +126,18 @@ describe('worktree git execution context', () => {
 
   test('fails closed for missing or unresolved git -C targets', () => {
     const fixture = createLinkedWorktreeFixture();
+    const fileTarget = join(fixture.rootDir, 'not-a-directory');
+    writeFileSync(fileTarget, '');
     try {
       expect(getGitExecutionContext(['git', '-C'], fixture.rootDir).gitCwd).toBeNull();
       expect(
         getGitExecutionContext(['git', `-C${join(fixture.rootDir, 'missing')}`], fixture.rootDir)
           .gitCwd,
       ).toBeNull();
+      expect(getGitExecutionContext(['git', '-C', fileTarget, 'status'], fixture.rootDir)).toEqual({
+        gitCwd: null,
+        hasExplicitGitContext: false,
+      });
     } finally {
       fixture.cleanup();
     }

--- a/tests/core/worktree.test.ts
+++ b/tests/core/worktree.test.ts
@@ -14,6 +14,7 @@ import {
   getGitExecutionContext,
   hasGitContextEnvOverride,
   isLinkedWorktree,
+  normalizePathForComparison,
 } from '@/core/worktree';
 import {
   createLinkedWorktreeFixture,
@@ -180,6 +181,15 @@ describe('worktree env context overrides', () => {
 });
 
 describe('linked worktree detection', () => {
+  test('normalizes Windows native realpath prefixes for comparison', () => {
+    expect(normalizePathForComparison('\\\\?\\C:\\Temp\\Linked\\.git\\')).toBe(
+      process.platform === 'win32' ? 'c:/temp/linked/.git' : 'C:/Temp/Linked/.git',
+    );
+    expect(normalizePathForComparison('\\\\?\\UNC\\server\\share\\linked\\.git')).toBe(
+      '//server/share/linked/.git',
+    );
+  });
+
   test('detects linked worktrees and symlinked directories inside them', () => {
     const fixture = createLinkedWorktreeFixture();
     const nested = join(fixture.linkedWorktree, 'nested');

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,13 +1,13 @@
 import { expect } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { VersionFetcher } from '@/bin/doctor/system-info';
 import { analyzeCommand } from '@/core/analyze';
 import { loadConfig } from '@/core/config';
+import { envTruthy } from '@/core/env';
 import type { AnalyzeOptions, Config } from '@/types';
-
-function envTruthy(name: string): boolean {
-  const val = process.env[name];
-  return val === '1' || val === 'true' || val === 'yes';
-}
 
 // Default empty config for tests that don't specify a cwd
 // This prevents loading the project's .safety-net.json
@@ -23,6 +23,7 @@ function getOptionsFromEnv(cwd?: string, config?: Config): AnalyzeOptions {
     paranoidRm: envTruthy('SAFETY_NET_PARANOID') || envTruthy('SAFETY_NET_PARANOID_RM'),
     paranoidInterpreters:
       envTruthy('SAFETY_NET_PARANOID') || envTruthy('SAFETY_NET_PARANOID_INTERPRETERS'),
+    worktreeMode: envTruthy('SAFETY_NET_WORKTREE'),
   };
 }
 
@@ -94,4 +95,63 @@ export const mockVersionFetcher: VersionFetcher = async (args: string[]) => {
  */
 export function toShellPath(p: string): string {
   return p.replace(/\\/g, '/');
+}
+
+export interface LinkedWorktreeFixture {
+  rootDir: string;
+  mainWorktree: string;
+  linkedWorktree: string;
+  cleanup: () => void;
+}
+
+function runGit(args: readonly string[], cwd: string): void {
+  execFileSync('git', [...args], { cwd, stdio: 'ignore' });
+}
+
+export function createLinkedWorktreeFixture(): LinkedWorktreeFixture {
+  const rootDir = mkdtempSync(join(tmpdir(), 'safety-net-worktree-'));
+  const mainWorktree = join(rootDir, 'main');
+  const linkedWorktree = join(rootDir, 'linked');
+
+  mkdirSync(mainWorktree);
+  runGit(['init'], mainWorktree);
+  runGit(['config', 'user.email', 'safety-net@example.test'], mainWorktree);
+  runGit(['config', 'user.name', 'Safety Net Test'], mainWorktree);
+  writeFileSync(join(mainWorktree, 'file.txt'), 'initial\n');
+  runGit(['add', 'file.txt'], mainWorktree);
+  runGit(['commit', '-m', 'initial'], mainWorktree);
+  runGit(['worktree', 'add', '-b', 'feature/worktree-test', linkedWorktree], mainWorktree);
+
+  return {
+    rootDir,
+    mainWorktree,
+    linkedWorktree,
+    cleanup: () => {
+      rmSync(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+export interface FakeGitFileFixture {
+  rootDir: string;
+  cwd: string;
+  cleanup: () => void;
+}
+
+export function createSubmoduleLikeGitFileFixture(): FakeGitFileFixture {
+  const rootDir = mkdtempSync(join(tmpdir(), 'safety-net-submodule-like-'));
+  const cwd = join(rootDir, 'submodule');
+  const gitDir = join(rootDir, '.git', 'modules', 'submodule');
+
+  mkdirSync(cwd, { recursive: true });
+  mkdirSync(gitDir, { recursive: true });
+  writeFileSync(join(cwd, '.git'), 'gitdir: ../.git/modules/submodule\n');
+
+  return {
+    rootDir,
+    cwd,
+    cleanup: () => {
+      rmSync(rootDir, { recursive: true, force: true });
+    },
+  };
 }


### PR DESCRIPTION
## Summary

- Adds **Worktree Mode** (`SAFETY_NET_WORKTREE=1`): relaxes local-discard git rules (restore, checkout --, reset --hard, clean -f, switch --force) when the cwd is a verified linked worktree, since linked worktrees are designed as disposable, isolated workspaces.
- Implements **comprehensive safety hardening** to prevent bypass: environment propagation through shell wrappers / interpreters / `xargs` / `parallel` / BusyBox, fail-closed on dynamic arguments, recursive submodules, forced branch resets, `--git-dir`/`--work-tree` overrides, and git config-affecting env vars.
- New `src/core/worktree.ts` module for filesystem-based linked worktree detection with gitdir backlink verification, `config.worktree` validation, inode-based path comparison, and symlink-safe `realpath` resolution.

## Changes

### New Module: `src/core/worktree.ts` (+335 lines)
- Linked worktree detection via `.git` file → `gitdir:` → `commondir` chain
- Gitdir backlink verification (rejects copied/symlinked `.git` files)
- `config.worktree` validation against actual worktree root
- `git -C` chained resolution with symlink-safe `realpath`
- Inode-based path comparison with normalized `realpath` fallback
- Windows native realpath prefix normalization (`\\?\`, `\\?\UNC\`)
- Platform-aware path separator handling

### Core Analysis Enhancements
- **`src/core/rules-git.ts`** (+608 lines): Worktree relaxation logic with fail-closed hardening:
  - `getGitWorktreeRelaxation()` — determines if a blocked git command should be relaxed
  - `isNonRelaxableLocalDiscard()` — checks for dynamic arguments, recursive submodules, double-force clean, forced branch resets
  - `hasRecursiveSubmoduleConfig()` — reads local git config files before invoking git binary; checks `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_*`/`GIT_CONFIG_VALUE_*` env vars and `--config-env`
  - `effectiveGitConfigEnablesRecursiveSubmodules()` — invokes trusted git binary (`/usr/bin/git`, `/usr/local/bin/git`) with sanitized env
  - Commands that reach beyond the local worktree remain blocked (push --force, branch -D, stash drop/clear)

- **`src/core/analyze/analyze-command.ts`** (+445 lines): Shell git context environment tracking:
  - `ShellGitContextEnvState` — tracks exported names, `set -a` (allexport), keyword export mode
  - `applyShellGitContextEnvSegment()` — handles `export`, `typeset`, `declare`, `readonly`, `builtin`, `command` builtins
  - `getSegmentGitContextEnvAssignments()` — computes per-segment env assignments from accumulated shell state
  - Append assignments (`NAME+=value`) tracked for git config env names
  - `AnalyzeNestedOverrides` propagated through nested analysis calls

- **`src/core/shell.ts`** (+261 lines): Wrapper/env stripping with cwd tracking:
  - `stripWrappersWithInfo()` now returns `cwd` (null = unknown, undefined = unchanged)
  - `sudo --chdir`/`-D`/`--login` cwd tracking
  - `env -C`/`--chdir`/`-S`/`--split-string` handling
  - Append env assignments (`NAME+=value`) preserved for git context

- **`src/core/analyze/parallel.ts`** (+150 lines): Worktree-aware parallel analysis:
  - Detects remote execution (`-S`, `--sshlogin`) and dynamic stdin/placeholder combinations
  - Disables worktree relaxation for remote and dynamic-argument contexts
  - Improved placeholder detection: `{1}`, `{.}`, `{/}`, `{//}`, `{/.}`, `{#}`, `{%}`
  - Propagates `envAssignments` and `cwd` from wrapper stripping to child analysis

- **`src/core/analyze/xargs.ts`** (+32 lines): Worktree-aware xargs analysis:
  - Uses wrapper-resolved cwd in `analyzeRm` calls
  - Disables worktree relaxation when dynamic replacement tokens are present
  - Propagates `envAssignments` through child analysis

- **`src/core/analyze/segment.ts`** (+53 lines): Propagates `envAssignments` and wrapper cwd into nested analysis calls

- **`src/types.ts`** (+11 lines):
  - `worktreeMode` option in `AnalyzeOptions`
  - `AnalyzeNestedOverrides` type for env/cwd/worktreeMode propagation
  - `worktree-relaxation` trace step type

### CLI Surface & Explain
- **All hook entry points** (`claude-code.ts`, `copilot-cli.ts`, `gemini-cli.ts`): Read `SAFETY_NET_WORKTREE` and pass `worktreeMode` to analysis
- **`src/bin/statusline.ts`**: 🌳 emoji for worktree mode
- **`src/bin/help.ts`**: Documents `SAFETY_NET_WORKTREE=1` env var
- **`src/bin/explain/segment.ts`** (+117 lines): Worktree relaxation trace steps, env/cwd propagation parity with guard analysis
- **`src/bin/explain/format-helpers.ts`**: Format `worktree-relaxation` trace step
- **`src/bin/explain/config.ts`**: Include `worktreeMode` in explain config
- **`src/bin/doctor/environment.ts`**: Report `SAFETY_NET_WORKTREE` in doctor output

### Documentation
- **README.md**: New "Worktree Mode" section under Advanced Features with usage, allowed/blocked commands, and detection details

### Tests (~1,600 lines added)
- **`tests/core/worktree.test.ts`** (+276 lines): Unit tests for linked worktree detection — linked/main/non-repo/submodule/symlinked/malformed/copied/backlink/config.worktree/Windows path normalization
- **`tests/core/rules-git.test.ts`** (+971 lines): Comprehensive worktree mode tests — bypass/hardening, env propagation (HOME, GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, GIT_CONFIG_*), sudo --chdir, export/typeset/declare/readonly, set -a, keyword export, recursive submodules, forced branch resets, dynamic arguments, xargs/parallel propagation, interpreter wrapping, shell wrapper nesting, explain parity
- **`tests/bin/explain/command.test.ts`** (+156 lines): Explain command worktree trace steps
- **`tests/core/analyze/edge-cases.test.ts`** (+30 lines): Platform-aware path formatting in xargs/parallel tests
- **`tests/helpers.ts`** (+70 lines): `createLinkedWorktreeFixture()`, `createSubmoduleLikeGitFileFixture()`, `toShellPath()`, `withEnv()`, worktreeMode env support

## Testing

```bash
# Run all checks (typecheck + knip + biome lint + tests)
bun run check

# Run worktree-specific tests
bun test tests/core/worktree.test.ts
bun test tests/core/rules-git.test.ts --test-name-pattern "worktree"

# Run explain parity tests
bun test tests/bin/explain/command.test.ts

# Manual test with a real linked worktree
cd /path/to/main-repo
git worktree add ../linked-worktree -b test-branch
cd ../linked-worktree
SAFETY_NET_WORKTREE=1 bun src/bin/cc-safety-net.ts explain "git checkout -- ."
SAFETY_NET_WORKTREE=1 bun src/bin/cc-safety-net.ts explain "git reset --hard"
SAFETY_NET_WORKTREE=1 bun src/bin/cc-safety-net.ts explain "git push --force"  # should still block
```

## Related Issue

<!-- Link the issue where this was discussed. Use "Closes #123" to auto-close on merge. -->

#44 #47
 
### PR Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Code follows project conventions (type hints, naming, etc.)
- [x] `bun run check` passes (lint, types, dead code, rules, tests)
- [x] Tests added for new rules (minimum 90% coverage required)
- [x] Tested locally with Claude Code, OpenCode, Gemini CLI or GitHub Copilot CLI
- [x] Updated documentation if needed (README, AGENTS.md)
- [x] No version changes in `package.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worktree Mode (enable with SAFETY_NET_WORKTREE=1): allows a curated set of local-discard git operations in linked worktrees while preserving fail-closed safety checks. Explain output emits a "Worktree relaxation" block when applicable; statusline shows 🌳 and environment reporting includes SAFETY_NET_WORKTREE.

* **Documentation**
  * README and help updated with Worktree Mode details, allowlist/blocklist, and fail-closed detection rules.

* **Tests**
  * Added extensive tests covering worktree detection, relaxation behavior, formatting, CLI/status, nested/parallel, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->