### PR TITLE
fix: bump shell-quote to 1.8.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "cc-safety-net",
       "dependencies": {
-        "shell-quote": "^1.8.3",
+        "shell-quote": "^1.8.4",
       },
       "devDependencies": {
         "@ast-grep/cli": "^0.40.4",
@@ -388,7 +388,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -3,13 +3,54 @@ var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, 
 
 // node_modules/shell-quote/quote.js
 var require_quote = __commonJS((exports, module) => {
+  var OPS = [
+    "||",
+    "&&",
+    ";;",
+    "|&",
+    "<(",
+    "<<<",
+    ">>",
+    ">&",
+    "<&",
+    "&",
+    ";",
+    "(",
+    ")",
+    "|",
+    "<",
+    ">"
+  ];
+  var LINE_TERMINATORS = /[\n\r\u2028\u2029]/;
+  var GLOB_SHELL_SPECIAL = /[\s#!"$&'():;<=>@\\^`|]/g;
   module.exports = function quote(xs) {
     return xs.map(function(s) {
       if (s === "") {
         return "''";
       }
       if (s && typeof s === "object") {
-        return s.op.replace(/(.)/g, "\\$1");
+        if (s.op === "glob") {
+          if (typeof s.pattern !== "string") {
+            throw new TypeError("glob token requires a string `pattern`");
+          }
+          if (LINE_TERMINATORS.test(s.pattern)) {
+            throw new TypeError("glob `pattern` must not contain line terminators");
+          }
+          return s.pattern.replace(GLOB_SHELL_SPECIAL, "\\$&");
+        }
+        if (typeof s.op === "string") {
+          if (OPS.indexOf(s.op) < 0) {
+            throw new TypeError("invalid `op` value: " + JSON.stringify(s.op));
+          }
+          return s.op.replace(/[\s\S]/g, "\\$&");
+        }
+        if (typeof s.comment === "string") {
+          if (LINE_TERMINATORS.test(s.comment)) {
+            throw new TypeError("`comment` must not contain line terminators");
+          }
+          return "#" + s.comment;
+        }
+        throw new TypeError("unrecognized object token shape");
       }
       if (/["\s\\]/.test(s) && !/'/.test(s)) {
         return "'" + s.replace(/(['])/g, "\\$1") + "'";

--- a/dist/index.js
+++ b/dist/index.js
@@ -2,13 +2,54 @@ var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, 
 
 // node_modules/shell-quote/quote.js
 var require_quote = __commonJS((exports, module) => {
+  var OPS = [
+    "||",
+    "&&",
+    ";;",
+    "|&",
+    "<(",
+    "<<<",
+    ">>",
+    ">&",
+    "<&",
+    "&",
+    ";",
+    "(",
+    ")",
+    "|",
+    "<",
+    ">"
+  ];
+  var LINE_TERMINATORS = /[\n\r\u2028\u2029]/;
+  var GLOB_SHELL_SPECIAL = /[\s#!"$&'():;<=>@\\^`|]/g;
   module.exports = function quote(xs) {
     return xs.map(function(s) {
       if (s === "") {
         return "''";
       }
       if (s && typeof s === "object") {
-        return s.op.replace(/(.)/g, "\\$1");
+        if (s.op === "glob") {
+          if (typeof s.pattern !== "string") {
+            throw new TypeError("glob token requires a string `pattern`");
+          }
+          if (LINE_TERMINATORS.test(s.pattern)) {
+            throw new TypeError("glob `pattern` must not contain line terminators");
+          }
+          return s.pattern.replace(GLOB_SHELL_SPECIAL, "\\$&");
+        }
+        if (typeof s.op === "string") {
+          if (OPS.indexOf(s.op) < 0) {
+            throw new TypeError("invalid `op` value: " + JSON.stringify(s.op));
+          }
+          return s.op.replace(/[\s\S]/g, "\\$&");
+        }
+        if (typeof s.comment === "string") {
+          if (LINE_TERMINATORS.test(s.comment)) {
+            throw new TypeError("`comment` must not contain line terminators");
+          }
+          return "#" + s.comment;
+        }
+        throw new TypeError("unrecognized object token shape");
       }
       if (/["\s\\]/.test(s) && !/'/.test(s)) {
         return "'" + s.replace(/(['])/g, "\\$1") + "'";

--- a/dist/pi/index.js
+++ b/dist/pi/index.js
@@ -2,13 +2,54 @@ var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, 
 
 // node_modules/shell-quote/quote.js
 var require_quote = __commonJS((exports, module) => {
+  var OPS = [
+    "||",
+    "&&",
+    ";;",
+    "|&",
+    "<(",
+    "<<<",
+    ">>",
+    ">&",
+    "<&",
+    "&",
+    ";",
+    "(",
+    ")",
+    "|",
+    "<",
+    ">"
+  ];
+  var LINE_TERMINATORS = /[\n\r\u2028\u2029]/;
+  var GLOB_SHELL_SPECIAL = /[\s#!"$&'():;<=>@\\^`|]/g;
   module.exports = function quote(xs) {
     return xs.map(function(s) {
       if (s === "") {
         return "''";
       }
       if (s && typeof s === "object") {
-        return s.op.replace(/(.)/g, "\\$1");
+        if (s.op === "glob") {
+          if (typeof s.pattern !== "string") {
+            throw new TypeError("glob token requires a string `pattern`");
+          }
+          if (LINE_TERMINATORS.test(s.pattern)) {
+            throw new TypeError("glob `pattern` must not contain line terminators");
+          }
+          return s.pattern.replace(GLOB_SHELL_SPECIAL, "\\$&");
+        }
+        if (typeof s.op === "string") {
+          if (OPS.indexOf(s.op) < 0) {
+            throw new TypeError("invalid `op` value: " + JSON.stringify(s.op));
+          }
+          return s.op.replace(/[\s\S]/g, "\\$&");
+        }
+        if (typeof s.comment === "string") {
+          if (LINE_TERMINATORS.test(s.comment)) {
+            throw new TypeError("`comment` must not contain line terminators");
+          }
+          return "#" + s.comment;
+        }
+        throw new TypeError("unrecognized object token shape");
       }
       if (/["\s\\]/.test(s) && !/'/.test(s)) {
         return "'" + s.replace(/(['])/g, "\\$1") + "'";

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "shell-quote": "^1.8.3"
+    "shell-quote": "^1.8.4"
   },
   "trustedDependencies": [
     "@ast-grep/cli"

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+describe('runtime dependencies', () => {
+  test('uses patched shell-quote release', () => {
+    const packageJson = JSON.parse(readFileSync('package.json', 'utf-8')) as {
+      dependencies?: Record<string, string>;
+    };
+    const lockfile = readFileSync('bun.lock', 'utf-8');
+
+    expect(packageJson.dependencies?.['shell-quote']).toBe('^1.8.4');
+    expect(lockfile).toContain('"shell-quote": "^1.8.4"');
+    expect(lockfile).toContain('"shell-quote": ["shell-quote@1.8.4"');
+    expect(lockfile).not.toContain('shell-quote@1.8.3');
+  });
+});


### PR DESCRIPTION
## Summary

- Bump `shell-quote` from `^1.8.3` to `^1.8.4`
- Regenerate `bun.lock` so the runtime dependency resolves to `shell-quote@1.8.4`
- Add a dependency regression test to ensure the manifest and lockfile stay on the patched release
- Rebuild tracked `dist/` bundles through the existing commit hook

This addresses CVE-2026-9277 / GHSA-w7jw-789q-3m8p, where `shell-quote` versions `<=1.8.3` are vulnerable in `quote()` handling for object `.op` values.

Closes #55

## Testing

- [x] `bun test tests/dependencies.test.ts`
- [x] `bun run check`
- [x] Pre-push `bun run check`
- [x] Confirmed `bun audit --json` no longer reports `shell-quote`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `shell-quote` dependency to version 1.8.4
  * Added automated test to verify dependency version consistency across configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->