### PR TITLE
Migrate from Kimi CLI to Kimi Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Install CC Safety Net into your Kimi Code config:
 npx -y cc-safety-net hook install --kimi-code
 ```
 
+Optional: run `npx skill add kenryu42/cc-safety-net` to add the `/cc-safety-net` skill for configuring custom rules.
+
 ---
 
 

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -9635,9 +9635,9 @@ function removeArrayRangeItem(content, item) {
 var KIMI_HOOK_COMMAND = "npx -y cc-safety-net hook --kimi-code";
 var KIMI_HOOK_BLOCK = `[[hooks]]
 event = "PreToolUse"
-matcher = "Shell"
+matcher = "Bash"
 command = "${KIMI_HOOK_COMMAND}"`;
-var KIMI_INLINE_HOOK = `{ event = "PreToolUse", matcher = "Shell", command = "${KIMI_HOOK_COMMAND}" }`;
+var KIMI_INLINE_HOOK = `{ event = "PreToolUse", matcher = "Bash", command = "${KIMI_HOOK_COMMAND}" }`;
 function getKimiConfigPath(homeDir) {
   return join12(process.env.KIMI_CODE_HOME ?? join12(homeDir, ".kimi-code"), "config.toml");
 }

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -9635,9 +9635,9 @@ function removeArrayRangeItem(content, item) {
 var KIMI_HOOK_COMMAND = "npx -y cc-safety-net hook --kimi-code";
 var KIMI_HOOK_BLOCK = `[[hooks]]
 event = "PreToolUse"
-matcher = "Bash"
+matcher = "Shell"
 command = "${KIMI_HOOK_COMMAND}"`;
-var KIMI_INLINE_HOOK = `{ event = "PreToolUse", matcher = "Bash", command = "${KIMI_HOOK_COMMAND}" }`;
+var KIMI_INLINE_HOOK = `{ event = "PreToolUse", matcher = "Shell", command = "${KIMI_HOOK_COMMAND}" }`;
 function getKimiConfigPath(homeDir) {
   return join12(process.env.KIMI_CODE_HOME ?? join12(homeDir, ".kimi-code"), "config.toml");
 }

--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -6429,7 +6429,7 @@ var CLAUDE_CODE_TOOL_NAME = "Bash";
 var GEMINI_CLI_HOOK_EVENT = "BeforeTool";
 var GEMINI_CLI_TOOL_NAME = "run_shell_command";
 var KIMI_CODE_HOOK_EVENT = "PreToolUse";
-var KIMI_CODE_TOOL_NAME = "Shell";
+var KIMI_CODE_TOOL_NAME = "Bash";
 
 // src/bin/hook/claude-code.ts
 async function runClaudeCodeHook() {
@@ -7531,7 +7531,7 @@ function detectGeminiCLI(extensionsListOutput) {
   };
 }
 function _getKimiConfigPath(homeDir) {
-  return join10(process.env.KIMI_SHARE_DIR || join10(homeDir, ".kimi"), "config.toml");
+  return join10(process.env.KIMI_CODE_HOME || join10(homeDir, ".kimi-code"), "config.toml");
 }
 function detectKimiCode(homeDir) {
   const configPath = _getKimiConfigPath(homeDir);
@@ -9635,11 +9635,11 @@ function removeArrayRangeItem(content, item) {
 var KIMI_HOOK_COMMAND = "npx -y cc-safety-net hook --kimi-code";
 var KIMI_HOOK_BLOCK = `[[hooks]]
 event = "PreToolUse"
-matcher = "Shell"
+matcher = "Bash"
 command = "${KIMI_HOOK_COMMAND}"`;
-var KIMI_INLINE_HOOK = `{ event = "PreToolUse", matcher = "Shell", command = "${KIMI_HOOK_COMMAND}" }`;
+var KIMI_INLINE_HOOK = `{ event = "PreToolUse", matcher = "Bash", command = "${KIMI_HOOK_COMMAND}" }`;
 function getKimiConfigPath(homeDir) {
-  return join12(process.env.KIMI_SHARE_DIR ?? join12(homeDir, ".kimi"), "config.toml");
+  return join12(process.env.KIMI_CODE_HOME ?? join12(homeDir, ".kimi-code"), "config.toml");
 }
 function removeTopLevelEmptyHooksArray(content) {
   const result = content.split(`

