### PR TITLE
fix(opencode): write audit logs when blocking commands with session id

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,2 +1,15 @@
-import type { Plugin } from '@opencode-ai/plugin';
-export declare const CCSafetyNetPlugin: Plugin;
+import type { PluginInput } from '@opencode-ai/plugin';
+type CCSafetyNetPluginInput = PluginInput & {
+    homeDir?: string;
+};
+export declare const CCSafetyNetPlugin: ({ directory, homeDir }: CCSafetyNetPluginInput) => Promise<{
+    config: (opencodeConfig: Record<string, unknown>) => Promise<void>;
+    'tool.execute.before': (input: {
+        tool: string;
+        sessionID: string;
+        callID: string;
+    }, output: {
+        args: any;
+    }) => Promise<void>;
+}>;
+export {};

--- a/dist/index.js
+++ b/dist/index.js
@@ -6336,7 +6336,7 @@ function loadBuiltinCommands(disabledCommands) {
 }
 // src/index.ts
 var REASON_SAFETY_NET_FAILED_CLOSED = "CC Safety Net failed closed because command analysis failed unexpectedly.";
-var CCSafetyNetPlugin = async ({ directory }) => {
+var CCSafetyNetPlugin = async ({ directory, homeDir }) => {
   const modes = getCCSafetyNetEnvModes();
   return {
     config: async (opencodeConfig) => {
@@ -6369,7 +6369,9 @@ var CCSafetyNetPlugin = async ({ directory }) => {
         }
         if (result) {
           if (input.sessionID) {
-            writeAuditLog(input.sessionID, command2, result.segment, result.reason, directory);
+            writeAuditLog(input.sessionID, command2, result.segment, result.reason, directory, {
+              homeDir
+            });
           }
           const message = formatBlockedMessage({
             reason: result.reason,

--- a/dist/index.js
+++ b/dist/index.js
@@ -6187,6 +6187,66 @@ function analyzeCommand(command2, options2 = {}) {
   return analyzeCommandInternal(command2, 0, { ...options2, config });
 }
 
+// src/core/audit.ts
+import { appendFileSync, existsSync as existsSync10, mkdirSync as mkdirSync3 } from "node:fs";
+import { homedir as homedir3 } from "node:os";
+import { join as join8 } from "node:path";
+function sanitizeSessionIdForFilename(sessionId) {
+  const raw = sessionId.trim();
+  if (!raw) {
+    return null;
+  }
+  let safe = raw.replace(/[^A-Za-z0-9_.-]+/g, "_");
+  safe = safe.replace(/^[._-]+|[._-]+$/g, "").slice(0, 128);
+  if (!safe || safe === "." || safe === "..") {
+    return null;
+  }
+  return safe;
+}
+function writeAuditLog(sessionId, command2, segment, reason, cwd, options2 = {}) {
+  const safeSessionId = sanitizeSessionIdForFilename(sessionId);
+  if (!safeSessionId) {
+    return;
+  }
+  const home = options2.homeDir ?? process.env.HOME ?? homedir3();
+  const logsDir = join8(home, ".cc-safety-net", "logs");
+  try {
+    if (!existsSync10(logsDir)) {
+      mkdirSync3(logsDir, { recursive: true });
+    }
+    const logFile = join8(logsDir, `${safeSessionId}.jsonl`);
+    const entry = {
+      ts: new Date().toISOString(),
+      decision: options2.decision ?? "deny",
+      command: redactSecrets(command2).slice(0, 300),
+      segment: redactSecrets(segment).slice(0, 300),
+      reason,
+      cwd
+    };
+    appendFileSync(logFile, `${JSON.stringify(entry)}
+`, "utf-8");
+  } catch {}
+}
+function redactSecrets(text) {
+  let result = text;
+  result = result.replace(/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, "<redacted>");
+  result = result.replace(/\b((?:DATABASE|POSTGRES|POSTGRESQL|MYSQL|MARIADB|REDIS|MONGO(?:DB)?|DB)_URL)=([^\s]+)/gi, "$1=<redacted>");
+  result = result.replace(/\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASS|KEY|CREDENTIALS)[A-Z0-9_]*)=([^\s]+)/gi, "$1=<redacted>");
+  result = result.replace(/(['"]?\s*(?:authorization|cookie|x-api-key|api-key)\s*:\s*)([^'"\r\n]+)(['"]?)/gi, "$1<redacted>$3");
+  result = result.replace(/(['"]?\s*authorization\s*:\s*)([^'"]+)(['"]?)/gi, "$1<redacted>$3");
+  result = result.replace(/(authorization\s*:\s*)([^\s"']+)(\s+[^\s"']+)?/gi, "$1<redacted>");
+  result = result.replace(/\b([a-z][a-z0-9+.-]*:\/\/)([^\s/:@]+):([^\s@/]+)@/gi, "$1<redacted>:<redacted>@");
+  result = result.replace(/\b([a-z][a-z0-9+.-]*:\/\/)([^\s/@:]+)@/gi, "$1<redacted>@");
+  result = result.replace(/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g, "<redacted>");
+  result = result.replace(/\bxoxb-[A-Za-z0-9-]{20,}\b/g, "<redacted>");
+  result = result.replace(/\bnpm_[A-Za-z0-9_]{20,}\b/g, "<redacted>");
+  result = result.replace(/\b[rs]k_(?:live|test)_[A-Za-z0-9_]{20,}\b/g, "<redacted>");
+  result = result.replace(/\bpypi-[A-Za-z0-9_-]{20,}\b/g, "<redacted>");
+  result = result.replace(/\b[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{6,}\b/g, "<redacted>");
+  result = result.replace(/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g, "<redacted>");
+  return result;
+}
+
 // src/core/format.ts
 function formatBlockedMessage(input) {
   const { reason, command: command2, segment } = input;
@@ -6308,6 +6368,9 @@ var CCSafetyNetPlugin = async ({ directory }) => {
           }));
         }
         if (result) {
+          if (input.sessionID) {
+            writeAuditLog(input.sessionID, command2, result.segment, result.reason, directory);
+          }
           const message = formatBlockedMessage({
             reason: result.reason,
             command: command2,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '@opencode-ai/plugin';
+import type { Plugin, PluginInput } from '@opencode-ai/plugin';
 import { analyzeCommand, loadConfig } from '@/core/analyze';
 import { writeAuditLog } from '@/core/audit';
 import { getCCSafetyNetEnvModes } from '@/core/env';
@@ -8,7 +8,9 @@ import { loadBuiltinCommands } from '@/opencode/builtin-commands/index';
 const REASON_SAFETY_NET_FAILED_CLOSED =
   'CC Safety Net failed closed because command analysis failed unexpectedly.';
 
-export const CCSafetyNetPlugin: Plugin = async ({ directory }) => {
+type CCSafetyNetPluginInput = PluginInput & { homeDir?: string };
+
+export const CCSafetyNetPlugin = (async ({ directory, homeDir }: CCSafetyNetPluginInput) => {
   const modes = getCCSafetyNetEnvModes();
 
   return {
@@ -46,7 +48,9 @@ export const CCSafetyNetPlugin: Plugin = async ({ directory }) => {
         }
         if (result) {
           if (input.sessionID) {
-            writeAuditLog(input.sessionID, command, result.segment, result.reason, directory);
+            writeAuditLog(input.sessionID, command, result.segment, result.reason, directory, {
+              homeDir,
+            });
           }
           const message = formatBlockedMessage({
             reason: result.reason,
@@ -60,4 +64,4 @@ export const CCSafetyNetPlugin: Plugin = async ({ directory }) => {
       }
     },
   };
-};
+}) satisfies Plugin;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from '@opencode-ai/plugin';
 import { analyzeCommand, loadConfig } from '@/core/analyze';
+import { writeAuditLog } from '@/core/audit';
 import { getCCSafetyNetEnvModes } from '@/core/env';
 import { formatBlockedMessage } from '@/core/format';
 import { loadBuiltinCommands } from '@/opencode/builtin-commands/index';
@@ -44,6 +45,9 @@ export const CCSafetyNetPlugin: Plugin = async ({ directory }) => {
           );
         }
         if (result) {
+          if (input.sessionID) {
+            writeAuditLog(input.sessionID, command, result.segment, result.reason, directory);
+          }
           const message = formatBlockedMessage({
             reason: result.reason,
             command,

--- a/tests/opencode/plugin.test.ts
+++ b/tests/opencode/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { CCSafetyNetPlugin } from '@/index';
@@ -11,7 +11,7 @@ import {
 
 type ToolPlugin = {
   'tool.execute.before': (
-    input: { tool: string },
+    input: { tool: string; sessionID?: string },
     output: { args: { command?: string } },
   ) => Promise<void>;
 };
@@ -65,6 +65,40 @@ describe('OpenCode plugin', () => {
     await expect(plugin['tool.execute.before']({ tool: 'bash' }, { args: {} })).rejects.toThrow(
       'CC Safety Net failed closed',
     );
+  });
+
+  test('writes audit log for blocked commands with session id', async () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'safety-net-opencode-home-'));
+    const projectDir = mkdtempSync(join(tmpdir(), 'safety-net-opencode-project-'));
+    const originalHome = process.env.HOME;
+    process.env.HOME = homeDir;
+    try {
+      const plugin = await loadToolPlugin(projectDir);
+
+      await expect(
+        plugin['tool.execute.before'](
+          { tool: 'bash', sessionID: 'opencode-test-session' },
+          { args: { command: 'git reset --hard' } },
+        ),
+      ).rejects.toThrow('git reset --hard');
+
+      const logFile = join(homeDir, '.cc-safety-net', 'logs', 'opencode-test-session.jsonl');
+      expect(existsSync(logFile)).toBe(true);
+      const entry = JSON.parse(readFileSync(logFile, 'utf-8').trim());
+      expect(entry.decision).toBe('deny');
+      expect(entry.command).toBe('git reset --hard');
+      expect(entry.segment).toBe('git reset --hard');
+      expect(entry.reason).toContain('git reset --hard');
+      expect(entry.cwd).toBe(projectDir);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      rmSync(homeDir, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
   });
 
   test('reloads and repairs local rules before each tool execution', async () => {

--- a/tests/opencode/plugin.test.ts
+++ b/tests/opencode/plugin.test.ts
@@ -70,10 +70,8 @@ describe('OpenCode plugin', () => {
   test('writes audit log for blocked commands with session id', async () => {
     const homeDir = mkdtempSync(join(tmpdir(), 'safety-net-opencode-home-'));
     const projectDir = mkdtempSync(join(tmpdir(), 'safety-net-opencode-project-'));
-    const originalHome = process.env.HOME;
-    process.env.HOME = homeDir;
     try {
-      const plugin = await loadToolPlugin(projectDir);
+      const plugin = await loadToolPlugin(projectDir, homeDir);
 
       await expect(
         plugin['tool.execute.before'](
@@ -91,11 +89,6 @@ describe('OpenCode plugin', () => {
       expect(entry.reason).toContain('git reset --hard');
       expect(entry.cwd).toBe(projectDir);
     } finally {
-      if (originalHome === undefined) {
-        delete process.env.HOME;
-      } else {
-        process.env.HOME = originalHome;
-      }
       rmSync(homeDir, { recursive: true, force: true });
       rmSync(projectDir, { recursive: true, force: true });
     }
@@ -118,8 +111,9 @@ describe('OpenCode plugin', () => {
   });
 });
 
-async function loadToolPlugin(directory: string): Promise<ToolPlugin> {
+async function loadToolPlugin(directory: string, homeDir?: string): Promise<ToolPlugin> {
   return (await CCSafetyNetPlugin({
     directory,
+    homeDir,
   } as Parameters<typeof CCSafetyNetPlugin>[0])) as unknown as ToolPlugin;
 }


### PR DESCRIPTION
## Summary

Fixes OpenCode audit logging for blocked commands.

Previously, the OpenCode `tool.execute.before` hook blocked dangerous bash commands but did not write audit log entries, so `doctor` activity stayed at `totalBlocked: 0` even after successful blocks.

Closes #58

## Changes

- Write a deny audit entry from the OpenCode plugin when a blocked command includes a `sessionID`
- Add regression coverage confirming blocked OpenCode commands create the expected JSONL audit log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit logging for `bash` command execution when a session ID is present, capturing the decision, command, analysis segment/reason, and the working directory.

* **Tests**
  * Expanded test coverage to include an end-to-end case for a blocked `bash` command with a session ID, verifying the generated JSONL audit log entry format and contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->