### PR TITLE
fix(rules): avoid duplicate home rule scope

### DIFF
--- a/dist/bin/cc-safety-net.js
+++ b/dist/bin/cc-safety-net.js
@@ -5126,7 +5126,7 @@ function writeJsonAtomic(path, value) {
 }
 
 // src/core/rules/policy/scope-policy.ts
-import { existsSync as existsSync7, readFileSync as readFileSync6 } from "node:fs";
+import { existsSync as existsSync7, readFileSync as readFileSync6, realpathSync as realpathSync7 } from "node:fs";
 import { dirname as dirname6, isAbsolute as isAbsolute6, join as join6, relative, resolve as resolve5, sep as sep4 } from "node:path";
 
 // src/core/rules/rulebook.ts
@@ -5552,8 +5552,9 @@ function sha256Digest(content) {
 // src/core/rules/policy/scope-policy.ts
 function loadRulesPolicy(options2 = {}) {
   const paths = getPolicyPaths(options2);
+  const sameConfigPath = isSameConfigPath(paths.userConfigPath, paths.projectConfigPath);
   const user = readRulesConfig(paths.userConfigPath);
-  const project = readRulesConfig(paths.projectConfigPath);
+  const project = sameConfigPath ? { config: null, errors: [] } : readRulesConfig(paths.projectConfigPath);
   const errors = [
     ...getLegacyRulesConfigErrors(paths, options2),
     ...user.errors.map((error) => `${paths.userConfigPath}: ${error}`),
@@ -5723,6 +5724,19 @@ function rulesPolicyToConfig(policy) {
     };
   }
   return { version: 1, rules: policy.rules };
+}
+function isSameConfigPath(userConfigPath, projectConfigPath) {
+  if (resolve5(userConfigPath) === resolve5(projectConfigPath)) {
+    return true;
+  }
+  if (!existsSync7(userConfigPath) || !existsSync7(projectConfigPath)) {
+    return false;
+  }
+  try {
+    return realpathSync7(userConfigPath) === realpathSync7(projectConfigPath);
+  } catch {
+    return false;
+  }
 }
 function getLegacyRulesConfigErrors(paths, options2) {
   return Array.from(new Set([

--- a/dist/index.js
+++ b/dist/index.js
@@ -5070,7 +5070,7 @@ function writeJsonAtomic(path, value) {
 }
 
 // src/core/rules/policy/scope-policy.ts
-import { existsSync as existsSync7, readFileSync as readFileSync6 } from "node:fs";
+import { existsSync as existsSync7, readFileSync as readFileSync6, realpathSync as realpathSync7 } from "node:fs";
 import { dirname as dirname6, isAbsolute as isAbsolute6, join as join6, relative, resolve as resolve5, sep as sep4 } from "node:path";
 
 // src/core/rules/rulebook.ts
@@ -5496,8 +5496,9 @@ function sha256Digest(content) {
 // src/core/rules/policy/scope-policy.ts
 function loadRulesPolicy(options2 = {}) {
   const paths = getPolicyPaths(options2);
+  const sameConfigPath = isSameConfigPath(paths.userConfigPath, paths.projectConfigPath);
   const user = readRulesConfig(paths.userConfigPath);
-  const project = readRulesConfig(paths.projectConfigPath);
+  const project = sameConfigPath ? { config: null, errors: [] } : readRulesConfig(paths.projectConfigPath);
   const errors = [
     ...getLegacyRulesConfigErrors(paths, options2),
     ...user.errors.map((error) => `${paths.userConfigPath}: ${error}`),
@@ -5667,6 +5668,19 @@ function rulesPolicyToConfig(policy) {
     };
   }
   return { version: 1, rules: policy.rules };
+}
+function isSameConfigPath(userConfigPath, projectConfigPath) {
+  if (resolve5(userConfigPath) === resolve5(projectConfigPath)) {
+    return true;
+  }
+  if (!existsSync7(userConfigPath) || !existsSync7(projectConfigPath)) {
+    return false;
+  }
+  try {
+    return realpathSync7(userConfigPath) === realpathSync7(projectConfigPath);
+  } catch {
+    return false;
+  }
 }
 function getLegacyRulesConfigErrors(paths, options2) {
   return Array.from(new Set([

--- a/dist/pi/index.js
+++ b/dist/pi/index.js
@@ -5134,7 +5134,7 @@ function writeJsonAtomic(path, value) {
 }
 
 // src/core/rules/policy/scope-policy.ts
-import { existsSync as existsSync7, readFileSync as readFileSync6 } from "node:fs";
+import { existsSync as existsSync7, readFileSync as readFileSync6, realpathSync as realpathSync7 } from "node:fs";
 import { dirname as dirname6, isAbsolute as isAbsolute6, join as join6, relative, resolve as resolve5, sep as sep4 } from "node:path";
 
 // src/core/rules/rulebook.ts
@@ -5560,8 +5560,9 @@ function sha256Digest(content) {
 // src/core/rules/policy/scope-policy.ts
 function loadRulesPolicy(options2 = {}) {
   const paths = getPolicyPaths(options2);
+  const sameConfigPath = isSameConfigPath(paths.userConfigPath, paths.projectConfigPath);
   const user = readRulesConfig(paths.userConfigPath);
-  const project = readRulesConfig(paths.projectConfigPath);
+  const project = sameConfigPath ? { config: null, errors: [] } : readRulesConfig(paths.projectConfigPath);
   const errors = [
     ...getLegacyRulesConfigErrors(paths, options2),
     ...user.errors.map((error) => `${paths.userConfigPath}: ${error}`),
@@ -5731,6 +5732,19 @@ function rulesPolicyToConfig(policy) {
     };
   }
   return { version: 1, rules: policy.rules };
+}
+function isSameConfigPath(userConfigPath, projectConfigPath) {
+  if (resolve5(userConfigPath) === resolve5(projectConfigPath)) {
+    return true;
+  }
+  if (!existsSync7(userConfigPath) || !existsSync7(projectConfigPath)) {
+    return false;
+  }
+  try {
+    return realpathSync7(userConfigPath) === realpathSync7(projectConfigPath);
+  } catch {
+    return false;
+  }
 }
 function getLegacyRulesConfigErrors(paths, options2) {
   return Array.from(new Set([

--- a/src/core/rules/policy/scope-policy.ts
+++ b/src/core/rules/policy/scope-policy.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { assertValidRulebook, type Rulebook } from '@/core/rules/rulebook';
 import type { Config, CustomRule } from '@/types';
@@ -36,8 +36,11 @@ interface ScopePolicy {
 
 export function loadRulesPolicy(options: RulesPolicyOptions = {}): LoadedRulesPolicy {
   const paths = getPolicyPaths(options);
+  const sameConfigPath = isSameConfigPath(paths.userConfigPath, paths.projectConfigPath);
   const user = readRulesConfig(paths.userConfigPath);
-  const project = readRulesConfig(paths.projectConfigPath);
+  const project = sameConfigPath
+    ? { config: null, errors: [] }
+    : readRulesConfig(paths.projectConfigPath);
   const errors = [
     ...getLegacyRulesConfigErrors(paths, options),
     ...user.errors.map((error) => `${paths.userConfigPath}: ${error}`),
@@ -281,6 +284,20 @@ export function rulesPolicyToConfig(policy: LoadedRulesPolicy): Config {
     };
   }
   return { version: 1, rules: policy.rules };
+}
+
+function isSameConfigPath(userConfigPath: string, projectConfigPath: string): boolean {
+  if (resolve(userConfigPath) === resolve(projectConfigPath)) {
+    return true;
+  }
+  if (!existsSync(userConfigPath) || !existsSync(projectConfigPath)) {
+    return false;
+  }
+  try {
+    return realpathSync(userConfigPath) === realpathSync(projectConfigPath);
+  } catch {
+    return false;
+  }
 }
 
 function getLegacyRulesConfigErrors(

--- a/tests/bin/rule.test.ts
+++ b/tests/bin/rule.test.ts
@@ -236,6 +236,26 @@ describe('rule list', () => {
     expect(result.stderr).toContain('Unknown option for rule list: --global');
   });
 
+  test('does not load global rules twice when listing from home directory', async () => {
+    await withTempDir('safety-net-rule-list-home-cwd-', async (tempDir) => {
+      const homeDir = join(tempDir, 'home');
+      mkdirSync(homeDir, { recursive: true });
+      const env = { HOME: homeDir };
+
+      expect((await runCCSafetyNetCli(['rule', 'init', '--global'], env, homeDir)).exitCode).toBe(
+        0,
+      );
+      const result = await runCCSafetyNetCli(['rule', 'list'], env, homeDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.output).toContain('Active sources (1):');
+      expect(result.output).toContain('[user] user-rules 1.0.0');
+      expect(result.output).not.toContain('[project] user-rules 1.0.0');
+      expect(result.output).not.toContain('duplicate active rulebook name');
+    });
+  });
+
   test('prints empty merged policy', async () => {
     await withTempDir('safety-net-rule-list-empty-', async (tempDir) => {
       const result = await runRuleList(tempDir);

--- a/tests/bin/rule.test.ts
+++ b/tests/bin/rule.test.ts
@@ -240,7 +240,10 @@ describe('rule list', () => {
     await withTempDir('safety-net-rule-list-home-cwd-', async (tempDir) => {
       const homeDir = join(tempDir, 'home');
       mkdirSync(homeDir, { recursive: true });
-      const env = { HOME: homeDir };
+      const env = {
+        CC_SAFETY_NET_HOME: join(homeDir, '.cc-safety-net'),
+        HOME: homeDir,
+      };
 
       expect((await runCCSafetyNetCli(['rule', 'init', '--global'], env, homeDir)).exitCode).toBe(
         0,

--- a/tests/core/rules-policy-recovery.test.ts
+++ b/tests/core/rules-policy-recovery.test.ts
@@ -11,6 +11,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { analyzeCommand } from '@/core/analyze';
 import {
   addRulebookSource,
   getProjectRulesConfigPath,
@@ -1024,6 +1025,29 @@ describe('rules policy recovery coverage', () => {
       expect(loadRulesPolicy({ cwd: tempDir, userConfigDir }).errors).toContain(
         'duplicate active rulebook name "shared"',
       );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('loads user rule config once when cwd is the home directory', async () => {
+    const tempDir = makeTempDir('rules-policy-home-cwd');
+    const homeDir = join(tempDir, 'home');
+    const userConfigDir = join(homeDir, '.cc-safety-net', 'rules');
+
+    try {
+      writeRulebook(join(userConfigDir, 'user-rules', 'rulebook.json'), 'user-rules');
+      writeDefaultRulesConfig(getUserRulesConfigPath({ userConfigDir }), ['user-rules']);
+      expect((await syncRulesConfig({ cwd: homeDir, userConfigDir, global: true })).ok).toBe(true);
+
+      const policy = loadRulesPolicy({ cwd: homeDir, userConfigDir });
+      const config = rulesPolicyToConfig(policy);
+
+      expect(policy.errors).toEqual([]);
+      expect(policy.rulebooks.map((rulebook) => rulebook.source)).toEqual(['user']);
+      expect(policy.rules.map((rule) => rule.name)).toEqual(['user-rules/block-docker-prune']);
+      expect(config.failClosedReason).toBeUndefined();
+      expect(analyzeCommand('echo ok', { cwd: homeDir, config })).toBeNull();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## PR Summary

   Fixes #61.

   This PR prevents user-scope rulebooks from being loaded twice when `cc-safety-net` runs with `cwd === $HOME`.

   When the current working directory is the user’s home directory, the computed user config path and project config path can both point to:

   ```text
   ~/.cc-safety-net/rules/rule.json
 ```

 Previously, the policy loader treated those as separate scopes, which duplicated the same active rulebook and caused runtime fail-closed behavior:

 ```text
   duplicate active rulebook name "user-rules"
 ```

 That blocked every tool call, including harmless commands.

 Changes

 - Detect when user and project rule config paths refer to the same file.
 - Load the shared config only once as user scope.
 - Preserve duplicate-rulebook-name detection for genuinely distinct user/project configs.
 - Add regression coverage for:
     - core policy loading from $HOME
     - runtime analysis allowing harmless commands after loading the config
     - rule list not showing duplicated global rules when run from $HOME

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed duplicate rule configuration loading when the user and project config paths point to the same real filesystem location, preventing redundant reads and avoiding incorrect project-scope handling.

* **Tests**
  * Added coverage to ensure global/user rules are not loaded twice when running from a home directory and that policy recovery behaves correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->