--- a/dist/bin/hook/constants.d.ts
+++ b/dist/bin/hook/constants.d.ts
@@ -3,4 +3,4 @@ export declare const CLAUDE_CODE_TOOL_NAME = "Bash";
 export declare const GEMINI_CLI_HOOK_EVENT = "BeforeTool";
 export declare const GEMINI_CLI_TOOL_NAME = "run_shell_command";
 export declare const KIMI_CODE_HOOK_EVENT = "PreToolUse";
-export declare const KIMI_CODE_TOOL_NAME = "Shell";
+export declare const KIMI_CODE_TOOL_NAME = "Bash";

--- a/src/bin/doctor/hooks.ts
+++ b/src/bin/doctor/hooks.ts
@@ -389,7 +389,7 @@ function detectGeminiCLI(extensionsListOutput: string | null | undefined): HookS
 }
 
 function _getKimiConfigPath(homeDir: string): string {
-  return join(process.env.KIMI_SHARE_DIR || join(homeDir, '.kimi'), 'config.toml');
+  return join(process.env.KIMI_CODE_HOME || join(homeDir, '.kimi-code'), 'config.toml');
 }
 
 function detectKimiCode(homeDir: string): HookStatus {

--- a/src/bin/hook/constants.ts
+++ b/src/bin/hook/constants.ts
@@ -3,4 +3,4 @@ export const CLAUDE_CODE_TOOL_NAME = 'Bash';
 export const GEMINI_CLI_HOOK_EVENT = 'BeforeTool';
 export const GEMINI_CLI_TOOL_NAME = 'run_shell_command';
 export const KIMI_CODE_HOOK_EVENT = 'PreToolUse';
-export const KIMI_CODE_TOOL_NAME = 'Shell';
+export const KIMI_CODE_TOOL_NAME = 'Bash';

--- a/src/bin/hook/install/kimi-code.ts
+++ b/src/bin/hook/install/kimi-code.ts
@@ -11,9 +11,9 @@ import type { InstallResult } from '@/bin/hook/install/types';
 const KIMI_HOOK_COMMAND = 'npx -y cc-safety-net hook --kimi-code';
 const KIMI_HOOK_BLOCK = `[[hooks]]
 event = "PreToolUse"
-matcher = "Shell"
+matcher = "Bash"
 command = "${KIMI_HOOK_COMMAND}"`;
-const KIMI_INLINE_HOOK = `{ event = "PreToolUse", matcher = "Shell", command = "${KIMI_HOOK_COMMAND}" }`;
+const KIMI_INLINE_HOOK = `{ event = "PreToolUse", matcher = "Bash", command = "${KIMI_HOOK_COMMAND}" }`;
 
 function getKimiConfigPath(homeDir: string) {
   return join(process.env.KIMI_CODE_HOME ?? join(homeDir, '.kimi-code'), 'config.toml');

--- a/src/bin/hook/install/kimi-code.ts
+++ b/src/bin/hook/install/kimi-code.ts
@@ -16,7 +16,7 @@ command = "${KIMI_HOOK_COMMAND}"`;
 const KIMI_INLINE_HOOK = `{ event = "PreToolUse", matcher = "Shell", command = "${KIMI_HOOK_COMMAND}" }`;
 
 function getKimiConfigPath(homeDir: string) {
-  return join(process.env.KIMI_SHARE_DIR ?? join(homeDir, '.kimi'), 'config.toml');
+  return join(process.env.KIMI_CODE_HOME ?? join(homeDir, '.kimi-code'), 'config.toml');
 }
 
 function removeTopLevelEmptyHooksArray(content: string) {

--- a/tests/bin/doctor/hooks.test.ts
+++ b/tests/bin/doctor/hooks.test.ts
@@ -680,7 +680,7 @@ describe('detectAllHooks', () => {
     const tmpBase = join(tmpdir(), `doctor-kimi-${Date.now()}`);
     const homeDir = join(tmpBase, 'home');
     const projectDir = join(tmpBase, 'project');
-    const configPath = join(homeDir, '.kimi', 'config.toml');
+    const configPath = join(homeDir, '.kimi-code', 'config.toml');
     mkdirSync(projectDir, { recursive: true });
     _writeKimiConfig(configPath);
 
@@ -702,7 +702,7 @@ describe('detectAllHooks', () => {
     const tmpBase = join(tmpdir(), `doctor-kimi-${Date.now()}`);
     const homeDir = join(tmpBase, 'home');
     const projectDir = join(tmpBase, 'project');
-    const configPath = join(homeDir, '.kimi', 'config.toml');
+    const configPath = join(homeDir, '.kimi-code', 'config.toml');
     mkdirSync(projectDir, { recursive: true });
     _writeKimiConfig(configPath, 'pre_tool_use = "cc-safety-net hook --kimi-code"');
 
@@ -718,7 +718,7 @@ describe('detectAllHooks', () => {
     }
   });
 
-  test('Kimi Code: configured from KIMI_SHARE_DIR config', () => {
+  test('Kimi Code: configured from KIMI_CODE_HOME config', () => {
     const tmpBase = join(tmpdir(), `doctor-kimi-${Date.now()}`);
     const homeDir = join(tmpBase, 'home');
     const projectDir = join(tmpBase, 'project');
@@ -729,7 +729,7 @@ describe('detectAllHooks', () => {
     _writeKimiConfig(configPath, 'bunx cc-safety-net hook --kimi-code');
 
     try {
-      const kimi = withEnv({ KIMI_SHARE_DIR: kimiShareDir }, () =>
+      const kimi = withEnv({ KIMI_CODE_HOME: kimiShareDir }, () =>
         detectAllHooks(projectDir, { homeDir }).find((hook) => hook.platform === 'kimi-code'),
       );
 
@@ -753,7 +753,7 @@ describe('detectAllHooks', () => {
       );
 
       expect(kimi?.status).toBe('n/a');
-      expect(kimi?.configPath).toBe(join(homeDir, '.kimi', 'config.toml'));
+      expect(kimi?.configPath).toBe(join(homeDir, '.kimi-code', 'config.toml'));
       expect(kimi?.selfTest).toBeUndefined();
     } finally {
       rmSync(tmpBase, { recursive: true, force: true });
@@ -764,7 +764,7 @@ describe('detectAllHooks', () => {
     const tmpBase = join(tmpdir(), `doctor-kimi-${Date.now()}`);
     const homeDir = join(tmpBase, 'home');
     const projectDir = join(tmpBase, 'project');
-    const configPath = join(homeDir, '.kimi', 'config.toml');
+    const configPath = join(homeDir, '.kimi-code', 'config.toml');
     mkdirSync(projectDir, { recursive: true });
     _writeKimiConfig(configPath, 'hooks = []');
 
@@ -785,7 +785,7 @@ describe('detectAllHooks', () => {
     const tmpBase = join(tmpdir(), `doctor-kimi-${Date.now()}`);
     const homeDir = join(tmpBase, 'home');
     const projectDir = join(tmpBase, 'project');
-    const configPath = join(homeDir, '.kimi', 'config.toml');
+    const configPath = join(homeDir, '.kimi-code', 'config.toml');
     mkdirSync(projectDir, { recursive: true });
     mkdirSync(configPath, { recursive: true });
 

--- a/tests/bin/hooks/hook-adapter-direct.test.ts
+++ b/tests/bin/hooks/hook-adapter-direct.test.ts
@@ -82,7 +82,7 @@ describe('hook adapter direct integration', () => {
     expect(output.reason).toContain('git reset --hard');
   });
 
-  test('Kimi Code hook blocks supported Shell commands', async () => {
+  test('Kimi Code hook blocks supported Bash commands', async () => {
     const output = await runHookJson(runKimiCodeHook, kimiShellInput('git reset --hard'));
 
     expect(output.hookSpecificOutput.permissionDecision).toBe('deny');

--- a/tests/bin/hooks/hook-helpers.ts
+++ b/tests/bin/hooks/hook-helpers.ts
@@ -101,7 +101,7 @@ export function kimiShellInput(command: string, cwd = TEST_HOOK_CWD) {
     hook_event_name: 'PreToolUse',
     session_id: 'kimi-test-session',
     cwd,
-    tool_name: 'Shell',
+    tool_name: 'Bash',
     tool_input: { command },
     tool_call_id: 'kimi-test-tool-call',
   };

--- a/tests/bin/hooks/hook-install.test.ts
+++ b/tests/bin/hooks/hook-install.test.ts
@@ -18,7 +18,7 @@ function makeTempHome(name: string) {
 }
 
 function writeKimiConfig(homeDir: string, content: string) {
-  const shareDir = join(homeDir, '.kimi');
+  const shareDir = join(homeDir, '.kimi-code');
   const configPath = join(shareDir, 'config.toml');
   mkdirSync(shareDir, { recursive: true });
   writeFileSync(configPath, content);
@@ -91,7 +91,7 @@ describe('hook install command', () => {
     }
   });
 
-  test('Kimi Code: honors KIMI_SHARE_DIR and removes top-level hooks array', async () => {
+  test('Kimi Code: honors KIMI_CODE_HOME and removes top-level hooks array', async () => {
     const homeDir = makeTempHome('safety-net-kimi-install');
     const shareDir = join(homeDir, 'custom-kimi');
     const configPath = join(shareDir, 'config.toml');
@@ -109,7 +109,7 @@ hooks = []
     try {
       const result = await runCli(['hook', 'install', '--kimi-code'], '', {
         HOME: homeDir,
-        KIMI_SHARE_DIR: shareDir,
+        KIMI_CODE_HOME: shareDir,
       });
       const content = readFileSync(configPath, 'utf-8');
 

--- a/tests/bin/hooks/hook-install.test.ts
+++ b/tests/bin/hooks/hook-install.test.ts
@@ -70,7 +70,7 @@ describe('hook install command', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('Choose exactly one install target: --kimi-code');
-      expect(existsSync(join(homeDir, '.kimi', 'config.toml'))).toBe(false);
+      expect(existsSync(join(homeDir, '.kimi-code', 'config.toml'))).toBe(false);
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
     }
@@ -81,7 +81,7 @@ describe('hook install command', () => {
 
     try {
       const result = await runCli(['hook', 'install', '--kimi-code'], '', { HOME: homeDir });
-      const configPath = join(homeDir, '.kimi', 'config.toml');
+      const configPath = join(homeDir, '.kimi-code', 'config.toml');
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(`Installed Kimi Code hook in ${configPath}`);
@@ -189,7 +189,7 @@ hooks = []
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('Unexpected argument for hook install: extra');
-      expect(existsSync(join(homeDir, '.kimi', 'config.toml'))).toBe(false);
+      expect(existsSync(join(homeDir, '.kimi-code', 'config.toml'))).toBe(false);
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
     }
@@ -205,7 +205,7 @@ hooks = []
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('Unknown install option: --opencode');
-      expect(existsSync(join(homeDir, '.kimi', 'config.toml'))).toBe(false);
+      expect(existsSync(join(homeDir, '.kimi-code', 'config.toml'))).toBe(false);
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
     }

--- a/tests/bin/hooks/hook-install.test.ts
+++ b/tests/bin/hooks/hook-install.test.ts
@@ -6,10 +6,10 @@ import { runCli } from './hook-helpers';
 
 const KIMI_HOOK_BLOCK = `[[hooks]]
 event = "PreToolUse"
-matcher = "Shell"
+matcher = "Bash"
 command = "npx -y cc-safety-net hook --kimi-code"`;
 const KIMI_INLINE_HOOK =
-  '{ event = "PreToolUse", matcher = "Shell", command = "npx -y cc-safety-net hook --kimi-code" }';
+  '{ event = "PreToolUse", matcher = "Bash", command = "npx -y cc-safety-net hook --kimi-code" }';
 
 function makeTempHome(name: string) {
   const dir = join(tmpdir(), `${name}-${Date.now()}-${Math.random().toString(36).slice(2)}`);

--- a/tests/bin/hooks/kimi-code-hook.test.ts
+++ b/tests/bin/hooks/kimi-code-hook.test.ts
@@ -3,7 +3,7 @@ import { expectNoHookOutput, getHookDenyReason, kimiShellInput, runKimiHook } fr
 
 describe('Kimi Code hook', () => {
   describe('blocked commands', () => {
-    test('blocks rm -rf via Shell tool', async () => {
+    test('blocks rm -rf via Bash tool', async () => {
       const { stdout, exitCode } = await runKimiHook(kimiShellInput('rm -rf /'));
 
       expect(exitCode).toBe(0);
@@ -21,7 +21,7 @@ describe('Kimi Code hook', () => {
   });
 
   describe('non-target tool', () => {
-    test('ignores non-Shell tools', async () => {
+    test('ignores non-Bash tools', async () => {
       const input = {
         hook_event_name: 'PreToolUse',
         tool_name: 'ReadFile',
@@ -36,7 +36,7 @@ describe('Kimi Code hook', () => {
     test('ignores non-PreToolUse events', async () => {
       const input = {
         hook_event_name: 'PostToolUse',
-        tool_name: 'Shell',
+        tool_name: 'Bash',
         tool_input: { command: 'rm -rf /' },
       };
 
@@ -78,7 +78,7 @@ describe('Kimi Code hook', () => {
     test('missing command in tool_input produces no output', async () => {
       const input = {
         hook_event_name: 'PreToolUse',
-        tool_name: 'Shell',
+        tool_name: 'Bash',
         tool_input: {},
       };
 


### PR DESCRIPTION
## Changes

### 1. Tool name: `Shell` → `Bash`
Kimi Code's shell execution tool is named `Bash`, not `Shell`. The hook matcher and all related constants/tests now target the correct tool name.

- **`src/bin/hook/constants.ts`** — `KIMI_CODE_TOOL_NAME` → `"Bash"`
- **`src/bin/hook/install/kimi-code.ts`** — hook block & inline hook templates updated
- Tests updated: `hook-helpers.ts`, `hook-adapter-direct.test.ts`, `kimi-code-hook.test.ts`, `hook-install.test.ts`

### 2. Config path: `.kimi` → `.kimi-code`
Kimi Code stores its config under `~/.kimi-code/`, not `~/.kimi/`.

- **`src/bin/hook/install/kimi-code.ts`** — `getKimiConfigPath` fallback dir updated
- **`src/bin/doctor/hooks.ts`** — `_getKimiConfigPath` fallback dir updated
- Tests updated: `hook-install.test.ts`, `hooks.test.ts`

### 3. Env var: `KIMI_SHARE_DIR` → `KIMI_CODE_HOME`
The environment variable override for the config directory is `KIMI_CODE_HOME`.

- **`src/bin/hook/install/kimi-code.ts`** — env var reference updated
- **`src/bin/doctor/hooks.ts`** — env var reference updated
- Tests updated: `hook-install.test.ts`, `hooks.test.ts`

### 4. Docs
- **`README.md`** — added a note about the optional `/cc-safety-net` skill for Kimi Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Installation guide now includes an optional step to install the `/cc-safety-net` skill, enabling users to define and enforce custom safety rules.

* **Configuration Updates**
  * Kimi Code configuration directory location changed from `.kimi` to `.kimi-code`, with `KIMI_CODE_HOME` environment variable now taking precedence for path resolution.
  * Tool reference identifier updated from "Shell" to "Bash".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->